### PR TITLE
feat(runtime): add Group.group_any_on aggregate

### DIFF
--- a/pyisyox/runtime/group.py
+++ b/pyisyox/runtime/group.py
@@ -166,6 +166,37 @@ class Group:
                 return False
         return True
 
+    @property
+    def group_any_on(self) -> bool:
+        """True iff at least one member node currently reports an "on" state.
+
+        Companion to :attr:`group_all_on`; this is the aggregation HA
+        scene-switch consumers want for their ``is_on`` — the legacy
+        ``pyisy.Group.status`` did the same thing (non-zero on any
+        responder).
+
+        Returns ``False`` when:
+
+        * the group was constructed without a node-registry reference;
+        * the group has no members;
+        * every present member's ``ST`` property is missing or zero
+          (missing members are skipped, not treated as 'off' — see
+          :attr:`group_all_on` for the strict variant).
+
+        Cheap: ``O(N)`` where N is the member count, only computed
+        when read.
+        """
+        if self._nodes is None or not self._record.member_addresses:
+            return False
+        for addr in self._record.member_addresses:
+            record = self._nodes.get(addr)
+            if record is None:
+                continue
+            st = record.properties.get(PROP_STATUS)
+            if st is not None and str(st.value) not in ("", "0"):
+                return True
+        return False
+
     # --- commanding ---------------------------------------------------
 
     async def send_command(self, command_id: str, *params: int) -> None:

--- a/tests/test_runtime/test_groups.py
+++ b/tests/test_runtime/test_groups.py
@@ -419,6 +419,112 @@ def test_group_all_on_false_when_no_members() -> None:
     assert group.group_all_on is False
 
 
+# group_any_on test scaffolding -----------------------------------------
+#
+# Mirrors the group_all_on cases above but with the inverted aggregation:
+# "at least one member on" is what HA's scene-switch ``is_on`` wants, and
+# what the legacy ``pyisy.Group.status`` returned.
+
+
+def test_group_any_on_true_when_at_least_one_member_is_on() -> None:
+    """Mixed on/off members — any-on aggregation is True."""
+    nodes: dict[str, NodeRecord] = {
+        "M1": _record_with_st("M1", "255"),
+        "M2": _record_with_st("M2", "0"),
+    }
+    record = GroupRecord(
+        address="G",
+        name="Mixed",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+        member_addresses=("M1", "M2"),
+    )
+    group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.group_any_on is True
+
+
+def test_group_any_on_false_when_every_member_is_off() -> None:
+    nodes: dict[str, NodeRecord] = {
+        "M1": _record_with_st("M1", "0"),
+        "M2": _record_with_st("M2", "0"),
+    }
+    record = GroupRecord(
+        address="G",
+        name="All Off",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+        member_addresses=("M1", "M2"),
+    )
+    group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.group_any_on is False
+
+
+def test_group_any_on_skips_missing_members_instead_of_short_circuiting() -> None:
+    """Unlike ``group_all_on``, a member dropped from the registry doesn't
+    flip the aggregation to False — present-and-on members still count."""
+    nodes: dict[str, NodeRecord] = {"M1": _record_with_st("M1", "255")}
+    record = GroupRecord(
+        address="G",
+        name="Stale",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+        member_addresses=("M1", "M2_MISSING"),
+    )
+    group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.group_any_on is True
+
+
+def test_group_any_on_false_when_member_has_no_st() -> None:
+    no_st = NodeRecord(
+        address="M1",
+        name="M1",
+        nodedef_id="X",
+        family_id="1",
+        instance_id="1",
+        properties={"BATLVL": NodePropertyValue(id="BATLVL", value="80", formatted="80%")},
+    )
+    nodes: dict[str, NodeRecord] = {"M1": no_st}
+    record = GroupRecord(
+        address="G",
+        name="No ST",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+        member_addresses=("M1",),
+    )
+    group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.group_any_on is False
+
+
+def test_group_any_on_false_when_constructed_without_nodes_ref() -> None:
+    record = GroupRecord(
+        address="G",
+        name="No Nodes",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+        member_addresses=("M1",),
+    )
+    group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)))
+    assert group.group_any_on is False
+
+
+def test_group_any_on_false_when_no_members() -> None:
+    record = GroupRecord(
+        address="EMPTY",
+        name="No Members",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+        member_addresses=(),
+    )
+    group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)), nodes={})
+    assert group.group_any_on is False
+
+
 @pytest.mark.asyncio
 async def test_group_rename_posts_name_and_type_group() -> None:
     """``Group.rename`` posts ``{"name", "nodeType": "group"}`` to


### PR DESCRIPTION
## Summary

- Add ``Group.group_any_on``: True iff at least one member node's ``ST`` is currently non-zero.
- Sibling to the existing ``group_all_on`` — same shape, opposite aggregation.
- Skips members missing from the registry (vs. ``group_all_on`` which treats a missing member as 'off' → False); rationale documented in the docstring.

## Why

The HA ``udi_iox`` scene-switch entity was routing ``Group`` through ``node_status_int`` which assumes a ``NodePropertyValue`` — but ``Group`` deliberately exposes no ``status`` since groups don't carry live wire-level state. Without this aggregate the consumer would have to walk ``member_addresses`` against the controller's nodes registry itself, duplicating logic that belongs on the wrapper. ``group_all_on`` already does the strict variant; ``group_any_on`` covers the ergonomic "is the scene on" case (which is what ``pyisy.Group.status`` returned in v3).

## Test plan

- [x] ``pytest`` — 395 passed (6 new tests: all-off / mixed / no-st / no nodes-ref / no members / missing-member-skip)
- [x] ``ruff check pyisyox tests`` — clean
- [x] ``mypy pyisyox`` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)