### PR TITLE
Fix async exception handling in set_climate_setpoint

### DIFF
--- a/pyisyox/nodes/node.py
+++ b/pyisyox/nodes/node.py
@@ -510,6 +510,9 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
             self.set_climate_setpoint_cool(val + adjustment),
         ]
         result = await asyncio.gather(*commands, return_exceptions=True)
+        for r in result:
+            if isinstance(r, Exception):
+                _LOGGER.error("Error setting climate setpoint on %s: %s", self.address, r)
         return all(r is True for r in result)
 
     async def set_climate_setpoint_heat(self, val: int) -> bool:

--- a/pyisyox/nodes/node.py
+++ b/pyisyox/nodes/node.py
@@ -510,7 +510,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
             self.set_climate_setpoint_cool(val + adjustment),
         ]
         result = await asyncio.gather(*commands, return_exceptions=True)
-        return all(result)
+        return all(r is True for r in result)
 
     async def set_climate_setpoint_heat(self, val: int) -> bool:
         """Send a command to the device to set the system heat setpoint."""


### PR DESCRIPTION
Fixes #43 by explicitly checking that all returned values from `asyncio.gather` are `True` rather than just relying on the truthiness of the return values, which would incorrectly evaluate exceptions to `True`.