### PR TITLE
feat(runtime): add Node.is_fan classifier

### DIFF
--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -287,6 +287,24 @@ class Node:
         return self._has_command(CMD_SECURE) or "Lock" in self.nodedef_id
 
     @property
+    def is_fan(self) -> bool:
+        """True if the node is a multi-speed fan controller.
+
+        Derived from the nodedef id substring ``"Fan"`` — matches
+        the Insteon ``FanLincMotor`` sub-node (the FanLinc light
+        side reports as ``DimmerLampOnly``, so light/fan separate
+        cleanly per sub-address) and PG3 plugin fan nodedefs that
+        follow the same naming convention.
+
+        Fan nodes are a subset of dimmable nodes (``FanLincMotor``
+        accepts ``DON`` with a level parameter restricted to the
+        ``{0, 25, 75, 100}`` Off/Low/Medium/High subset), so
+        callers classifying onto a HA-style ``Platform.FAN`` should
+        check ``is_fan`` **before** ``is_dimmable``.
+        """
+        return "Fan" in self.nodedef_id
+
+    @property
     def is_dimmable(self) -> bool:
         """True if the node reports a multilevel ``ST`` (status) state.
 

--- a/tests/test_runtime/test_node_introspection.py
+++ b/tests/test_runtime/test_node_introspection.py
@@ -117,6 +117,33 @@ def test_is_dimmable_false_for_relay_only(real_profile: Profile) -> None:
     assert node.is_dimmable is False
 
 
+def test_is_fan_true_for_fanlinc_motor(real_profile: Profile) -> None:
+    """``FanLincMotor`` is the Insteon FanLinc fan-side sub-node;
+    its sibling light reports as ``DimmerLampOnly``.
+
+    Note: ``is_dimmable`` returns False on FanLincMotor because the
+    ``I_FLM_LVL`` editor pins the level to a 4-value subset
+    (``{0, 25, 75, 100}``) without an explicit range max — the
+    multilevel-range check requires a numeric max. ``is_fan`` is
+    therefore the only positive classification signal for these
+    nodes; today they fall through to ``SWITCH``."""
+    node = _make_node(_make_record(nodedef_id="FanLincMotor"), real_profile)
+    assert node.is_fan is True
+
+
+def test_is_fan_false_for_dimmer(real_profile: Profile) -> None:
+    """A plain dimmer must not be misclassified as a fan."""
+    node = _make_node(_make_record(nodedef_id="DimmerLampOnly"), real_profile)
+    assert node.is_fan is False
+
+
+def test_is_fan_false_for_thermostat(real_profile: Profile) -> None:
+    """The fan-mode editors on a thermostat are editor ids, not
+    nodedef ids — the Thermostat nodedef must not match ``is_fan``."""
+    node = _make_node(_make_record(nodedef_id="Thermostat"), real_profile)
+    assert node.is_fan is False
+
+
 def test_is_battery_node_detects_batlvl_only_devices(real_profile: Profile) -> None:
     """Battery sensors expose BATLVL but no ST."""
     record = _make_record(properties={"BATLVL": NodePropertyValue(id="BATLVL", value="80", formatted="80%")})
@@ -142,6 +169,7 @@ def test_introspection_safe_when_nodedef_unresolved(real_profile: Profile) -> No
     assert node.nodedef is None
     assert node.is_thermostat is False
     assert node.is_lock is False
+    assert node.is_fan is False
     assert node.is_dimmable is False
 
 


### PR DESCRIPTION
## Summary

Adds `Node.is_fan`, the missing introspection helper for fan controllers. Mirrors the `is_lock` pattern: substring check on `nodedef_id`.

`"Fan" in node.nodedef_id` cleanly catches:

- Insteon **`FanLincMotor`** — the FanLinc fan-side sub-node (the sibling light reports as `DimmerLampOnly`, so light/fan separate by sub-address).
- PG3 plugin fan nodedefs that follow the same naming convention.

## Why this is needed

Without `is_fan`, consumers classifying onto a HA-style `Platform.FAN` have no positive signal. `is_dimmable` already reports `False` for `FanLincMotor` because the `I_FLM_LVL` editor uses a 4-value subset (`{0, 25, 75, 100}`) without an explicit range max — the multilevel-range check requires a numeric max. So FanLincMotor falls through to a plain `SWITCH` today. Wiring `is_fan` ahead of `is_dimmable` in the consumer's classifier closes the gap.

The test_is_fan_true_for_fanlinc_motor test pins the actual current behavior (is_dimmable=False) and notes why is_fan is the only positive signal.

## Test plan

- [x] Add `test_is_fan_true_for_fanlinc_motor` (positive case against the captured `FanLincMotor` nodedef in `tests/fixtures/eisy6/profiles_with_flume.json`).
- [x] Add `test_is_fan_false_for_dimmer` (`DimmerLampOnly`) and `test_is_fan_false_for_thermostat` (the fan-mode editor ids on `Thermostat` aren't nodedef ids, so they must not match).
- [x] Extend `test_introspection_safe_when_nodedef_unresolved` to cover `is_fan`.
- [x] `pytest -q` — 351 passed.
- [x] `ruff check` — clean.