### PR TITLE
feat(runtime): add Node.status and Node.primary_node shortcuts

### DIFF
--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -157,6 +157,16 @@ class Node:
         return self._record.parent_address
 
     @property
+    def primary_node(self) -> str | None:
+        """Alias for :attr:`parent_address`.
+
+        The IoX REST surface and the legacy PyISY 3.x consumer API both
+        used the term "primary node" for the address of the device's
+        root node. Kept here so consumers don't have to translate.
+        """
+        return self._record.parent_address
+
+    @property
     def enabled(self) -> bool:
         """Whether the eisy considers this node active."""
         return self._record.enabled
@@ -171,6 +181,20 @@ class Node:
         in place at runtime via :class:`pyisyox.runtime.EventDispatcher`.
         """
         return self._record.properties
+
+    @property
+    def status(self) -> NodePropertyValue | None:
+        """Shortcut for :attr:`properties`\\ ``[PROP_STATUS]`` — the
+        node's primary status reading (``"ST"``).
+
+        Returns ``None`` when the node hasn't reported ST yet (common
+        for write-only Insteon controllers and plugin nodes that don't
+        advertise ST). Consumers that want a scalar should read
+        ``node.status.value`` (a string) and parse it themselves;
+        the property keeps the structured shape so callers can also
+        reach ``.uom``, ``.formatted``, etc.
+        """
+        return self._record.properties.get(PROP_STATUS)
 
     @property
     def nodedef(self) -> NodeDef | None:

--- a/tests/test_runtime/test_node_introspection.py
+++ b/tests/test_runtime/test_node_introspection.py
@@ -146,6 +146,37 @@ def test_introspection_safe_when_nodedef_unresolved(real_profile: Profile) -> No
     assert node.is_dimmable is False
 
 
+# --- shortcuts: status + primary_node ------------------------------------
+
+
+def test_status_returns_st_property_when_present(real_profile: Profile) -> None:
+    """``Node.status`` is a shortcut for ``properties["ST"]``."""
+    st = NodePropertyValue(id="ST", value="100", formatted="On", uom="51")
+    node = _make_node(_make_record(properties={"ST": st}), real_profile)
+    assert node.status is st
+
+
+def test_status_none_when_st_absent(real_profile: Profile) -> None:
+    """Nodes without an ST reading (write-only controllers, plugin nodes
+    that don't advertise it) return ``None`` — callers branch on it."""
+    node = _make_node(_make_record(properties={}), real_profile)
+    assert node.status is None
+
+
+def test_primary_node_aliases_parent_address(real_profile: Profile) -> None:
+    """``primary_node`` is the IoX-spelling alias for ``parent_address``;
+    consumers migrating from PyISY 3.x can keep the old name."""
+    node = _make_node(_make_record(parent_address="AA BB CC 1"), real_profile)
+    assert node.primary_node == "AA BB CC 1"
+    assert node.primary_node == node.parent_address
+
+
+def test_primary_node_none_for_root_node(real_profile: Profile) -> None:
+    """A device-root node has no parent address — primary_node is None."""
+    node = _make_node(_make_record(parent_address=None), real_profile)
+    assert node.primary_node is None
+
+
 # --- ergonomic wrappers (URL pinning) ------------------------------------
 #
 # Each wrapper does the same thing: route through send_command with a


### PR DESCRIPTION
## Summary

Two read-through aliases on `Node` for v6 consumers.

- **`Node.status`** → `properties.get(PROP_STATUS)`. Returns the full `NodePropertyValue` or `None`. Most consumers want the primary reading; `properties.get(\"ST\")` at every call site is busywork that obscures intent.
- **`Node.primary_node`** → `parent_address`. Both the IoX REST surface and PyISY 3.x used \"primary node\" for the sub-node's parent address. The alias keeps v3-era integrations idiomatic without renaming the variable.

Both are pure read-through properties — no new state, no behavior change.

## Motivation

Porting `hacs-udi-iox` (the eisy/Polisy consumer of pyisyox 6.x) surfaced 36+ call sites that reach for `node.status` / `node.primary_node`. Adding the shortcuts upstream keeps consumer code idiomatic and avoids forcing every consumer that follows to add the same shim.

## Test plan

- [x] `tests/test_runtime/test_node_introspection.py` — 4 new tests covering `status` (present), `status` (absent → None), `primary_node` (subnode), `primary_node` (root → None).
- [x] Reviewer to confirm consistent with the v6 \"public surface is final for 6.0.0a1\" stance — these are additive, no removals or renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)