### PR TITLE
feat(runtime): rename_node / rename_group / rename_folder + Node.rename / Group.rename

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -399,13 +399,9 @@ class IoXClient:
         Raises:
             HTTPError on non-2xx; ClientError on malformed response.
         """
-        return await self._post_json(
-            f"/api/variables/{var_type}/{var_id}", body
-        )
+        return await self._post_json(f"/api/variables/{var_type}/{var_id}", body)
 
-    async def post_node_update(
-        self, address: str, body: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def post_node_update(self, address: str, body: dict[str, Any]) -> dict[str, Any]:
         """Issue ``POST /api/nodes/{address}`` with the supplied body.
 
         Documented body shape (verified against eisy-ui capture):
@@ -420,9 +416,7 @@ class IoXClient:
         encoded = quote(address, safe="")
         return await self._post_json(f"/api/nodes/{encoded}", body)
 
-    async def _post_json(
-        self, path: str, body: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def _post_json(self, path: str, body: dict[str, Any]) -> dict[str, Any]:
         """Shared POST-JSON path with auth-recovery on 401.
 
         Variable + node update endpoints share the exact same shape:

--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -399,7 +399,36 @@ class IoXClient:
         Raises:
             HTTPError on non-2xx; ClientError on malformed response.
         """
-        path = f"/api/variables/{var_type}/{var_id}"
+        return await self._post_json(
+            f"/api/variables/{var_type}/{var_id}", body
+        )
+
+    async def post_node_update(
+        self, address: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Issue ``POST /api/nodes/{address}`` with the supplied body.
+
+        Documented body shape (verified against eisy-ui capture):
+
+        * ``{"name": "<str>", "nodeType": "node" | "group"}`` —
+          rename the node or group. ``nodeType`` is required by the
+          server even though the address already disambiguates.
+
+        Returns the parsed response body (a ``{successful, data}``
+        envelope).
+        """
+        encoded = quote(address, safe="")
+        return await self._post_json(f"/api/nodes/{encoded}", body)
+
+    async def _post_json(
+        self, path: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Shared POST-JSON path with auth-recovery on 401.
+
+        Variable + node update endpoints share the exact same shape:
+        JSON body, ``{successful, data}`` envelope, single-shot 401
+        retry through :meth:`Auth.handle_unauthorized`.
+        """
         url = f"{self.base_url}{path}"
         kwargs: dict[str, Any] = {"json": body}
         if not self._authenticated:

--- a/pyisyox/controller.py
+++ b/pyisyox/controller.py
@@ -462,6 +462,34 @@ class Controller:
             raise ControllerNotConnectedError("controller has no client")
         await client.post_variable_update(var_type, var_id, body)
 
+    async def rename_node(self, address: str, name: str) -> None:
+        """Rename a node.
+
+        Wire shape: ``POST /api/nodes/{address}`` with
+        ``{"name": "<str>", "nodeType": "node"}``.
+
+        The ``nodeType`` field is required by the server. Use
+        :meth:`rename_group` for scenes.
+        """
+        await self._post_node(address, {"name": name, "nodeType": "node"})
+
+    async def rename_group(self, address: str, name: str) -> None:
+        """Rename a group / scene.
+
+        Same endpoint as :meth:`rename_node` but with
+        ``nodeType: "group"`` so the server applies the change
+        through the scene registry.
+        """
+        await self._post_node(address, {"name": name, "nodeType": "group"})
+
+    async def _post_node(self, address: str, body: dict) -> None:
+        """Internal: route a node mutation through the IoXClient."""
+        self._loaded_or_raise()
+        client = self._client
+        if client is None:  # pragma: no cover
+            raise ControllerNotConnectedError("controller has no client")
+        await client.post_node_update(address, body)
+
     # --- testing seams -------------------------------------------------
 
     def feed_event_frame(self, raw_frame: str) -> Event | None:

--- a/pyisyox/controller.py
+++ b/pyisyox/controller.py
@@ -482,6 +482,16 @@ class Controller:
         """
         await self._post_node(address, {"name": name, "nodeType": "group"})
 
+    async def rename_folder(self, address: str, name: str) -> None:
+        """Rename a folder (organisational container).
+
+        Same endpoint as :meth:`rename_node` / :meth:`rename_group`
+        but with ``nodeType: "folder"``. Folders are address-keyed
+        like nodes/groups; their addresses are typically 5-digit
+        integers (family ``"13"``).
+        """
+        await self._post_node(address, {"name": name, "nodeType": "folder"})
+
     async def _post_node(self, address: str, body: dict) -> None:
         """Internal: route a node mutation through the IoXClient."""
         self._loaded_or_raise()

--- a/pyisyox/runtime/group.py
+++ b/pyisyox/runtime/group.py
@@ -191,5 +191,17 @@ class Group:
         """
         await self._client.send_node_command(self.address, command_id, *params)
 
+    async def rename(self, name: str) -> None:
+        """Rename this group / scene.
+
+        Wire shape: ``POST /api/nodes/{address}`` with
+        ``{"name": "<str>", "nodeType": "group"}``. The ``nodeType``
+        field is required by the server even though the address
+        already disambiguates — without it the call is rejected.
+        """
+        await self._client.post_node_update(
+            self.address, {"name": name, "nodeType": "group"}
+        )
+
     def __repr__(self) -> str:
         return f"Group(address={self.address!r}, name={self.name!r}, members={len(self.member_addresses)})"

--- a/pyisyox/runtime/group.py
+++ b/pyisyox/runtime/group.py
@@ -199,9 +199,7 @@ class Group:
         field is required by the server even though the address
         already disambiguates — without it the call is rejected.
         """
-        await self._client.post_node_update(
-            self.address, {"name": name, "nodeType": "group"}
-        )
+        await self._client.post_node_update(self.address, {"name": name, "nodeType": "group"})
 
     def __repr__(self) -> str:
         return f"Group(address={self.address!r}, name={self.name!r}, members={len(self.member_addresses)})"

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -479,3 +479,18 @@ class Node:
     async def stop_manual_dimming(self) -> None:
         """End manual dimming (legacy Insteon ``SMAN``)."""
         await self.send_command(CMD_MANUAL_DIM_STOP)
+
+    async def rename(self, name: str) -> None:
+        """Rename this node.
+
+        Wire shape: ``POST /api/nodes/{address}`` with
+        ``{"name": "<str>", "nodeType": "node"}``. The IoX server
+        emits a ``<control>_3</control>`` lifecycle event with
+        ``action="NN"`` after a successful rename, so consumers
+        listening through
+        :meth:`Controller.add_node_lifecycle_listener` will see the
+        change without polling.
+        """
+        await self._client.post_node_update(
+            self.address, {"name": name, "nodeType": "node"}
+        )

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -491,6 +491,4 @@ class Node:
         :meth:`Controller.add_node_lifecycle_listener` will see the
         change without polling.
         """
-        await self._client.post_node_update(
-            self.address, {"name": name, "nodeType": "node"}
-        )
+        await self._client.post_node_update(self.address, {"name": name, "nodeType": "node"})

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -589,6 +589,26 @@ async def test_rename_group_posts_name_and_type_group() -> None:
 
 
 @pytest.mark.asyncio
+async def test_rename_folder_posts_name_and_type_folder() -> None:
+    """``rename_folder`` posts ``nodeType: "folder"`` — the IoX
+    admin UI distinguishes folders from groups even though both go
+    through the same endpoint."""
+    session = FakeSession(BASE)
+    _stub_responses(session)
+    session.set_route("POST", "/api/nodes/12345", 200, {"successful": True, "data": None})
+    controller = Controller(BASE, LocalAuth("admin", "p"), session=session)  # type: ignore[arg-type]
+    await controller.connect(start_websocket=False)
+
+    await controller.rename_folder("12345", "Hallway")
+
+    method, path, kwargs = session.calls[-1]
+    assert (method, path) == ("POST", "/api/nodes/12345")
+    assert kwargs["json"] == {"name": "Hallway", "nodeType": "folder"}
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
 async def test_rename_node_before_connect_raises() -> None:
     controller = Controller(BASE, LocalAuth("admin", "p"))
     with pytest.raises(ControllerNotConnectedError):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -546,6 +546,56 @@ async def test_rename_variable_posts_name_body() -> None:
 
 
 @pytest.mark.asyncio
+async def test_rename_node_posts_name_and_type_node() -> None:
+    """``rename_node`` posts ``{"name", "nodeType": "node"}`` to
+    ``/api/nodes/{address}`` (URL-encoded). Wire shape verified
+    against an eisy 6+ admin-UI capture; ``nodeType`` is required
+    even though the address already disambiguates."""
+    session = FakeSession(BASE)
+    _stub_responses(session)
+    session.set_route("POST", "/api/nodes/3E%20FF%201F%204", 200, {"successful": True, "data": None})
+    controller = Controller(BASE, LocalAuth("admin", "p"), session=session)  # type: ignore[arg-type]
+    await controller.connect(start_websocket=False)
+
+    await controller.rename_node("3E FF 1F 4", "Test Remote - G-H - Test")
+
+    method, path, kwargs = session.calls[-1]
+    assert (method, path) == ("POST", "/api/nodes/3E%20FF%201F%204")
+    assert kwargs["json"] == {
+        "name": "Test Remote - G-H - Test",
+        "nodeType": "node",
+    }
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_rename_group_posts_name_and_type_group() -> None:
+    """``rename_group`` is the scene-side variant — same endpoint,
+    same address-encoding, but ``nodeType: "group"``."""
+    session = FakeSession(BASE)
+    _stub_responses(session)
+    session.set_route("POST", "/api/nodes/12345", 200, {"successful": True, "data": None})
+    controller = Controller(BASE, LocalAuth("admin", "p"), session=session)  # type: ignore[arg-type]
+    await controller.connect(start_websocket=False)
+
+    await controller.rename_group("12345", "Hallway Scene")
+
+    method, path, kwargs = session.calls[-1]
+    assert (method, path) == ("POST", "/api/nodes/12345")
+    assert kwargs["json"] == {"name": "Hallway Scene", "nodeType": "group"}
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_rename_node_before_connect_raises() -> None:
+    controller = Controller(BASE, LocalAuth("admin", "p"))
+    with pytest.raises(ControllerNotConnectedError):
+        await controller.rename_node("3E FF 1F 4", "any")
+
+
+@pytest.mark.asyncio
 async def test_set_variable_before_connect_raises() -> None:
     controller = Controller(BASE, LocalAuth("admin", "p"))
     with pytest.raises(ControllerNotConnectedError):

--- a/tests/test_runtime/test_groups.py
+++ b/tests/test_runtime/test_groups.py
@@ -433,9 +433,7 @@ async def test_group_rename_posts_name_and_type_group() -> None:
         instance_id="1",
     )
     session = FakeSession(BASE)
-    session.set_route(
-        "POST", "/api/nodes/55090", 200, '{"successful": true, "data": null}'
-    )
+    session.set_route("POST", "/api/nodes/55090", 200, '{"successful": true, "data": null}')
     group = Group.from_record(record, _profile(), _make_client(session))
 
     await group.rename("Front Yard")

--- a/tests/test_runtime/test_groups.py
+++ b/tests/test_runtime/test_groups.py
@@ -417,3 +417,29 @@ def test_group_all_on_false_when_no_members() -> None:
     )
     group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)), nodes={})
     assert group.group_all_on is False
+
+
+@pytest.mark.asyncio
+async def test_group_rename_posts_name_and_type_group() -> None:
+    """``Group.rename`` posts ``{"name", "nodeType": "group"}`` to
+    ``/api/nodes/{address}`` — same endpoint as Node.rename, but the
+    server requires the type field to dispatch through the scene
+    registry instead of the node registry."""
+    record = GroupRecord(
+        address="55090",
+        name="Driveway",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+    )
+    session = FakeSession(BASE)
+    session.set_route(
+        "POST", "/api/nodes/55090", 200, '{"successful": true, "data": null}'
+    )
+    group = Group.from_record(record, _profile(), _make_client(session))
+
+    await group.rename("Front Yard")
+
+    method, path, kwargs = session.calls[-1]
+    assert (method, path) == ("POST", "/api/nodes/55090")
+    assert kwargs["json"] == {"name": "Front Yard", "nodeType": "group"}

--- a/tests/test_runtime/test_node_introspection.py
+++ b/tests/test_runtime/test_node_introspection.py
@@ -277,6 +277,26 @@ async def test_set_fan_mode_routes_to_clifs(real_profile: Profile) -> None:
     assert any("/cmd/CLIFS/" in path for _, path, _ in session.calls)
 
 
+@pytest.mark.asyncio
+async def test_node_rename_posts_name_and_type_node(real_profile: Profile) -> None:
+    """``Node.rename`` posts ``{"name", "nodeType": "node"}`` to
+    ``/api/nodes/{address}``. URL encoding on the address is
+    handled by the client's quote(safe="") — spaces become ``%20``."""
+    session = FakeSession(BASE)
+    session.set_route(
+        "POST",
+        "/api/nodes/AA%20BB%20CC%201",
+        200,
+        '{"successful": true, "data": null}',
+    )
+    node = _make_node(_make_record(), real_profile, session)
+    await node.rename("New Name")
+
+    method, path, kwargs = session.calls[-1]
+    assert (method, path) == ("POST", "/api/nodes/AA%20BB%20CC%201")
+    assert kwargs["json"] == {"name": "New Name", "nodeType": "node"}
+
+
 #
 # secure_lock / secure_unlock / start_manual_dimming / stop_manual_dimming:
 #


### PR DESCRIPTION
## Summary

Adds rename support for nodes, groups (scenes), and folders — the missing counterpart to `rename_variable`. Wire shape verified against eisy 6+ admin-UI captures:

\`\`\`
POST /api/nodes/{address}
{"name": "<str>", "nodeType": "node" | "group" | "folder"}
\`\`\`

The `nodeType` field is required by the server even though the address already disambiguates. Three values are valid: `"node"` for devices, `"group"` for scenes, `"folder"` for organisational containers.

## Surfaces

- **`Controller.rename_node(address, name)` / `rename_group(address, name)` / `rename_folder(address, name)`** — symmetric with the existing `rename_variable`.
- **`Node.rename(name)` / `Group.rename(name)`** — ergonomic one-liners on the runtime wrappers.
- **`IoXClient.post_node_update(address, body)`** — the underlying client method, paralleling `post_variable_update`. Both go through a new shared `_post_json` helper so the variable-write and node-write paths share auth-recovery + 401-retry + envelope-parsing.

No ergonomic `Folder.rename` wrapper: the `Folder` runtime class doesn't carry a client reference (folders have no command surface beyond identity), so the controller-level helper is sufficient for the rare folder-rename case.

## Lifecycle

The IoX server emits a `<control>_3</control>` lifecycle event with `action="NN"` after a successful rename, so consumers listening through `Controller.add_node_lifecycle_listener` see the change without polling.

## Test plan

- [x] \`pytest -q\` — 357 passed
- [x] \`ruff check\` — clean
- [x] Pin URL + body for `Controller.rename_node` / `rename_group` / `rename_folder`
- [x] `ControllerNotConnectedError` before connect
- [x] `Node.rename` ergonomic wrapper URL/body
- [x] `Group.rename` ergonomic wrapper URL + `nodeType="group"` body