### PR TITLE
feat(runtime): preserve <eventInfo> on Event for non-lifecycle frames

### DIFF
--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -170,6 +170,13 @@ class Event:
         uom: Unit-of-measure id from ``<action uom="...">``.
         prec: Decimal precision from ``<action prec="...">``, or
             ``None`` if absent.
+        event_info: Inner ``<eventInfo>`` XML preserved verbatim.
+            Empty string when the frame had no ``<eventInfo>`` element
+            or when its content was empty. Consumers that need the
+            structured payload (e.g. variable change frames carrying
+            ``<var type="..." id="...">``, or controller logs in CDATA)
+            parse this themselves — the IoX wire schema differs across
+            system control codes and pyisyox stays neutral.
     """
 
     seqnum: int
@@ -181,6 +188,7 @@ class Event:
     formatted_name: str = ""
     uom: str = ""
     prec: int | None = None
+    event_info: str = ""
 
     @property
     def is_system(self) -> bool:
@@ -234,7 +242,38 @@ def parse_event_frame(raw: str) -> Event | None:
         formatted_name=root.findtext("fmtName", default="") or "",
         uom=uom,
         prec=prec,
+        event_info=_extract_event_info(root),
     )
+
+
+def _extract_event_info(root: ET.Element) -> str:
+    """Serialise ``<eventInfo>`` back to a string, or return ``""``.
+
+    Variable change frames pack ``<var type="..." id="..."><val>``,
+    network resource frames carry ``<eventInfo>`` plus typed children,
+    Z-Wave / Matter status frames carry config dicts, and controller
+    logs (``_7``) carry CDATA. The parser keeps the inner XML verbatim
+    so consumers can pick the parsing strategy that fits — most
+    consumers won't care, but when they do, re-parsing the frame
+    themselves would mean carrying the raw bytes alongside every
+    ``Event``, defeating the value of having a parsed dataclass.
+
+    Empty ``<eventInfo/>`` and absent elements both return ``""``.
+    """
+    info = root.find("eventInfo")
+    if info is None:
+        return ""
+    # Use a string builder over .text + child serialisation so that
+    # mixed-content nodes (CDATA + element children, like _7
+    # controller logs) round-trip without losing bits.
+    pieces: list[str] = []
+    if info.text:
+        pieces.append(info.text)
+    for child in info:
+        pieces.append(ET.tostring(child, encoding="unicode"))
+        if child.tail:
+            pieces.append(child.tail)
+    return "".join(pieces).strip()
 
 
 def _text(element: ET.Element | None) -> str:

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -87,6 +87,67 @@ def test_parse_system_event_has_empty_node() -> None:
     assert event.is_system is True
     assert event.is_node_property is False
     assert event.node_address == ""
+    assert event.event_info == ""
+
+
+def test_parse_preserves_event_info_for_variable_value_change() -> None:
+    """Variable change frames (control=_1 action=6) carry the new
+    value inside ``<eventInfo><var type=... id=...>``. Consumers
+    can re-parse the inner XML to drive variable state updates."""
+    xml = (
+        '<Event seqnum="312" sid="uuid:1" timestamp="2026-05-02">'
+        "<control>_1</control><action>6</action><node></node>"
+        "<eventInfo>"
+        '<var type="1" id="1">'
+        "<prec>1</prec><val>20</val><ts>20260502 14:56:16 </ts>"
+        "</var>"
+        "</eventInfo>"
+        "</Event>"
+    )
+    event = parse_event_frame(xml)
+    assert event is not None
+    assert event.control == "_1"
+    assert event.action == "6"
+    assert "<var" in event.event_info and 'type="1"' in event.event_info
+    assert "<val>20</val>" in event.event_info
+
+
+def test_parse_preserves_cdata_event_info_for_controller_logs() -> None:
+    """``_7`` controller-log frames pack the message in CDATA inside
+    ``<eventInfo>``. Round-tripping the inner content has to keep the
+    text payload — even if the CDATA wrapper itself doesn't survive,
+    the consumer-visible string must."""
+    xml = (
+        '<Event seqnum="291" sid="uuid:1" timestamp="2026-05-02">'
+        "<control>_7</control><action>1</action><node></node>"
+        "<eventInfo><![CDATA["
+        "U7 Rest:  submitCmd([A9 AD 83 1],[OL],[<NULL>])"
+        "]]></eventInfo>"
+        "</Event>"
+    )
+    event = parse_event_frame(xml)
+    assert event is not None
+    assert "submitCmd" in event.event_info
+
+
+def test_parse_empty_self_closing_event_info_normalises_to_empty_string() -> None:
+    """``<eventInfo/>`` and absent eventInfo both normalise to ``""`` so
+    consumers can ``if event.event_info:`` without checking None."""
+    xml_self_closing = (
+        '<Event seqnum="1" sid="uuid:1" timestamp="x">'
+        "<control>ST</control><action>1</action>"
+        "<node>A</node><eventInfo/>"
+        "</Event>"
+    )
+    xml_absent = (
+        '<Event seqnum="1" sid="uuid:1" timestamp="x">'
+        "<control>ST</control><action>1</action><node>A</node>"
+        "</Event>"
+    )
+    for xml in (xml_self_closing, xml_absent):
+        event = parse_event_frame(xml)
+        assert event is not None
+        assert event.event_info == ""
 
 
 def test_parse_handles_jsonenvelope_from_api_events_subscribe() -> None:


### PR DESCRIPTION
## Summary

The lifecycle path already extracts \`<eventInfo>\` content into \`NodeLifecycleEvent.node_xml\` for \`_3\` add/remove/rename frames. Every **other** system control code drops eventInfo during parsing — even when the payload *is* the entire point of the frame:

- **\`_1\` action=6/7** — variable value / init change. \`<eventInfo>\` carries \`<var type=\"...\" id=\"...\"><val>..</val>\`. Without it the consumer knows a variable changed, but not which one or to what.
- **\`_22\`** energy summary, **\`_25\`** Z-Wave, **\`_28\`** Matter status — typed config dicts inside eventInfo.
- **\`_7\`** controller logs — message in CDATA inside eventInfo.
- Network-resource execution events (when they arrive) — same shape.

Adds \`event_info: str\` to \`Event\`. Round-trips the inner XML verbatim (mixed-content + CDATA-safe). \`\"\"\` when absent or self-closing — consumers branch on \`if event.event_info:\`. pyisyox stays neutral on the eventInfo *shape*; the IoX wire schema differs per control code and the consumer picks its parsing strategy.

## Tests

- \`_1\` variable change preserves \`<var type=\"1\" id=\"1\"><val>20</val>\`
- \`_7\` controller log preserves the CDATA text body
- \`<eventInfo/>\` and absent \`<eventInfo>\` both normalise to \`\"\"\`
- existing \`_5\` system-event test extended to assert \`event_info == \"\"\`

## Motivation

\`hacs-udi-iox\` needs variable change frames to update \`ISYVariableNumberEntity\` in real time, and the same pattern unblocks network-resource execution feedback. \`Controller.add_event_listener\` only delivers the parsed \`Event\`, so without preserving \`event_info\` the consumer would have to re-parse the raw frame — and the raw frame isn't reachable from a listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)