### PR TITLE
feat(client): carry prec on NodePropertyValue

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -81,6 +81,13 @@ class NodePropertyValue:
     The shape mirrors :class:`pyisyox.schema.nodedef.Property` but is kept
     here as a private data carrier so the client can produce values
     without importing the runtime Node classes.
+
+    ``prec`` is the decimal precision the controller declares for this
+    value (``raw / 10**prec`` is the displayed number). It arrives on
+    every wire shape — ``/api/nodes`` JSON has ``"prec": <int>``,
+    ``/rest/status`` XML uses ``prec="<int>"``, and WS frames put it on
+    the ``<action prec="...">`` element. Defaults to ``0`` (= no
+    scaling) when the controller omits it.
     """
 
     id: str
@@ -88,6 +95,7 @@ class NodePropertyValue:
     formatted: str = ""
     uom: str = ""
     name: str = ""
+    prec: int = 0
 
 
 @dataclass(slots=True)
@@ -581,6 +589,21 @@ class IoXClient:
 # --- parsers --------------------------------------------------------------
 
 
+def _coerce_prec(raw: Any) -> int:
+    """Normalise a wire-side ``prec`` value to ``int``.
+
+    Returns ``0`` when the field is missing, blank, or non-numeric so
+    the dataclass default holds; the controller occasionally omits the
+    attribute entirely on properties without scaling.
+    """
+    if raw is None or raw == "":
+        return 0
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
 def parse_api_nodes(raw: dict[str, Any]) -> dict[str, NodeRecord]:
     """Decode the ``/api/nodes`` JSON payload into a map of address → record.
 
@@ -625,6 +648,7 @@ def _node_from_api_json(item: dict[str, Any]) -> NodeRecord:
             formatted=str(prop.get("formatted", "")),
             uom=str(prop.get("uom", "")),
             name=str(prop.get("name", "")),
+            prec=_coerce_prec(prop.get("prec")),
         )
 
     # ``flag`` arrives stringified from the controller (e.g. ``"128"``
@@ -682,6 +706,7 @@ def parse_rest_status(xml: str) -> dict[str, dict[str, NodePropertyValue]]:
                 formatted=prop.get("formatted", ""),
                 uom=prop.get("uom", ""),
                 name=prop.get("name", ""),
+                prec=_coerce_prec(prop.get("prec")),
             )
         out[addr] = props
     return out

--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -582,6 +582,7 @@ class EventDispatcher:
             formatted=event.formatted_action,
             uom=event.uom,
             name=event.formatted_name,
+            prec=event.prec or 0,
         )
 
     def _apply_program_status(self, event: Event) -> None:

--- a/tests/test_client/test_parsers.py
+++ b/tests/test_client/test_parsers.py
@@ -138,6 +138,87 @@ def test_parse_rest_status_preserves_empty_value_attrs() -> None:
     assert out["X"]["OL"].uom == "0"
 
 
+# --- prec field on NodePropertyValue --------------------------------------
+#
+# ``prec`` is the controller-declared decimal scaling for a property's raw
+# ``value``: the displayed reading is ``raw / 10**prec``. It arrives on every
+# wire shape; consumers (e.g. an HA sensor entity) read it to format numeric
+# state.
+
+
+def test_parse_api_nodes_captures_prec_from_json() -> None:
+    """``/api/nodes`` JSON puts ``prec`` next to ``value`` on each property."""
+    raw = {
+        "data": {
+            "nodes": {
+                "node": [
+                    {
+                        "address": "X",
+                        "property": [
+                            {"id": "GV1", "value": "6839", "uom": "69", "prec": 4},
+                            {"id": "ST", "value": "1", "uom": "2", "prec": 0},
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    nodes = parse_api_nodes(raw)
+    assert nodes["X"].properties["GV1"].prec == 4
+    assert nodes["X"].properties["ST"].prec == 0
+
+
+def test_parse_api_nodes_omitted_prec_defaults_to_zero() -> None:
+    """Properties without scaling (Insteon ``ST``, plugin enums) typically
+    omit ``prec`` entirely — falling through to ``0`` keeps ``raw / 10**0``
+    a no-op."""
+    raw = {
+        "data": {
+            "nodes": {
+                "node": [
+                    {
+                        "address": "X",
+                        "property": [{"id": "ST", "value": "0", "uom": "100"}],
+                    }
+                ]
+            }
+        }
+    }
+    nodes = parse_api_nodes(raw)
+    assert nodes["X"].properties["ST"].prec == 0
+
+
+def test_parse_rest_status_captures_prec_from_xml_attr() -> None:
+    """``/rest/status`` puts ``prec`` on the ``<property>`` XML attr."""
+    xml = (
+        '<nodes><node id="X">'
+        '<property id="GV1" value="6839" formatted="0.6839" uom="69" prec="4"/>'
+        '<property id="ST" value="1" formatted="On" uom="100"/>'
+        "</node></nodes>"
+    )
+    out = parse_rest_status(xml)
+    assert out["X"]["GV1"].prec == 4
+    # ST entry has no prec attribute — default applies.
+    assert out["X"]["ST"].prec == 0
+
+
+def test_parse_status_handles_non_numeric_prec_defensively() -> None:
+    """A blank or junk ``prec`` shouldn't poison the parse — coerce to 0."""
+    xml = (
+        '<nodes><node id="X">'
+        '<property id="GV1" value="" formatted="" uom="" prec=""/>'
+        "</node></nodes>"
+    )
+    assert parse_rest_status(xml)["X"]["GV1"].prec == 0
+
+
+def test_node_property_value_default_prec_is_zero() -> None:
+    """Construction without ``prec`` defaults to 0 — preserves backwards-
+    compatible NodePropertyValue construction at the API level."""
+    npv = NodePropertyValue(id="ST", value="0")
+    assert npv.prec == 0
+
+
 # --- merge ---------------------------------------------------------------
 
 

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -271,6 +271,39 @@ def test_dispatcher_overlays_property_into_node_record() -> None:
     assert prop.uom == "100"
 
 
+def test_dispatcher_propagates_prec_into_node_record() -> None:
+    """``<action prec="...">`` flows through to ``NodePropertyValue.prec``
+    so the consumer can scale ``raw / 10**prec`` without a second wire trip."""
+    nodes = {"X": _make_record("X")}
+    dispatcher = EventDispatcher(nodes)
+    xml = (
+        '<Event seqnum="1"><control>GV1</control>'
+        '<action uom="69" prec="4">6839</action>'
+        "<node>X</node>"
+        "<fmtAct>0.6839 US gallons</fmtAct><fmtName>Volume</fmtName></Event>"
+    )
+
+    dispatcher.feed(xml)
+
+    prop = nodes["X"].properties["GV1"]
+    assert prop.prec == 4
+    assert prop.value == "6839"
+
+
+def test_dispatcher_falls_back_to_zero_prec_when_action_omits_it() -> None:
+    """An ``<action>`` without ``prec`` (Insteon ``ST``, etc.) defaults to
+    ``prec=0`` rather than leaving the field unset — the consumer always
+    has a numeric scaler."""
+    nodes = {"X": _make_record("X")}
+    dispatcher = EventDispatcher(nodes)
+    xml = (
+        '<Event seqnum="1"><control>ST</control><action uom="100">255</action>'
+        "<node>X</node><fmtAct>On</fmtAct></Event>"
+    )
+    dispatcher.feed(xml)
+    assert nodes["X"].properties["ST"].prec == 0
+
+
 def test_dispatcher_replaces_existing_property() -> None:
     """An event for an already-tracked property replaces (not merges) it."""
     nodes = {


### PR DESCRIPTION
## Summary

- Add a ``prec: int = 0`` field to ``NodePropertyValue`` so consumers can scale ``raw / 10**prec`` without a second wire trip.
- Plumb the value through all three ingest paths: ``/api/nodes`` JSON, ``/rest/status`` XML attr, and the WS event dispatcher (``Event.prec`` → property).
- Add a small ``_coerce_prec`` helper so missing / blank / non-numeric values fall through to ``0`` (matches what the controller emits for properties without scaling, e.g. Insteon ``ST`` or plugin enums).

## Why

The HA ``udi_iox`` integration was carrying ``status.prec`` / ``target.precision`` reads against this shape under the assumption it had been migrated from pyisy 3.x's ``NodeProperty.prec``. Without it, ``climate.current_temperature`` and ``sensor.native_value`` crash at state computation. The schema layer (``pyisyox.schema.nodedef.Property``, ``pyisyox.schema.editor.Range``) already understood ``prec``; this just brings the live wire-state shape into line.

## Test plan

- [x] ``pytest`` — 389 passed (7 new tests covering all three ingest paths + default + non-numeric fallback)
- [x] ``ruff check pyisyox tests`` — clean
- [x] ``mypy pyisyox`` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)