### PR TITLE
fix(runtime): Node.primary_address derives from <pnode> not <parent>

### DIFF
--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -153,19 +153,42 @@ class Node:
 
     @property
     def parent_address(self) -> str | None:
-        """Address of the parent node (for KeypadLinc buttons, the primary
-        load; for plugin sub-nodes, the controller). ``None`` for primaries."""
+        """Address of the tree-hierarchy parent (folder containing this node).
+
+        Sourced from the IoX ``<parent>`` element. ``None`` for nodes at the
+        root of the node tree. Matches the ``parent_address`` semantic on
+        :class:`pyisyox.Folder`, :class:`pyisyox.Group`, and
+        :class:`pyisyox.Program` — i.e., "what folder is this in?"
+
+        Note: this is NOT the device primary for multi-button physical
+        devices (KeypadLinc, RemoteLinc, FanLinc). For that, use
+        :attr:`primary_address` — which derives from the IoX ``<pnode>``
+        element. The two concepts are independent: a sub-button can be
+        under a folder while also being a sub-node of a device primary.
+        """
         return self._record.parent_address
 
     @property
-    def primary_node(self) -> str | None:
-        """Alias for :attr:`parent_address`.
+    def primary_address(self) -> str | None:
+        """Address of the device primary for sub-button nodes.
 
-        The IoX REST surface and the legacy PyISY 3.x consumer API both
-        used the term "primary node" for the address of the device's
-        root node. Kept here so consumers don't have to translate.
+        Sourced from the IoX ``<pnode>`` element. For multi-button physical
+        devices (KeypadLinc, RemoteLinc, FanLinc) the sub-button nodes carry
+        the primary load node's address in ``<pnode>``; primaries carry
+        their own address. We return ``None`` for primaries so the consumer
+        can treat ``primary_address is not None`` as a "this is a sub-node"
+        indicator and ``primary_address or address`` as "the canonical
+        device-grouping address."
+
+        PyISY 3.x exposed the same concept as ``Node.primary_node`` (which
+        returned a string). The ``_address`` suffix here matches the
+        convention used elsewhere in the package (``parent_address``,
+        ``member_addresses``, ``controller_addresses``).
         """
-        return self._record.parent_address
+        pnode = self._record.pnode
+        if pnode is None or pnode == self._record.address:
+            return None
+        return pnode
 
     @property
     def enabled(self) -> bool:

--- a/tests/test_runtime/test_node_introspection.py
+++ b/tests/test_runtime/test_node_introspection.py
@@ -41,6 +41,7 @@ def _make_record(
     properties: dict[str, NodePropertyValue] | None = None,
     type_: str = "1.0.0.0",
     parent_address: str | None = None,
+    pnode: str | None = None,
 ) -> NodeRecord:
     return NodeRecord(
         address=address,
@@ -51,6 +52,7 @@ def _make_record(
         type=type_,
         properties=properties or {},
         parent_address=parent_address,
+        pnode=pnode,
     )
 
 
@@ -173,7 +175,7 @@ def test_introspection_safe_when_nodedef_unresolved(real_profile: Profile) -> No
     assert node.is_dimmable is False
 
 
-# --- shortcuts: status + primary_node ------------------------------------
+# --- shortcuts: status + primary_address + parent_address ----------------
 
 
 def test_status_returns_st_property_when_present(real_profile: Profile) -> None:
@@ -190,18 +192,57 @@ def test_status_none_when_st_absent(real_profile: Profile) -> None:
     assert node.status is None
 
 
-def test_primary_node_aliases_parent_address(real_profile: Profile) -> None:
-    """``primary_node`` is the IoX-spelling alias for ``parent_address``;
-    consumers migrating from PyISY 3.x can keep the old name."""
-    node = _make_node(_make_record(parent_address="AA BB CC 1"), real_profile)
-    assert node.primary_node == "AA BB CC 1"
-    assert node.primary_node == node.parent_address
+def test_primary_address_resolves_from_pnode(real_profile: Profile) -> None:
+    """``primary_address`` derives from the IoX ``<pnode>`` element — the
+    device-primary address for multi-button physicals (KeypadLinc,
+    RemoteLinc, FanLinc). Returns the primary only when this node is a
+    sub-button (``pnode != address``)."""
+    sub_button = _make_node(
+        _make_record(address="AA BB CC 2", pnode="AA BB CC 1"), real_profile
+    )
+    assert sub_button.primary_address == "AA BB CC 1"
 
 
-def test_primary_node_none_for_root_node(real_profile: Profile) -> None:
-    """A device-root node has no parent address — primary_node is None."""
-    node = _make_node(_make_record(parent_address=None), real_profile)
-    assert node.primary_node is None
+def test_primary_address_none_for_device_root(real_profile: Profile) -> None:
+    """The device primary has ``pnode == address`` — surface as ``None`` so
+    consumers can use ``primary_address is not None`` as a sub-button
+    indicator. ``pnode`` absent is treated the same way."""
+    root_with_self_pnode = _make_node(
+        _make_record(address="AA BB CC 1", pnode="AA BB CC 1"), real_profile
+    )
+    assert root_with_self_pnode.primary_address is None
+
+    root_without_pnode = _make_node(_make_record(pnode=None), real_profile)
+    assert root_without_pnode.primary_address is None
+
+
+def test_parent_address_returns_tree_parent(real_profile: Profile) -> None:
+    """``parent_address`` exposes the IoX ``<parent>`` element — the
+    tree-hierarchy parent (folder/scene), independent of the device
+    primary. The two concepts are orthogonal: a sub-button can be inside
+    a folder while also being a sub-node of a device primary."""
+    sub_button_in_folder = _make_node(
+        _make_record(
+            address="AA BB CC 2",
+            parent_address="folder-id",  # tree parent
+            pnode="AA BB CC 1",  # device primary (different concept)
+        ),
+        real_profile,
+    )
+    assert sub_button_in_folder.parent_address == "folder-id"
+    assert sub_button_in_folder.primary_address == "AA BB CC 1"
+
+    # Tree-root node, no folder parent, also a device primary
+    node = _make_node(
+        _make_record(
+            address="AA BB CC 1",
+            parent_address=None,
+            pnode="AA BB CC 1",
+        ),
+        real_profile,
+    )
+    assert node.parent_address is None
+    assert node.primary_address is None
 
 
 # --- flag / has_flag -----------------------------------------------------


### PR DESCRIPTION
## Summary

- Restore the PyISY 3.x semantic split between **tree-hierarchy parent** (`<parent>`) and **device primary** (`<pnode>`) that the 6.x rewrite collapsed.
- `Node.parent_address` now returns `<parent>` (matches `Folder` / `Program` / `Group`).
- New `Node.primary_address` reads `<pnode>`; returns `None` when the node *is* the primary (`pnode == address`).

## Why

On real eisy hardware, every button-pair node of a RemoteLinc appeared as its own root device in HA instead of grouping under one device. The classifier had no way to detect "sub-button of physical device X" because `parent_address` was wired to `<parent>` (the folder/tree parent, typically empty for top-level devices) rather than `<pnode>` (the device primary's address).

PyISY 3.x kept these as two distinct concepts: `nparent` / `nparents[]` for tree-walk and `_primary_node` for device grouping. The 6.x rewrite parsed both `<parent>` and `<pnode>` into `NodeRecord` but only surfaced one through the runtime wrapper — and picked the wrong one.

## What changed

- `Node.parent_address` reverts to returning `self._record.parent_address` (the tree parent).
- `Node.primary_address` is the new accessor for the device primary. Returns `None` when `pnode is None` or `pnode == address`, so:
  - `primary_address is not None` → "this node is a sub-button of another node"
  - `primary_address or address` → "canonical device-grouping address"
- `NodeRecord` is unchanged — it already carried both `parent_address` (from `<parent>`) and `pnode` (from `<pnode>`).

Naming follows the codebase's `_address` suffix convention (matching `parent_address`, `member_addresses`, `controller_addresses`). PyISY 3.x's `Node.primary_node` returned a `str` despite the `_node` suffix — opted not to perpetuate that.

## Test plan

- [x] `pytest tests/` — 488 passed (3 rewritten / renamed tests for the new semantics).
- [ ] Consumer integration test against a multi-button Insteon device (RemoteLinc / KeypadLinc / FanLinc) — pending consumer-side PR.

## Downstream

Consumer (`hacs-udi-iox`) PR is queued behind this; it pins `pyisyox==6.0.0a2` once tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)