### PR TITLE
feat(runtime): dispatcher updates VariableRecord on _1/6 + _1/7 frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ example/
 
 ruff_cache/
 .claude/
+.venv/

--- a/pyisyox/controller.py
+++ b/pyisyox/controller.py
@@ -171,7 +171,11 @@ class Controller:
         # Bind the dispatcher to the same dict the LoadResult holds —
         # so runtime Nodes (which read from LoadResult.nodes) see live
         # updates without an explicit notification path.
-        self._dispatcher = EventDispatcher(self._loaded.nodes, programs=self._loaded.programs)
+        self._dispatcher = EventDispatcher(
+            self._loaded.nodes,
+            programs=self._loaded.programs,
+            variables=self._loaded.variables,
+        )
 
         if start_websocket:
             self._ws = WebSocketEventStream(self._client, self._dispatcher, path=self._ws_path)

--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -39,7 +39,7 @@ from xml.etree import ElementTree as ET
 from pyisyox.client import NodePropertyValue
 
 if TYPE_CHECKING:
-    from pyisyox.client import NodeRecord, ProgramRecord
+    from pyisyox.client import NodeRecord, ProgramRecord, VariableRecord
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,6 +55,8 @@ _NODE_LIFECYCLE_CONTROL = "_3"
 #: interested).
 _PROGRAM_OR_VAR_CONTROL = "_1"
 _PROGRAM_STATUS_ACTION = "0"
+_VARIABLE_VALUE_ACTION = "6"
+_VARIABLE_INIT_ACTION = "7"
 
 
 class NodeLifecycleAction(StrEnum):
@@ -421,14 +423,16 @@ class EventDispatcher:
         "_nodes",
         "_program_status_listeners",
         "_programs",
+        "_variables",
     )
 
     def __init__(
         self,
         nodes: dict[str, NodeRecord],
         programs: dict[str, ProgramRecord] | None = None,
+        variables: dict[str, dict[str, VariableRecord]] | None = None,
     ) -> None:
-        """Bind to a node + program registry.
+        """Bind to a node + program + variable registry.
 
         Args:
             nodes: The same ``dict[str, NodeRecord]`` that
@@ -443,9 +447,19 @@ class EventDispatcher:
                 in place on program-status frames. ``None`` (the
                 default for tests that only care about node events)
                 makes program-status dispatch a no-op.
+            variables: Optional variable registry, shape
+                ``{type_id: {var_id: VariableRecord}}``. When provided,
+                the dispatcher mutates ``record.value`` (action ``"6"``
+                frames) or ``record.init`` (action ``"7"`` frames) in
+                place; symmetric with the node-property and
+                program-status handling. ``None`` (the default) makes
+                variable-change dispatch a no-op — consumers that need
+                variable updates without registering a registry can
+                still parse :attr:`Event.event_info` themselves.
         """
         self._nodes = nodes
         self._programs = programs if programs is not None else {}
+        self._variables = variables if variables is not None else {}
         self._listeners: list[EventListener] = []
         self._lifecycle_listeners: list[NodeLifecycleListener] = []
         self._program_status_listeners: list[ProgramStatusListener] = []
@@ -535,8 +549,11 @@ class EventDispatcher:
         # reload UX than re-parsing the raw frame.
         if event.control == _NODE_LIFECYCLE_CONTROL:
             self._emit_lifecycle(event, raw_frame)
-        elif event.control == _PROGRAM_OR_VAR_CONTROL and event.action == _PROGRAM_STATUS_ACTION:
-            self._apply_program_status(event)
+        elif event.control == _PROGRAM_OR_VAR_CONTROL:
+            if event.action == _PROGRAM_STATUS_ACTION:
+                self._apply_program_status(event)
+            elif event.action in (_VARIABLE_VALUE_ACTION, _VARIABLE_INIT_ACTION):
+                self._apply_variable_change(event)
         for listener in tuple(self._listeners):
             try:
                 listener(event)
@@ -584,6 +601,78 @@ class EventDispatcher:
             name=event.formatted_name,
             prec=event.prec or 0,
         )
+
+    def _apply_variable_change(self, event: Event) -> None:
+        """Decode a variable-change frame and update the matching record.
+
+        Wire shape (same control as program-status, different action)::
+
+            <control>_1</control><action>6|7</action>
+            <eventInfo><var type="N" id="M"><val>123</val><ts>...</ts>...</var></eventInfo>
+
+        Action ``"6"`` is a current-value change; ``"7"`` is an init
+        (restore-on-startup) change. ``type`` is ``"1"`` (integer) or
+        ``"2"`` (state); the ``VariableRecord`` registry is keyed
+        ``{type_id: {id: record}}`` matching what
+        :func:`pyisyox.client.parse_api_variables_type` produces.
+
+        Unknown (type, id) pairs are dropped silently — typically a
+        variable created after the initial load. Consumers that care
+        can trigger a reload via :meth:`Controller.refresh`.
+        """
+        if not event.event_info:
+            return
+        try:
+            info = ET.fromstring(  # noqa: S314 — eisy LAN traffic
+                f"<eventInfo>{event.event_info}</eventInfo>"
+            )
+        except ET.ParseError:
+            return
+
+        var_elem = info.find("var")
+        if var_elem is None:
+            return
+
+        type_id = (var_elem.get("type") or "").strip()
+        var_id = (var_elem.get("id") or "").strip()
+        if not type_id or not var_id:
+            return
+
+        type_bucket = self._variables.get(type_id)
+        if type_bucket is None:
+            _LOGGER.debug("WS variable-change event for unknown type %r — dropping", type_id)
+            return
+        record = type_bucket.get(var_id)
+        if record is None:
+            _LOGGER.debug(
+                "WS variable-change event for unknown id %r/%r — dropping",
+                type_id,
+                var_id,
+            )
+            return
+
+        val_text = (var_elem.findtext("val") or "").strip()
+        if not val_text:
+            return
+        try:
+            new_value = int(val_text)
+        except ValueError:
+            _LOGGER.debug(
+                "WS variable-change event for %s.%s carried non-numeric value %r",
+                type_id,
+                var_id,
+                val_text,
+            )
+            return
+
+        if event.action == _VARIABLE_VALUE_ACTION:
+            record.value = new_value
+        else:  # _VARIABLE_INIT_ACTION
+            record.init = new_value
+
+        ts_text = (var_elem.findtext("ts") or "").strip()
+        if ts_text:
+            record.ts = ts_text
 
     def _apply_program_status(self, event: Event) -> None:
         """Decode a program-status frame and update the matching record.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -899,9 +899,7 @@ _PROGRAM_VERBS = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(("method_name", "wire_verb"), _PROGRAM_VERBS)
-async def test_program_command_wrappers_hit_legacy_endpoint(
-    method_name: str, wire_verb: str
-) -> None:
+async def test_program_command_wrappers_hit_legacy_endpoint(method_name: str, wire_verb: str) -> None:
     """Every command method on ``Program`` issues
     ``GET /rest/programs/{id}/{wire_verb}``."""
     session = FakeSession(BASE)
@@ -936,9 +934,7 @@ async def test_program_command_wrappers_hit_legacy_endpoint(
     ("method_name", "wire_verb"),
     [("run", "run"), ("stop", "stop"), ("enable", "enable"), ("disable", "disable")],
 )
-async def test_program_folder_command_wrappers_hit_legacy_endpoint(
-    method_name: str, wire_verb: str
-) -> None:
+async def test_program_folder_command_wrappers_hit_legacy_endpoint(method_name: str, wire_verb: str) -> None:
     """``ProgramFolder`` only carries the four shared verbs; each
     routes to ``GET /rest/programs/{folder_id}/{wire_verb}``."""
     session = FakeSession(BASE)

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from pyisyox.client import NodePropertyValue, NodeRecord
+from pyisyox.client import NodePropertyValue, NodeRecord, VariableRecord
 from pyisyox.runtime.events import (
     Event,
     EventDispatcher,
@@ -391,3 +391,127 @@ def test_dispatcher_feed_returns_none_on_garbage() -> None:
     assert dispatcher.feed("") is None
     assert dispatcher.feed("not xml") is None
     assert dispatcher.feed('{"type":"spolisy","data":{}}') is None
+
+
+# --- dispatcher: variable change -----------------------------------------
+#
+# Variable events ride on ``<control>_1</control>`` (same as program-status)
+# but with action ``"6"`` (current value change) or ``"7"`` (init change).
+# The wire payload is ``<eventInfo><var type="N" id="M"><val>...</val></var></eventInfo>``.
+# The dispatcher updates the matching ``VariableRecord`` in place, mirroring
+# how it already handles node properties and program status.
+
+
+def _make_variable_record(
+    *, type_id: str = "1", id_: str = "5", value: int = 0, init: int = 0
+) -> VariableRecord:
+    return VariableRecord(type_id=type_id, id=id_, name=f"Var_{type_id}_{id_}", value=value, init=init)
+
+
+def test_dispatcher_applies_variable_value_change_to_record() -> None:
+    """Action ``"6"`` updates ``record.value`` in place."""
+    record = _make_variable_record(type_id="1", id_="5", value=0)
+    variables = {"1": {"5": record}, "2": {}}
+    dispatcher = EventDispatcher({}, variables=variables)
+
+    frame = (
+        '<Event seqnum="1"><control>_1</control><action>6</action>'
+        "<node></node>"
+        '<eventInfo><var type="1" id="5"><val>42</val><ts>20260510 21:00:00</ts></var></eventInfo>'
+        "</Event>"
+    )
+    event = dispatcher.feed(frame)
+
+    assert event is not None
+    assert record.value == 42
+    assert record.init == 0  # untouched on action 6
+    assert record.ts == "20260510 21:00:00"
+
+
+def test_dispatcher_applies_variable_init_change_to_record() -> None:
+    """Action ``"7"`` updates ``record.init`` in place; value is untouched."""
+    record = _make_variable_record(type_id="2", id_="8", value=5, init=0)
+    variables = {"1": {}, "2": {"8": record}}
+    dispatcher = EventDispatcher({}, variables=variables)
+
+    frame = (
+        '<Event seqnum="1"><control>_1</control><action>7</action>'
+        "<node></node>"
+        '<eventInfo><var type="2" id="8"><val>100</val></var></eventInfo>'
+        "</Event>"
+    )
+    dispatcher.feed(frame)
+
+    assert record.init == 100
+    assert record.value == 5  # untouched on action 7
+
+
+def test_dispatcher_drops_variable_event_for_unknown_type() -> None:
+    """A variable change for a type the registry doesn't track is dropped
+    silently — no exception, no autovivified bucket."""
+    record = _make_variable_record(type_id="1", id_="5", value=0)
+    variables = {"1": {"5": record}}
+    dispatcher = EventDispatcher({}, variables=variables)
+
+    # Type "3" doesn't exist on IoX; the dispatcher should ignore it.
+    frame = (
+        '<Event seqnum="1"><control>_1</control><action>6</action>'
+        "<node></node>"
+        '<eventInfo><var type="3" id="5"><val>42</val></var></eventInfo>'
+        "</Event>"
+    )
+    dispatcher.feed(frame)
+    assert record.value == 0
+
+
+def test_dispatcher_drops_variable_event_for_unknown_id() -> None:
+    """A variable change for an id missing from its type bucket is dropped."""
+    record = _make_variable_record(type_id="1", id_="5", value=0)
+    variables = {"1": {"5": record}, "2": {}}
+    dispatcher = EventDispatcher({}, variables=variables)
+
+    frame = (
+        '<Event seqnum="1"><control>_1</control><action>6</action>'
+        "<node></node>"
+        '<eventInfo><var type="1" id="99"><val>42</val></var></eventInfo>'
+        "</Event>"
+    )
+    dispatcher.feed(frame)
+    assert record.value == 0
+
+
+def test_dispatcher_drops_variable_event_with_non_numeric_val() -> None:
+    """The wire is supposed to carry an int; a junk value is ignored rather
+    than coerced to 0 (which would silently clobber state)."""
+    record = _make_variable_record(type_id="1", id_="5", value=99)
+    variables = {"1": {"5": record}}
+    dispatcher = EventDispatcher({}, variables=variables)
+
+    frame = (
+        '<Event seqnum="1"><control>_1</control><action>6</action>'
+        "<node></node>"
+        '<eventInfo><var type="1" id="5"><val>not-a-number</val></var></eventInfo>'
+        "</Event>"
+    )
+    dispatcher.feed(frame)
+    assert record.value == 99  # unchanged
+
+
+def test_dispatcher_variable_change_no_registry_is_no_op() -> None:
+    """When constructed without a variables registry (the test-friendly
+    default), variable-change frames flow through to the generic listener
+    channel but don't mutate any shared state — symmetric with the
+    program-status no-op when ``programs=None``."""
+    dispatcher = EventDispatcher({})  # no variables
+    received: list[Event] = []
+    dispatcher.add_listener(received.append)
+
+    frame = (
+        '<Event seqnum="1"><control>_1</control><action>6</action>'
+        "<node></node>"
+        '<eventInfo><var type="1" id="5"><val>42</val></var></eventInfo>'
+        "</Event>"
+    )
+    event = dispatcher.feed(frame)
+    assert event is not None
+    assert len(received) == 1


### PR DESCRIPTION
## Summary

Symmetric extension of the node-property + program-status update path that already lives on ``EventDispatcher``: a ``<control>_1</control>`` frame with action ``"6"`` (value change) or ``"7"`` (init change) carries ``<eventInfo><var type="N" id="M"><val>N</val></var></eventInfo>`` that the dispatcher now decodes and writes onto the matching ``VariableRecord`` in place.

- ``EventDispatcher.__init__`` accepts a new ``variables`` registry (``{type_id: {id: VariableRecord}}`` — same shape as ``LoadResult.variables`` produces); defaults to ``{}`` so existing test callers that don't care about variable events keep working.
- ``feed()`` routes ``_1`` frames by action: ``"0"`` → existing program-status path; ``"6"`` / ``"7"`` → new ``_apply_variable_change`` path.
- ``_apply_variable_change`` parses the ``<var>`` element, validates the ``(type_id, id)`` pair against the registry (unknown values drop silently — variables added post-load), coerces ``<val>`` to int (non-numeric drops silently rather than clobbering the cached value), and overlays ``record.value`` or ``record.init``. ``<ts>`` rides along when present.
- ``Controller.connect`` wires ``self._loaded.variables`` into the dispatcher alongside ``nodes`` / ``programs``.

## Why

Consumer payoff: the HA ``udi_iox`` ``number`` platform currently reaches into ``Variable._record`` in its WS echo handler to mirror the wire change locally (with a ``# pylint: disable=protected-access``). With this PR the dispatcher does it transparently — consumers just register a normal listener and read ``variable.value`` / ``variable.init`` off the wrapper.

## Test plan

- [x] ``pytest`` — 436 passed (6 new: value change, init change, unknown-type drop, unknown-id drop, non-numeric value drop, no-registry no-op)
- [x] ``ruff check pyisyox tests`` — clean
- [x] ``ruff format --check pyisyox tests`` — clean
- [x] ``mypy pyisyox`` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)