### PR TITLE
feat(runtime): expose WS health (status / connected / last_event_at) + Controller.websocket

### DIFF
--- a/pyisyox/controller.py
+++ b/pyisyox/controller.py
@@ -211,6 +211,20 @@ class Controller:
         return self._loaded is not None
 
     @property
+    def websocket(self) -> WebSocketEventStream | None:
+        """The active WebSocket stream, or ``None``.
+
+        Returns the live :class:`WebSocketEventStream` when
+        :meth:`connect` was called with ``start_websocket=True`` and
+        :meth:`stop` hasn't run yet. ``None`` for one-shot reads
+        (CLI tools, snapshot tests) that opted out of the WS
+        upgrade. Consumers polling stream health (HA system_health,
+        diagnostics) read ``websocket.status`` /
+        ``websocket.last_event_at`` directly.
+        """
+        return self._ws
+
+    @property
     def base_url(self) -> str:
         """The controller URL passed to ``__init__``."""
         return self._base_url

--- a/pyisyox/runtime/ws.py
+++ b/pyisyox/runtime/ws.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import aiohttp
@@ -69,7 +70,9 @@ class WebSocketEventStream:
         "_backoff_idx",
         "_client",
         "_dispatcher",
+        "_last_event_at",
         "_path",
+        "_status",
         "_status_listeners",
         "_stop_requested",
         "_task",
@@ -104,8 +107,46 @@ class WebSocketEventStream:
         self._stop_requested = False
         self._backoff_idx = 0
         self._status_listeners: list[StatusListener] = []
+        self._status: EventStreamStatus = EventStreamStatus.NOT_STARTED
+        self._last_event_at: datetime | None = None
 
     # --- public API ----------------------------------------------------
+
+    @property
+    def status(self) -> EventStreamStatus:
+        """Most-recent stream status.
+
+        Updated on every transition (initialise / connect /
+        reconnect / disconnect / lost). Defaults to
+        :attr:`EventStreamStatus.NOT_STARTED` before :meth:`start`.
+        Useful for system-health pages that want a single
+        readable status string without subscribing to every
+        notification.
+        """
+        return self._status
+
+    @property
+    def connected(self) -> bool:
+        """``True`` while the stream is in the ``CONNECTED`` state.
+
+        Convenience over comparing :attr:`status` directly. Note
+        that ``connected`` flipping ``False`` doesn't mean the
+        reader has given up — it may be reconnecting.
+        """
+        return self._status == EventStreamStatus.CONNECTED
+
+    @property
+    def last_event_at(self) -> datetime | None:
+        """UTC timestamp of the most recent text frame, or ``None``
+        if no frame has been received this lifetime.
+
+        The eisy emits a heartbeat ``<control>_0</control>`` frame
+        every 30 seconds even when nothing else changes, so a
+        stale ``last_event_at`` (more than ~60 s ago) is a
+        reasonable signal that the connection is broken even
+        when the WS handshake hasn't returned an error yet.
+        """
+        return self._last_event_at
 
     def add_status_listener(self, callback: StatusListener) -> Callable[[], None]:
         """Register a callback for stream-status changes.
@@ -203,6 +244,7 @@ class WebSocketEventStream:
                 if self._stop_requested:
                     break
                 if msg.type == aiohttp.WSMsgType.TEXT:
+                    self._last_event_at = datetime.now(UTC)
                     self._dispatcher.feed(msg.data)
                 elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
                     break
@@ -244,6 +286,7 @@ class WebSocketEventStream:
 
     def _notify(self, status: EventStreamStatus) -> None:
         """Fan a status update out to listeners; suppress listener errors."""
+        self._status = status
         for listener in tuple(self._status_listeners):
             try:
                 listener(status)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -12,9 +12,11 @@ import aiohttp
 import pytest
 
 from pyisyox.auth import LocalAuth, PortalAuth
+from pyisyox.constants import EventStreamStatus
 from pyisyox.controller import Controller, ControllerNotConnectedError
 from pyisyox.runtime import ProgramCommand
-from pyisyox.runtime.events import Event, NodeLifecycleAction, NodeLifecycleEvent
+from pyisyox.runtime.events import Event, EventDispatcher, NodeLifecycleAction, NodeLifecycleEvent
+from pyisyox.runtime.ws import WebSocketEventStream
 from tests.test_client.conftest import FakeSession as FakeHttpSession
 from tests.test_runtime.test_ws import FakeWebSocket, FakeWSMessage
 
@@ -187,9 +189,77 @@ async def test_connect_without_websocket_skips_ws_call() -> None:
 
     assert controller.connected is True
     assert session.ws_calls == []
+    # ``websocket`` is None when the WS wasn't started — system_health
+    # consumers branch on this.
+    assert controller.websocket is None
     # Status listener registration requires the WS; should raise.
     with pytest.raises(ControllerNotConnectedError, match="WebSocket"):
         controller.add_status_listener(lambda _s: None)
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_websocket_status_and_connected_track_state() -> None:
+    """``WebSocketEventStream.status`` mirrors the most recent
+    ``EventStreamStatus``; ``connected`` is True only while in
+    ``CONNECTED``. ``last_event_at`` advances when a frame arrives."""
+    session = FakeSession(BASE)
+    _stub_responses(session)
+    controller = Controller(BASE, LocalAuth("admin", "p"), session=session)  # type: ignore[arg-type]
+    await controller.connect(start_websocket=False)
+
+    # Construct a WS stream against the controller's client + a
+    # fresh dispatcher; we don't start the read loop because we
+    # want to drive status manually.
+    ws = WebSocketEventStream(
+        controller._client,  # type: ignore[arg-type]
+        EventDispatcher(controller.nodes),
+    )
+    assert ws.status == EventStreamStatus.NOT_STARTED
+    assert ws.connected is False
+    assert ws.last_event_at is None
+
+    ws._notify(EventStreamStatus.CONNECTED)  # type: ignore[attr-defined]
+    assert ws.status == EventStreamStatus.CONNECTED
+    assert ws.connected is True
+
+    ws._notify(EventStreamStatus.LOST_CONNECTION)  # type: ignore[attr-defined]
+    assert ws.connected is False
+    assert ws.status == EventStreamStatus.LOST_CONNECTION
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_websocket_records_last_event_on_text_frame() -> None:
+    """Each TEXT frame the read loop dispatches updates
+    ``last_event_at`` to UTC now. Driven through the public
+    surface by queueing a frame on the FakeWebSocket."""
+    session = FakeSession(BASE)
+    _stub_responses(session)
+    session.queue_ws(
+        [
+            FakeWSMessage(
+                type=aiohttp.WSMsgType.TEXT,
+                data='<?xml version="1.0"?><Event seqnum="1" sid="x" timestamp="t">'
+                "<control>_0</control><action>90</action><node></node>"
+                "<eventInfo></eventInfo></Event>",
+            ),
+            FakeWSMessage(type=aiohttp.WSMsgType.CLOSED),
+        ]
+    )
+    controller = Controller(BASE, LocalAuth("admin", "p"), session=session)  # type: ignore[arg-type]
+    await controller.connect()
+
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline and (
+        controller.websocket is None or controller.websocket.last_event_at is None
+    ):
+        await asyncio.sleep(0)
+    ws = controller.websocket
+    assert ws is not None
+    assert ws.last_event_at is not None
 
     await controller.stop()
 


### PR DESCRIPTION
## Summary

Closes the gap that left \`Controller.websocket\` private and \`WebSocketEventStream\` without read-only health accessors. HA's system_health page (and any diagnostic surface) can now report live WS stream health, not just the initial-load handshake.

## New surface

### \`WebSocketEventStream\`

- **\`status\`** (\`EventStreamStatus\`) — most-recent state, defaults to \`NOT_STARTED\` before \`start()\`. Recorded in \`_notify\` so consumers reading the property after a transition see the latest value without subscribing.
- **\`connected\`** (\`bool\`) — convenience: \`status == CONNECTED\`. (Note: \`False\` doesn't mean the reader has given up — it may be reconnecting.)
- **\`last_event_at\`** (\`datetime | None\`) — UTC timestamp of the most recent text frame. The eisy emits a heartbeat \`<control>_0</control>\` frame every 30 s, so a stale value (>60 s ago) is a reasonable signal the connection is broken even when the WS handshake hasn't errored.

### \`Controller\`

- **\`websocket\`** (\`WebSocketEventStream | None\`) — the live stream, or \`None\` when \`connect(start_websocket=False)\`.

## Why this is needed

The hacs-udi-iox \`system_health.py\` currently reports only \`host_reachable\` (an HTTP reachability check on the host URL) and \`device_connected\` (\`Controller.connected\`, which only tracks the initial-load handshake — not whether the live WS stream is healthy). With this PR the consumer can add \`event_stream_status\` / \`last_event_at\` rows that surface real WS health.

## Test plan

- [x] \`pytest -q\` — 382 passed
- [x] \`ruff check\` + \`ruff format --check\` — clean
- [x] \`mypy pyisyox\` — clean
- [x] \`websocket\` is None without WS upgrade
- [x] \`status\` mirrors the latest \`_notify\`
- [x] \`connected\` flips correctly on \`CONNECTED\` → \`LOST_CONNECTION\` transitions
- [x] \`last_event_at\` advances when the read loop dispatches a TEXT frame (driven end-to-end through \`controller.connect()\` + queued FakeWebSocket frame)