### PR TITLE
chore(api): rename `prec` → `precision` on the Python attribute surface

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -82,11 +82,13 @@ class NodePropertyValue:
     here as a private data carrier so the client can produce values
     without importing the runtime Node classes.
 
-    ``prec`` is the decimal precision the controller declares for this
-    value (``raw / 10**prec`` is the displayed number). It arrives on
-    every wire shape — ``/api/nodes`` JSON has ``"prec": <int>``,
-    ``/rest/status`` XML uses ``prec="<int>"``, and WS frames put it on
-    the ``<action prec="...">`` element. Defaults to ``0`` (= no
+    ``precision`` is the decimal precision the controller declares for
+    this value (``raw / 10**precision`` is the displayed number). The
+    wire keyed it as ``"prec"`` across all three ingest paths —
+    ``/api/nodes`` JSON has ``"prec": <int>``, ``/rest/status`` XML uses
+    ``prec="<int>"``, and WS frames put it on the ``<action prec="...">``
+    element — but the Python attribute spells it out for readability
+    (matches PyISY 3.x's ``precision`` naming). Defaults to ``0`` (= no
     scaling) when the controller omits it.
     """
 
@@ -95,7 +97,7 @@ class NodePropertyValue:
     formatted: str = ""
     uom: str = ""
     name: str = ""
-    prec: int = 0
+    precision: int = 0
 
 
 @dataclass(slots=True)
@@ -243,7 +245,9 @@ class VariableRecord:
         name: User-assigned label.
         value: Current value (wire field ``val``).
         init: Restore-on-startup value.
-        prec: Decimal precision (``displayed = raw / 10**prec``).
+        precision: Decimal precision (``displayed = raw / 10**precision``).
+            The wire keyed it as ``"prec"`` — Python attribute spells
+            it out (matches PyISY 3.x).
         ts: Last-change timestamp as the controller emits it (ISO 8601
             UTC). Empty string when the controller omits it.
     """
@@ -253,7 +257,7 @@ class VariableRecord:
     name: str
     value: int = 0
     init: int = 0
-    prec: int = 0
+    precision: int = 0
     ts: str = ""
 
     @property
@@ -686,7 +690,7 @@ def _node_from_api_json(item: dict[str, Any]) -> NodeRecord:
             formatted=str(prop.get("formatted", "")),
             uom=str(prop.get("uom", "")),
             name=str(prop.get("name", "")),
-            prec=_coerce_prec(prop.get("prec")),
+            precision=_coerce_prec(prop.get("prec")),
         )
 
     # ``flag`` arrives stringified from the controller (e.g. ``"128"``
@@ -744,7 +748,7 @@ def parse_rest_status(xml: str) -> dict[str, dict[str, NodePropertyValue]]:
                 formatted=prop.get("formatted", ""),
                 uom=prop.get("uom", ""),
                 name=prop.get("name", ""),
-                prec=_coerce_prec(prop.get("prec")),
+                precision=_coerce_prec(prop.get("prec")),
             )
         out[addr] = props
     return out
@@ -910,7 +914,7 @@ def parse_api_variables_type(raw: list[dict[str, Any]], type_id: str) -> dict[st
             name=str(entry.get("name", "")),
             value=_coerce_int(entry.get("val"), default=0),
             init=_coerce_int(entry.get("init"), default=0),
-            prec=_coerce_prec(entry.get("prec")),
+            precision=_coerce_prec(entry.get("prec")),
             ts=str(entry.get("ts", "")),
         )
     return out

--- a/pyisyox/helpers/__init__.py
+++ b/pyisyox/helpers/__init__.py
@@ -50,7 +50,7 @@ def convert_isy_raw_value(
 
     ISY provides float values as an integer and precision component.
     Correct by shifting the decimal place left by the value of precision.
-    (e.g. value=2345, prec="2" == 23.45)
+    (e.g. value=2345, precision=2 → 23.45; wire keys it as "prec")
 
     Insteon Thermostats report temperature in 0.5-deg precision as an int
     by sending a value of 2 times the Temp. Correct by dividing by 2 here.

--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -177,8 +177,9 @@ class Event:
         formatted_name: Display name of the property (e.g.
             ``"Current"``). Empty when not provided.
         uom: Unit-of-measure id from ``<action uom="...">``.
-        prec: Decimal precision from ``<action prec="...">``, or
-            ``None`` if absent.
+        precision: Decimal precision from ``<action prec="...">``, or
+            ``None`` if absent. (Wire keys it as ``"prec"``; Python
+            attribute spells it out.)
         event_info: Inner ``<eventInfo>`` XML preserved verbatim.
             Empty string when the frame had no ``<eventInfo>`` element
             or when its content was empty. Consumers that need the
@@ -196,7 +197,7 @@ class Event:
     formatted_action: str = ""
     formatted_name: str = ""
     uom: str = ""
-    prec: int | None = None
+    precision: int | None = None
     event_info: str = ""
 
     @property
@@ -240,7 +241,7 @@ def parse_event_frame(raw: str) -> Event | None:
         return None
 
     action_el = root.find("action")
-    uom, prec = _decode_action_attrs(action_el)
+    uom, precision = _decode_action_attrs(action_el)
     return Event(
         seqnum=_int_or(root.get("seqnum", "0"), default=0),
         timestamp=root.get("timestamp", ""),
@@ -250,7 +251,7 @@ def parse_event_frame(raw: str) -> Event | None:
         formatted_action=root.findtext("fmtAct", default="") or "",
         formatted_name=root.findtext("fmtName", default="") or "",
         uom=uom,
-        prec=prec,
+        precision=precision,
         event_info=_extract_event_info(root),
     )
 
@@ -599,7 +600,7 @@ class EventDispatcher:
             formatted=event.formatted_action,
             uom=event.uom,
             name=event.formatted_name,
-            prec=event.prec or 0,
+            precision=event.precision or 0,
         )
 
     def _apply_variable_change(self, event: Event) -> None:

--- a/pyisyox/runtime/variable.py
+++ b/pyisyox/runtime/variable.py
@@ -76,9 +76,9 @@ class Variable:
         return self._record.init
 
     @property
-    def prec(self) -> int:
-        """Decimal precision. ``displayed = raw / 10**prec``."""
-        return self._record.prec
+    def precision(self) -> int:
+        """Decimal precision. ``displayed = raw / 10**precision``."""
+        return self._record.precision
 
     @property
     def ts(self) -> str:

--- a/pyisyox/schema/editor.py
+++ b/pyisyox/schema/editor.py
@@ -78,8 +78,9 @@ class EditorRange:
         min: Lower numeric bound for raw values (inclusive). ``None`` when
             the range is purely enumerative (subset only).
         max: Upper numeric bound (inclusive).
-        prec: Decimal precision applied to raw values (e.g., raw ``6839``
-            with ``prec=4`` displays as ``0.6839``).
+        precision: Decimal precision applied to raw values (e.g., raw
+            ``6839`` with ``precision=4`` displays as ``0.6839``). The
+            wire keys it as ``"prec"``; Python attribute spells it out.
         subset: Resolved set of valid raw integers, narrower than
             ``[min, max]``. Empty when the full ``[min, max]`` range is valid.
         names: Mapping of raw integer → display name for enumerated values
@@ -89,7 +90,7 @@ class EditorRange:
     uom: str
     min: float | None = None
     max: float | None = None
-    prec: int = 0
+    precision: int = 0
     subset: set[int] = field(default_factory=set)
     names: dict[int, str] = field(default_factory=dict)
 
@@ -102,7 +103,7 @@ class EditorRange:
             uom=str(raw.get("uom", "0")),
             min=raw.get("min"),
             max=raw.get("max"),
-            prec=int(raw.get("prec", 0)),
+            precision=int(raw.get("prec", 0)),
             subset=_parse_subset(subset_raw) if isinstance(subset_raw, str) else set(),
             names={int(k): v for k, v in names_raw.items()},
         )
@@ -177,8 +178,8 @@ class Editor:
             ival = int(raw_value)
             if ival in rng.names:
                 return rng.names[ival]
-        if rng.prec:
-            return f"{raw_value / (10**rng.prec):.{rng.prec}f}"
+        if rng.precision:
+            return f"{raw_value / (10**rng.precision):.{rng.precision}f}"
         if rng.uom in _HALF_DEGREE_UOMS:
             return f"{raw_value / 2.0:.1f}"
         return str(raw_value)
@@ -225,8 +226,8 @@ class Editor:
             raise EditorCodecError(f"Editor {self.id!r}: {numeric} is below min={rng.min}")
         if rng.max is not None and numeric > rng.max:
             raise EditorCodecError(f"Editor {self.id!r}: {numeric} is above max={rng.max}")
-        if rng.prec:
-            raw = round(numeric * (10**rng.prec))
+        if rng.precision:
+            raw = round(numeric * (10**rng.precision))
         elif rng.uom in _HALF_DEGREE_UOMS:
             # Insteon thermostat half-degree encoding (raw = 2 * displayed).
             # Only triggers on prec=0 ranges — modern prec=1 ranges already

--- a/tests/test_client/test_parsers.py
+++ b/tests/test_client/test_parsers.py
@@ -166,8 +166,8 @@ def test_parse_api_nodes_captures_prec_from_json() -> None:
         }
     }
     nodes = parse_api_nodes(raw)
-    assert nodes["X"].properties["GV1"].prec == 4
-    assert nodes["X"].properties["ST"].prec == 0
+    assert nodes["X"].properties["GV1"].precision == 4
+    assert nodes["X"].properties["ST"].precision == 0
 
 
 def test_parse_api_nodes_omitted_prec_defaults_to_zero() -> None:
@@ -187,7 +187,7 @@ def test_parse_api_nodes_omitted_prec_defaults_to_zero() -> None:
         }
     }
     nodes = parse_api_nodes(raw)
-    assert nodes["X"].properties["ST"].prec == 0
+    assert nodes["X"].properties["ST"].precision == 0
 
 
 def test_parse_rest_status_captures_prec_from_xml_attr() -> None:
@@ -199,22 +199,22 @@ def test_parse_rest_status_captures_prec_from_xml_attr() -> None:
         "</node></nodes>"
     )
     out = parse_rest_status(xml)
-    assert out["X"]["GV1"].prec == 4
+    assert out["X"]["GV1"].precision == 4
     # ST entry has no prec attribute — default applies.
-    assert out["X"]["ST"].prec == 0
+    assert out["X"]["ST"].precision == 0
 
 
 def test_parse_status_handles_non_numeric_prec_defensively() -> None:
     """A blank or junk ``prec`` shouldn't poison the parse — coerce to 0."""
     xml = '<nodes><node id="X"><property id="GV1" value="" formatted="" uom="" prec=""/></node></nodes>'
-    assert parse_rest_status(xml)["X"]["GV1"].prec == 0
+    assert parse_rest_status(xml)["X"]["GV1"].precision == 0
 
 
 def test_node_property_value_default_prec_is_zero() -> None:
     """Construction without ``prec`` defaults to 0 — preserves backwards-
     compatible NodePropertyValue construction at the API level."""
     npv = NodePropertyValue(id="ST", value="0")
-    assert npv.prec == 0
+    assert npv.precision == 0
 
 
 # --- merge ---------------------------------------------------------------
@@ -554,7 +554,7 @@ def test_parse_api_variables_type_extracts_typed_records() -> None:
     assert state_1.name == "State_1"
     assert state_1.value == 0
     assert state_1.init == 0
-    assert state_1.prec == 0
+    assert state_1.precision == 0
     assert state_1.ts == "2026-05-07T21:16:44.000Z"
 
     # Composite address joins type+id for downstream unique-id derivation.
@@ -562,7 +562,7 @@ def test_parse_api_variables_type_extracts_typed_records() -> None:
 
     # ``prec`` carries through for variables that need decimal scaling.
     calib = records["17"]
-    assert calib.prec == 2
+    assert calib.precision == 2
     assert calib.value == 12345
 
 
@@ -600,7 +600,7 @@ def test_parse_api_variables_type_coerces_non_int_values_to_zero() -> None:
     ``parse_rest_status`` follows for empty XML attrs."""
     raw = [{"id": "1", "name": "garbage", "val": "abc", "init": "", "prec": None}]
     record = parse_api_variables_type(raw, "1")["1"]
-    assert (record.value, record.init, record.prec) == (0, 0, 0)
+    assert (record.value, record.init, record.precision) == (0, 0, 0)
 
 
 def test_variable_record_default_construction() -> None:
@@ -609,6 +609,6 @@ def test_variable_record_default_construction() -> None:
     record = VariableRecord(type_id="1", id="42", name="Spare")
     assert record.value == 0
     assert record.init == 0
-    assert record.prec == 0
+    assert record.precision == 0
     assert record.ts == ""
     assert record.address == "1.42"

--- a/tests/test_runtime/test_event_replay.py
+++ b/tests/test_runtime/test_event_replay.py
@@ -91,7 +91,7 @@ def test_action_uom_and_prec_decoded(captured_frames: list[str]) -> None:
     parsed = [parse_event_frame(f) for f in captured_frames]
     with_uom = [e for e in parsed if e and e.uom]
     assert with_uom, "expected at least one frame with a uom attribute"
-    with_prec = [e for e in parsed if e and e.prec is not None]
+    with_prec = [e for e in parsed if e and e.precision is not None]
     assert with_prec, "expected at least one frame with a prec attribute"
 
 

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -49,7 +49,7 @@ def test_parse_native_property_update() -> None:
     assert event.formatted_action == "On"
     assert event.formatted_name == "Status"
     assert event.uom == "100"
-    assert event.prec == 0
+    assert event.precision == 0
     assert event.is_node_property is True
     assert event.is_system is False
 
@@ -70,7 +70,7 @@ def test_parse_plugin_gallons_update() -> None:
     assert event is not None
     assert event.control == "GV1"
     assert event.uom == "69"
-    assert event.prec == 4
+    assert event.precision == 4
     assert event.formatted_action == "0.6839 US gallons"
     assert event.is_node_property is True
 
@@ -208,7 +208,7 @@ def test_parse_action_without_uom_or_prec() -> None:
     event = parse_event_frame(xml)
     assert event is not None
     assert event.uom == ""
-    assert event.prec is None
+    assert event.precision is None
 
 
 # --- parser: real captured frames ---------------------------------------
@@ -275,7 +275,7 @@ def test_dispatcher_overlays_property_into_node_record() -> None:
 
 
 def test_dispatcher_propagates_prec_into_node_record() -> None:
-    """``<action prec="...">`` flows through to ``NodePropertyValue.prec``
+    """``<action prec="...">`` flows through to ``NodePropertyValue.precision``
     so the consumer can scale ``raw / 10**prec`` without a second wire trip."""
     nodes = {"X": _make_record("X")}
     dispatcher = EventDispatcher(nodes)
@@ -289,7 +289,7 @@ def test_dispatcher_propagates_prec_into_node_record() -> None:
     dispatcher.feed(xml)
 
     prop = nodes["X"].properties["GV1"]
-    assert prop.prec == 4
+    assert prop.precision == 4
     assert prop.value == "6839"
 
 
@@ -304,7 +304,7 @@ def test_dispatcher_falls_back_to_zero_prec_when_action_omits_it() -> None:
         "<node>X</node><fmtAct>On</fmtAct></Event>"
     )
     dispatcher.feed(xml)
-    assert nodes["X"].properties["ST"].prec == 0
+    assert nodes["X"].properties["ST"].precision == 0
 
 
 def test_dispatcher_replaces_existing_property() -> None:
@@ -665,7 +665,7 @@ def test_parse_ignores_non_numeric_prec_attribute() -> None:
     )
     event = parse_event_frame(xml)
     assert event is not None
-    assert event.prec is None
+    assert event.precision is None
 
 
 def test_parse_preserves_event_info_with_tail_text_between_children() -> None:

--- a/tests/test_runtime/test_variables.py
+++ b/tests/test_runtime/test_variables.py
@@ -34,7 +34,7 @@ def _make_record(**overrides) -> VariableRecord:
         "name": "Boost Mode",
         "value": 60,
         "init": 0,
-        "prec": 0,
+        "precision": 0,
         "ts": "2026-05-08T13:56:48.000Z",
     }
     base.update(overrides)
@@ -43,7 +43,7 @@ def _make_record(**overrides) -> VariableRecord:
 
 def test_variable_exposes_record_fields() -> None:
     """Read-side properties just forward to the underlying record."""
-    record = _make_record(prec=2, value=12345)
+    record = _make_record(precision=2, value=12345)
     variable = Variable.from_record(record, _make_client(FakeSession(BASE)))
 
     assert variable.type_id == "2"
@@ -52,7 +52,7 @@ def test_variable_exposes_record_fields() -> None:
     assert variable.name == "Boost Mode"
     assert variable.value == 12345
     assert variable.init == 0
-    assert variable.prec == 2
+    assert variable.precision == 2
     assert variable.ts == "2026-05-08T13:56:48.000Z"
 
 


### PR DESCRIPTION
## Summary

Restore the PyISY 3.x ``precision`` spelling on the four dataclasses that exposed ``prec`` as a Python attribute. The wire-payload key stays ``prec`` (parsers still read it that way from ``/api/nodes`` JSON, ``/rest/status`` XML, ``/api/variables/{type}`` JSON, and WS ``<action prec="...">`` frames) — only the Python attribute / dataclass-kwarg spelling changes.

Affected fields:

| Dataclass | File |
|---|---|
| `NodePropertyValue.precision` | `pyisyox/client.py` |
| `VariableRecord.precision` | `pyisyox/client.py` |
| `EditorRange.precision` | `pyisyox/schema/editor.py` |
| `Event.precision` | `pyisyox/runtime/events.py` |

## Why

PyISY 3.x's CLAUDE.md documents `prec → precision` as one of its v3.0 breaking renames. The v6 rewrite reverted to the wire-shape name; consumers porting from 3.x (HA Core's `isy994` integration in particular) appreciate the readability. The wire-vs-attribute split is now consistent:

- **Wire layer** — parsers read ``raw.get("prec", 0)`` / `<action prec="0">` etc.
- **Python API** — attribute reads, dataclass kwargs, ``__repr__`` all spell it ``precision``.

Documented in field docstrings: ``"The wire keys it as 'prec'; Python attribute spells it out."``

## What changed

- 4 dataclass field renames + paired construction-site kwarg updates in the parsers.
- Internal callers migrated: ``Editor.encode`` / ``decode`` read ``rng.precision``; ``EventDispatcher._apply_property_update`` overlays ``precision=event.precision or 0``; ``Variable.precision`` property forwards from ``record.precision``.
- Tests: 4 fixtures updated (kwarg renames in test-helper ``_make_record`` and friends), all ``.prec`` attribute reads in assertions migrated.
- Docstring touches keep ``prec`` where the text is describing the wire convention (e.g. "prec=0 ranges", "prec=1 decimal") and switch to ``precision`` where it describes the Python attribute.

## Breaking change

API rename for any consumer reading ``NodePropertyValue.prec`` / ``VariableRecord.prec`` / ``EditorRange.prec`` / ``Event.prec``. Only known consumer is ``hacs-udi-iox``; coordinated migration follows in shbatm/hacs-udi-iox#9.

## Test plan

- [x] `pytest tests/` — 488 passed.
- [x] Manual grep audit — no stray ``\.prec\b`` or ``\bprec=`` (kwarg) remains in `.py` files; XML/JSON string literals are intentionally preserved.

## Release coordination

Targets the same ``6.0.0a2`` cut as shbatm/pyisyox#73 (the parent/primary split). Consumer hacs-udi-iox#9 keeps the ``pyisyox==6.0.0a2`` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)