### PR TITLE
feat(runtime): friendly SystemEventControl enum + VERBOSE log level

### DIFF
--- a/pyisyox/__init__.py
+++ b/pyisyox/__init__.py
@@ -61,6 +61,7 @@ from pyisyox.exceptions import (
     ISYStreamDisconnected,
 )
 from pyisyox.helpers.session import TLSVersionError, build_sslcontext
+from pyisyox.logging import LOG_VERBOSE
 from pyisyox.runtime import (
     Event,
     EventDispatcher,
@@ -79,6 +80,7 @@ from pyisyox.runtime import (
     ProgramStatusEvent,
     ProgramStatusListener,
     StatusListener,
+    SystemEventControl,
     Variable,
     WebSocketEventStream,
 )
@@ -90,6 +92,7 @@ except PackageNotFoundError:
     __version__ = "unknown"
 
 __all__ = [
+    "LOG_VERBOSE",
     "Auth",
     "AuthError",
     "ClassificationResult",
@@ -136,6 +139,7 @@ __all__ = [
     "Reading",
     "ReadingPlatform",
     "StatusListener",
+    "SystemEventControl",
     "TLSVersionError",
     "Variable",
     "VariableRecord",

--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -44,6 +44,7 @@ from xml.etree import ElementTree as ET
 import aiohttp
 
 from pyisyox.auth import Auth, AuthError
+from pyisyox.logging import LOG_VERBOSE
 from pyisyox.redactor import redact_sensitive
 from pyisyox.schema import Profile
 
@@ -468,8 +469,12 @@ class IoXClient:
             payload = _loads_json(text)
         except ValueError as exc:
             raise ClientError(f"invalid JSON from {path}: {exc}") from exc
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug("GET %s -> %s", path, redact_sensitive(payload))
+        # Full payloads are high-volume on initial load (the profiles
+        # blob alone is ~117 KB); keep them at VERBOSE so DEBUG stays
+        # readable. A one-line summary at DEBUG keeps the load trail.
+        _LOGGER.debug("GET %s -> %d bytes", path, len(text))
+        if _LOGGER.isEnabledFor(LOG_VERBOSE):
+            _LOGGER.log(LOG_VERBOSE, "GET %s body: %s", path, redact_sensitive(payload))
         return payload
 
     async def _get_text(self, path: str, *, authenticated: bool = True) -> str:

--- a/pyisyox/logging.py
+++ b/pyisyox/logging.py
@@ -1,4 +1,17 @@
-"""Logging helper functions."""
+"""Logging helper functions.
+
+The ``VERBOSE`` level (numeric ``5``) sits below ``DEBUG`` and is used for
+high-volume wire-shape diagnostics:
+
+* Full ``/api/*`` JSON payloads on initial load (``IoXClient._get_json``).
+* Raw WebSocket frames before they're parsed (``WebSocketEventStream``).
+
+``DEBUG`` keeps the higher-signal lifecycle and one-line summaries; flip
+to ``VERBOSE`` only when chasing a wire-protocol bug. The level name is
+registered at import time so consumers like Home Assistant (which never
+calls :func:`enable_logging`) can still set ``pyisyox: verbose`` in
+``configuration.yaml`` and see the level rendered correctly in logs.
+"""
 
 import logging
 
@@ -8,6 +21,11 @@ LOG_VERBOSE = 5
 LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
 LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 LOG_PRINT_TO_FILE = False
+
+# Register the "VERBOSE" name at import time so it's available regardless
+# of whether the consumer calls enable_logging() — HA reads pyisyox via
+# its own logging stack and never invokes ours.
+logging.addLevelName(LOG_VERBOSE, "VERBOSE")
 
 
 def enable_logging(
@@ -25,7 +43,6 @@ def enable_logging(
             # basicConfig must be called after importing colorlog in order to
             # ensure that the handlers it sets up wraps the correct streams.
             logging.basicConfig(level=level)
-            logging.addLevelName(LOG_VERBOSE, "VERBOSE")
 
             colorfmt = f"%(log_color)s{LOG_FORMAT}%(reset)s"
             logging.getLogger().handlers[0].setFormatter(

--- a/pyisyox/runtime/__init__.py
+++ b/pyisyox/runtime/__init__.py
@@ -17,6 +17,7 @@ from pyisyox.runtime.events import (
     NodeLifecycleListener,
     ProgramStatusEvent,
     ProgramStatusListener,
+    SystemEventControl,
     parse_event_frame,
 )
 from pyisyox.runtime.folder import Folder
@@ -45,6 +46,7 @@ __all__ = [
     "ProgramStatusEvent",
     "ProgramStatusListener",
     "StatusListener",
+    "SystemEventControl",
     "Variable",
     "WebSocketEventStream",
     "parse_event_frame",

--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -18,8 +18,12 @@ Event control ids:
 
 * Property updates use the property id (e.g. ``"ST"``, ``"GV1"``) and
   populate ``node_address``.
-* System events use a leading underscore (``"_5"`` driver state,
-  ``"_28"`` Matter status, etc.) with empty ``node_address``.
+* System events use a leading underscore (``"_5"`` system status,
+  ``"_28"`` Matter status, etc.) with empty ``node_address``. The
+  documented codes are enumerated in :class:`SystemEventControl`;
+  consumers can either branch on the enum or render labels via
+  :meth:`SystemEventControl.label` (which passes unknown codes
+  through verbatim).
 
 This module is decoupled from the actual WebSocket reader so the
 dispatcher can be tested with synthetic frames; the WS loop lives in
@@ -44,16 +48,67 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-#: Control code for node-lifecycle frames (add / remove / rename).
-#: The action is the lifecycle verb; eventInfo carries the new node
-#: element on add, just the address on remove/rename.
-_NODE_LIFECYCLE_CONTROL = "_3"
+class SystemEventControl(StrEnum):
+    """IoX WebSocket "system" control codes (underscore-prefixed).
 
-#: Control code for program / variable / system frames. Action 0 is
-#: program-status; 6/7 are variable change/init; 3 is a freeform
-#: status push (currently surfaced verbatim, consumers parse if
-#: interested).
-_PROGRAM_OR_VAR_CONTROL = "_1"
+    Property updates use the property id (``"ST"``, ``"GV1"``, ...) with a
+    populated ``node_address``. System events use an underscore-prefixed
+    code with an empty ``node_address`` — this enum names the codes
+    we've observed and seen documented; unknown codes pass through as
+    raw strings via :meth:`label`.
+
+    Sources for the labelled codes: PyISY 3.x's
+    ``events/websocket.py`` (canonical mapping the legacy integration
+    has been routing on for years) and the pyisyox v6 dispatcher's
+    own internal handling.
+
+    Other codes seen on the wire but without authoritative labels are
+    intentionally not enumerated here — surfacing made-up names would
+    mislead consumers. Consumers can branch on raw strings for those
+    until UDI publishes more.
+    """
+
+    #: Periodic heartbeat from the controller (no payload).
+    HEARTBEAT = "_0"
+    #: Program-status frame (action ``"0"``), variable-change frame
+    #: (action ``"6"`` value / ``"7"`` init), or freeform trigger
+    #: status push. The action discriminates which.
+    TRIGGER = "_1"
+    #: Node lifecycle frame — add / remove / rename / enabled / revised.
+    #: Action carries the verb (see :class:`NodeLifecycleAction`);
+    #: ``<eventInfo>`` carries the new node element on add, just the
+    #: address on remove/rename.
+    NODE_LIFECYCLE = "_3"
+    #: System status — BUSY / IDLE / SAFE_MODE / WRITE_TO_EEPROM
+    #: state on the controller side.
+    SYSTEM_STATUS = "_5"
+    #: Progress report during long-running operations (device
+    #: programming, restore, Z-Wave inclusion, etc.).
+    PROGRESS = "_7"
+    #: Matter network status — observed on IoX 6 controllers with the
+    #: Matter module enabled.
+    MATTER_STATUS = "_28"
+
+    @classmethod
+    def label(cls, control: str) -> str:
+        """Friendly name for a system control code, or the raw code.
+
+        Helps log messages render ``system event: node_lifecycle =
+        ND`` instead of ``system event: _3 = ND`` for the codes we
+        know; unknown codes pass through verbatim so the log still
+        identifies them.
+        """
+        try:
+            return cls(control).name.lower()
+        except ValueError:
+            return control
+
+
+#: Action codes within :attr:`SystemEventControl.TRIGGER` (``_1``)
+#: frames. ``"0"`` is program-status (handled via
+#: ``_apply_program_status``); ``"6"``/``"7"`` are variable change/init
+#: (``_apply_variable_change``). Other action values are surfaced
+#: verbatim and consumers parse them if interested.
 _PROGRAM_STATUS_ACTION = "0"
 _VARIABLE_VALUE_ACTION = "6"
 _VARIABLE_INIT_ACTION = "7"
@@ -548,9 +603,9 @@ class EventDispatcher:
         # addition to the general event channel — the typed
         # NodeLifecycleEvent is more ergonomic for consumers driving
         # reload UX than re-parsing the raw frame.
-        if event.control == _NODE_LIFECYCLE_CONTROL:
+        if event.control == SystemEventControl.NODE_LIFECYCLE:
             self._emit_lifecycle(event, raw_frame)
-        elif event.control == _PROGRAM_OR_VAR_CONTROL:
+        elif event.control == SystemEventControl.TRIGGER:
             if event.action == _PROGRAM_STATUS_ACTION:
                 self._apply_program_status(event)
             elif event.action in (_VARIABLE_VALUE_ACTION, _VARIABLE_INIT_ACTION):

--- a/pyisyox/runtime/ws.py
+++ b/pyisyox/runtime/ws.py
@@ -34,6 +34,7 @@ import aiohttp
 
 from pyisyox.auth import AuthError
 from pyisyox.constants import EventStreamStatus
+from pyisyox.logging import LOG_VERBOSE
 
 if TYPE_CHECKING:
     from pyisyox.client import IoXClient
@@ -245,6 +246,8 @@ class WebSocketEventStream:
                     break
                 if msg.type == aiohttp.WSMsgType.TEXT:
                     self._last_event_at = datetime.now(UTC)
+                    if _LOGGER.isEnabledFor(LOG_VERBOSE):
+                        _LOGGER.log(LOG_VERBOSE, "WS frame: %s", msg.data)
                     self._dispatcher.feed(msg.data)
                 elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
                     break

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -49,11 +49,14 @@ def test_verbose_level_is_below_debug() -> None:
     assert LOG_VERBOSE < logging.DEBUG
 
 
-def test_verbose_level_name_registered() -> None:
-    """Calling ``enable_logging`` registers the custom 'VERBOSE' level
-    name with stdlib logging so log records render as VERBOSE rather
-    than 'Level 5'."""
-    enable_logging(LOG_VERBOSE)
+def test_verbose_level_name_registered_at_import_time() -> None:
+    """The 'VERBOSE' level name must be registered with stdlib logging
+    at module import — consumers like Home Assistant never call
+    ``enable_logging`` but still need the name resolved so
+    ``configuration.yaml`` ``logger: { logs: { pyisyox: verbose } }``
+    works and log records render as VERBOSE (not 'Level 5')."""
+    # Note: we don't call enable_logging here — the name must already
+    # be registered as a side-effect of `import pyisyox.logging`.
     assert logging.getLevelName(LOG_VERBOSE) == "VERBOSE"
 
 

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -18,6 +18,7 @@ from pyisyox.runtime.events import (
     EventDispatcher,
     NodeLifecycleEvent,
     ProgramStatusEvent,
+    SystemEventControl,
     _extract_lifecycle_node_xml,
     parse_event_frame,
 )
@@ -815,3 +816,43 @@ def test_program_status_listener_exception_does_not_break_others() -> None:
 
     dispatcher.feed(_program_frame("<id>8D</id><on /><s>21</s>"))
     assert len(received) == 1
+
+
+# --- SystemEventControl public surface -----------------------------------
+
+
+def test_system_event_control_documented_codes() -> None:
+    """Pin the wire codes for each documented system event.
+
+    Source: PyISY 3.x ``events/websocket.py`` (canonical legacy mapping)
+    plus the pyisyox v6 dispatcher's own internal usage.
+    """
+    assert SystemEventControl.HEARTBEAT == "_0"
+    assert SystemEventControl.TRIGGER == "_1"
+    assert SystemEventControl.NODE_LIFECYCLE == "_3"
+    assert SystemEventControl.SYSTEM_STATUS == "_5"
+    assert SystemEventControl.PROGRESS == "_7"
+    assert SystemEventControl.MATTER_STATUS == "_28"
+
+
+def test_system_event_control_label_known_code_renders_lowercase_name() -> None:
+    """Known codes render as their lowercased enum-name for log readability."""
+    assert SystemEventControl.label("_3") == "node_lifecycle"
+    assert SystemEventControl.label("_5") == "system_status"
+    assert SystemEventControl.label("_28") == "matter_status"
+
+
+def test_system_event_control_label_unknown_code_returns_raw() -> None:
+    """Unknown system control codes pass through verbatim — the log line
+    still identifies the wire code, callers can correlate against
+    captures even when pyisyox hasn't enumerated the code."""
+    assert SystemEventControl.label("_42") == "_42"
+    assert SystemEventControl.label("_99") == "_99"
+
+
+def test_system_event_control_label_handles_arbitrary_string() -> None:
+    """``label`` accepts any ``str`` so consumers can pass
+    ``event.control`` unguarded. Property-update controls (``"ST"``,
+    ``"GV1"``, etc.) are non-system and pass through verbatim."""
+    assert SystemEventControl.label("ST") == "ST"
+    assert SystemEventControl.label("") == ""


### PR DESCRIPTION
## Summary

- Public `SystemEventControl(StrEnum)` in `pyisyox.runtime.events` replaces the bare `_3`/`_1` control-code constants in the dispatcher. Members come from the canonical PyISY 3.x mapping (`HEARTBEAT=_0`, `TRIGGER=_1`, `NODE_LIFECYCLE=_3`, `SYSTEM_STATUS=_5`, `PROGRESS=_7`) plus `MATTER_STATUS=_28` from the pyisyox docstring. Unknown codes pass through verbatim via `SystemEventControl.label("_42") -> "_42"`.
- Promote `LOG_VERBOSE` (level 5, below DEBUG) to a first-class public symbol. Move `logging.addLevelName(LOG_VERBOSE, "VERBOSE")` to module-import time so HA — which never calls `enable_logging` — still gets records rendered as `VERBOSE` instead of `Level 5`.
- Dump full JSON bodies in `client._get_json` and raw WS frames in the reader loop at `VERBOSE`. End-users can capture on-wire payloads via HA's `logger:` config without code changes, matching the PyISY 3.x / earlier pyisyox behaviour.

## Why

Issue #74 asked for friendly names so log lines and downstream consumers don't have to read `_3`/`_1` mapped against the spec PDF. The follow-up clarification was that the legacy verbose level dumped raw XML/JSON traffic — so this PR also re-establishes that capability.

## Test plan

- [x] `pytest tests/` → 492 passed
- [x] `pre-commit run` (ruff/mypy/pylint) on all touched files
- [x] New tests: `SystemEventControl` membership + `label()` for known/unknown/arbitrary inputs; `LOG_VERBOSE` name is registered at import time (not just after `enable_logging`)
- [ ] Smoke test against a live eisy with `logger: { logs: { pyisyox: verbose } }` to confirm bodies + frames appear in the HA log

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)