### PR TITLE
fix(build): update pyproject.toml for setuptools compatibility and package discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           node-version: "18"
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.0
+        env:
+          SKIP: no-commit-to-branch
         with:
           extra_args: --all-files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pyisyox"
 description = "Python module for asynchronous communication with Universal Devices, Inc.'s ISY & IoX controllers."
-license     = {text = "Apache-2.0"}
+license = "Apache-2.0"
 keywords = ["home", "automation", "isy", "isy994", "isy-994", "UDI", "polisy", "eisy", "home-assistant"]
 authors = [
     {name = "Ryan Kraus", email = "automicus@gmail.com"},
@@ -16,7 +16,6 @@ classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: End Users/Desktop",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -38,6 +37,11 @@ dependencies = [
 "Homepage" = "https://github.com/shbatm/pyisyox"
 
 [tool.setuptools_scm]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["pyisyox*"]
+exclude = ["script*"]
 
 [tool.black]
 target-version = ["py310", "py311"]


### PR DESCRIPTION
## Summary

Fixes two critical build issues preventing successful package publishing via GitHub Actions:

- **License configuration**: Migrated from deprecated `{text = "Apache-2.0"}` table format to modern SPDX expression `"Apache-2.0"` (required by setuptools>=77.0.0, mandatory by Feb 2026)
- **Package discovery**: Added explicit `[tool.setuptools.packages.find]` configuration to include only `pyisyox` package and exclude `script/` directory
- **Classifier cleanup**: Removed deprecated `License :: OSI Approved :: Apache Software License` classifier
- **CI workflow fix**: Added `SKIP=no-commit-to-branch` to prevent pre-commit hook failures during squash-and-merge operations

## Problem

The Python package build was failing in CI with:
```
error: Multiple top-level packages discovered in a flat-layout: ['script', 'pyisyox'].
```

And multiple deprecation warnings about license configuration.

Additionally, the `no-commit-to-branch` pre-commit hook was failing during squash-and-merge operations because GitHub creates a direct commit to main/dev when merging PRs.

## Solution

1. Updated license field to use SPDX expression format (setuptools>=77.0.0 requirement)
2. Added setuptools package discovery configuration explicitly excluding non-package directories
3. Removed deprecated license classifier
4. Set `SKIP=no-commit-to-branch` environment variable in CI pre-commit action to bypass this check in automated workflows while keeping it active locally

## Test Plan

- [x] Local build succeeds: `python -m build --sdist`
- [x] No deprecation warnings
- [x] No "multiple top-level packages" errors
- [x] Package structure verified in generated tarball
- [x] Pre-commit hooks pass locally
- [x] CI workflow will allow squash-and-merge operations

## Related

Addresses build failures from the pythonpublish GitHub Actions workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)