### PR TITLE
chore: pin pytest-asyncio default fixture loop scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ pythonpath = ["."]
 log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(name)s:%(filename)s:%(lineno)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 required-version = ">=0.15.12"


### PR DESCRIPTION
## Summary
- Sets `asyncio_default_fixture_loop_scope = "function"` in `pyproject.toml`
- Silences the `PytestDeprecationWarning` emitted on every test run and pins current behavior ahead of pytest-asyncio's planned default change

## Test plan
- [x] `pytest -q` → 487 passed, no deprecation warning