### PR TITLE
fix(ci): upgrade mypy to >=1.11.0 and fix pre-commit errors on Python 3.13

### DIFF
--- a/pyisyox/__main__.py
+++ b/pyisyox/__main__.py
@@ -106,7 +106,11 @@ async def main(args: argparse.Namespace) -> None:
             key (str): The key provided for this listener
 
         """
-        output: str = json.dumps(asdict(event), default=str) if is_dataclass(event) else event
+        output: str = (
+            json.dumps(asdict(event), default=str)
+            if is_dataclass(event) and not isinstance(event, type)
+            else event
+        )
         _LOGGER.info("%s status changed: %s", key.title(), output)
 
     # Print a representation of all the Nodes

--- a/pyisyox/node_servers.py
+++ b/pyisyox/node_servers.py
@@ -120,7 +120,7 @@ class NodeDef:
         return cls(**{k: v for k, v in props.items() if k in inspect.signature(cls).parameters})
 
     sts: InitVar[dict[str, list | dict]]
-    cmds: InitVar[dict[str, Any]] | None = None
+    cmds: InitVar[dict[str, Any] | None] = None
     id: str = ""
     node_type: str = ""
     name: str = ""

--- a/pyisyox/nodes/node.py
+++ b/pyisyox/nodes/node.py
@@ -156,7 +156,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
 
         Check ISYv4 UOM, then Insteon and Z-Wave Types for dimmable types.
         """
-        dimmable = (
+        return (
             "%" in str(self._uom)
             or (
                 self._protocol == Protocol.INSTEON
@@ -170,14 +170,11 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
                 and self.zwave_props.category in ZWAVE_CAT_DIMMABLE
             )
         )
-        return dimmable
 
     @property
     def is_lock(self) -> bool:
         """Determine if this device is a door lock type."""
-        return (
-            self.type_ and any(self.type_.startswith(t) for t in INSTEON_TYPE_LOCK)
-        ) or (
+        return (self.type_ and any(self.type_.startswith(t) for t in INSTEON_TYPE_LOCK)) or (
             self.protocol == Protocol.ZWAVE
             and self.zwave_props is not None
             and self.zwave_props.category in ZWAVE_CAT_LOCK
@@ -186,10 +183,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
     @property
     def is_thermostat(self) -> bool:
         """Determine if this device is a thermostat/climate control device."""
-        return (
-            self.type_
-            and any(self.type_.startswith(t) for t in INSTEON_TYPE_THERMOSTAT)
-        ) or (
+        return (self.type_ and any(self.type_.startswith(t) for t in INSTEON_TYPE_THERMOSTAT)) or (
             self._protocol == Protocol.ZWAVE
             and self.zwave_props is not None
             and self.zwave_props.category in ZWAVE_CAT_THERMOSTAT
@@ -277,7 +271,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
         self.update_last_update()
 
         if aux_prop := self.aux_properties.get(prop.control):
-            if prop.uom == "" and not aux_prop.uom == "":
+            if prop.uom == "" and aux_prop.uom != "":
                 # Guard against overwriting known UOM with blank UOM (ISYv4).
                 prop.uom = aux_prop.uom
             if aux_prop == prop:
@@ -312,9 +306,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
         parameter_xml = await self.isy.conn.request(
             self.isy.conn.compile_url(
                 [
-                    URL_ZMATTER_ZWAVE
-                    if self.detail.family == NodeFamily.ZMATTER_ZWAVE
-                    else URL_ZWAVE,
+                    URL_ZMATTER_ZWAVE if self.detail.family == NodeFamily.ZMATTER_ZWAVE else URL_ZWAVE,
                     URL_NODE,
                     self.address,
                     URL_CONFIG,
@@ -346,9 +338,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
 
         return result
 
-    async def set_zwave_parameter(
-        self, parameter: int, value: int | str, size: int
-    ) -> bool:
+    async def set_zwave_parameter(self, parameter: int, value: int | str, size: int) -> bool:
         """Set a Z-Wave Parameter on an end device via the ISY."""
         if self.protocol != Protocol.ZWAVE:
             _LOGGER.warning("Cannot set parameters of non-Z-Wave device")
@@ -380,9 +370,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
         # /rest/zwave/node/<nodeAddress>/config/set/<parameterNumber>/<value>/<size>
         req_url = self.isy.conn.compile_url(
             [
-                URL_ZMATTER_ZWAVE
-                if self.detail.family == NodeFamily.ZMATTER_ZWAVE
-                else URL_ZWAVE,
+                URL_ZMATTER_ZWAVE if self.detail.family == NodeFamily.ZMATTER_ZWAVE else URL_ZWAVE,
                 URL_NODE,
                 self.address,
                 URL_CONFIG,
@@ -420,9 +408,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
         # /rest/zwave/node/<nodeAddress>/security/user/<user_num>/set/code/<code>
         req_url = self.isy.conn.compile_url(
             [
-                URL_ZMATTER_ZWAVE
-                if self.detail.family == NodeFamily.ZMATTER_ZWAVE
-                else URL_ZWAVE,
+                URL_ZMATTER_ZWAVE if self.detail.family == NodeFamily.ZMATTER_ZWAVE else URL_ZWAVE,
                 URL_NODE,
                 self.address,
                 "security",
@@ -451,9 +437,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
         # /rest/zwave/node/<nodeAddress>/security/user/<user_num>/delete
         req_url = self.isy.conn.compile_url(
             [
-                URL_ZMATTER_ZWAVE
-                if self.detail.family == NodeFamily.ZMATTER_ZWAVE
-                else URL_ZWAVE,
+                URL_ZMATTER_ZWAVE if self.detail.family == NodeFamily.ZMATTER_ZWAVE else URL_ZWAVE,
                 URL_NODE,
                 self.address,
                 "security",
@@ -476,13 +460,9 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
     def get_command_value(self, uom: str, cmd: str) -> str | None:
         """Check against the list of UOM States if this is a valid command."""
         if cmd not in UOM_TO_STATES[uom].values():
-            _LOGGER.warning(
-                "Failed to call %s on %s, invalid command.", cmd, self.address
-            )
+            _LOGGER.warning("Failed to call %s on %s, invalid command.", cmd, self.address)
             return None
-        return list(UOM_TO_STATES[uom].keys())[
-            list(UOM_TO_STATES[uom].values()).index(cmd)
-        ]
+        return list(UOM_TO_STATES[uom].keys())[list(UOM_TO_STATES[uom].values()).index(cmd)]
 
     def get_property_uom(self, prop: str) -> str:
         """Get the Unit of Measurement an aux property."""
@@ -540,9 +520,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
         """Send a command to the device to set the system heat setpoint."""
         return await self._set_climate_setpoint(val, "cool", PROP_SETPOINT_COOL)
 
-    async def _set_climate_setpoint(
-        self, val: int, setpoint_name: str, setpoint_prop: str
-    ) -> bool:
+    async def _set_climate_setpoint(self, val: int, setpoint_name: str, setpoint_prop: str) -> bool:
         """Send a command to the device to set the system heat setpoint."""
         if not self.is_thermostat:
             _LOGGER.warning(
@@ -554,9 +532,7 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
         # ISY wants 2 times the temperature for Insteon in order to not lose precision
         if self._uom in ("101", "degrees"):
             val = 2 * val
-        return await self.send_cmd(
-            setpoint_prop, str(val), self.get_property_uom(setpoint_prop)
-        )
+        return await self.send_cmd(setpoint_prop, str(val), self.get_property_uom(setpoint_prop))
 
     async def set_fan_mode(self, cmd: str) -> bool:
         """Send a command to the device to set the fan mode setting."""
@@ -588,16 +564,12 @@ class Node(NodeBase, Entity[NodeDetail, StatusT]):
 
     async def start_manual_dimming(self) -> bool:
         """Begin manually dimming a device."""
-        _LOGGER.warning(
-            "'%s' is depreciated, use FADE<xx> commands instead", CMD_MANUAL_DIM_BEGIN
-        )
+        _LOGGER.warning("'%s' is depreciated, use FADE<xx> commands instead", CMD_MANUAL_DIM_BEGIN)
         return await self.send_cmd(CMD_MANUAL_DIM_BEGIN)
 
     async def stop_manual_dimming(self) -> bool:
         """Stop manually dimming  a device."""
-        _LOGGER.warning(
-            "'%s' is depreciated, use FADE<xx> commands instead", CMD_MANUAL_DIM_STOP
-        )
+        _LOGGER.warning("'%s' is depreciated, use FADE<xx> commands instead", CMD_MANUAL_DIM_STOP)
         return await self.send_cmd(CMD_MANUAL_DIM_STOP)
 
     def get_node_def(self) -> NodeDef | None:

--- a/pyisyox/variables/__init__.py
+++ b/pyisyox/variables/__init__.py
@@ -74,9 +74,15 @@ class Variables(EntityPlatform[Variable]):
         # Check if State Variables defined
         await self.check_if_variables_defined("state", results[1], results[3])
 
-    async def check_if_variables_defined(self, var_type: str, def_result: str, var_result: str) -> None:
+    async def check_if_variables_defined(
+        self, var_type: str, def_result: str | BaseException | None, var_result: str | BaseException | None
+    ) -> None:
         """Check if variables are correctly defined and collect dict."""
-        if def_result is None or def_result in EMPTY_VARIABLES_RESPONSE:
+        if (
+            def_result is None
+            or isinstance(def_result, BaseException)
+            or def_result in EMPTY_VARIABLES_RESPONSE
+        ):
             return
 
         def_dict = parse_xml(def_result, attr_prefix="")
@@ -87,6 +93,8 @@ class Variables(EntityPlatform[Variable]):
         if isinstance(e_list, dict):
             e_list = [e_list]
 
+        if var_result is None or isinstance(var_result, BaseException):
+            return
         var_dict = parse_xml(var_result, attr_prefix="")
         if not (var_list := var_dict["vars"][ATTR_VAR]):
             return

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 codespell>=2.4.2
-mypy-extensions==1.0.0
-mypy==1.4.1
+mypy-extensions>=1.0.0
+mypy>=1.11.0
 nodeenv>=1.10.0
 pre-commit>=4.5.1
 pylint-strict-informational>=0.1


### PR DESCRIPTION
## Summary

- **Root cause of CI mypy failure**: `mypy==1.4.1` does not support Python 3.13; the CI workflow uses `python-version: "3.x"` which resolves to 3.13 on GitHub Actions, causing the _"typed_ast not installed"_ error. Upgraded to `mypy>=1.11.0`.
- **Three type errors** surfaced by the stricter mypy and fixed:
  - `node_servers.py`: `InitVar[dict[str, Any]] | None` → `InitVar[dict[str, Any] | None]` so `__post_init__` signature matches mypy's dataclass-derived expectation
  - `variables/__init__.py`: broadened `check_if_variables_defined` params to `str | BaseException | None` to match `asyncio.gather(return_exceptions=True)` return type; added explicit `isinstance(…, BaseException)` guards before `parse_xml` calls
  - `__main__.py`: narrowed `is_dataclass()` guard with `not isinstance(event, type)` so `asdict()` only receives instances
- **Two ruff warnings** also fixed in `node.py`: RET504 (unnecessary intermediate `dimmable` variable) and SIM201 (`not aux_prop.uom == ""` → `aux_prop.uom != ""`)

## Test plan

- [x] All pre-commit hooks pass locally (`uvx pre-commit run --all-files`)
- [x] `mypy pyisyox` reports no issues with mypy >=1.11.0
- [x] CI passes on Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)