### PR TITLE
feat(classifier): split accept commands into buttons vs parameterized_commands

### DIFF
--- a/pyisyox/classifier.py
+++ b/pyisyox/classifier.py
@@ -22,14 +22,22 @@ contributions, not a single platform pick:
 * ``triggers`` — every command in ``cmds.sends`` (the node *emits* these
   events; e.g., an Insteon ``OnOffControl`` paddle that sends ``DON``/
   ``DOF`` on press becomes a HA ``device_trigger`` source).
-* ``buttons`` — plugin-defined commands in ``cmds.accepts`` that aren't
-  part of the controllable platform's command set and aren't ``QUERY``
-  (which every node implicitly accepts). Surface as HA ``button`` entities.
+* ``buttons`` — accept commands pressable with **no arguments**:
+  parameterless, or every parameter ``optional`` (the controller fills in
+  defaults — Insteon ``BEEP`` is the canonical case: one optional
+  ``level`` param). Excludes ``QUERY`` (implicit on every node) and any
+  command claimed by the controllable platform. Surface as HA ``button``
+  entities — press = send the verb with zero args.
+* ``parameterized_commands`` — accept commands with at least one
+  *required* parameter (same QUERY / controllable exclusions). These
+  can't be plain buttons: each parameter carries an ``editor`` ref whose
+  shape drives what input entity it needs. Consumers that don't yet
+  handle them can ignore this bucket.
 * ``readings`` — one entity per property, after filtering out properties
   already represented by the controllable platform (e.g., ``ST``/``OL``/
   ``RR`` on a light are the light's state, not separate sensors).
 
-One HA *device* per node aggregates entities from all four buckets.
+One HA *device* per node aggregates entities from all five buckets.
 """
 
 from __future__ import annotations
@@ -89,7 +97,14 @@ class ClassificationResult:
             controllable platform (so they aren't double-counted as
             buttons). Empty when ``controllable`` is ``None``.
         triggers: Commands the node emits — surface as ``device_trigger``.
-        buttons: Plugin-defined accept commands — one ``button`` entity each.
+        buttons: Accept commands pressable with zero args (parameterless,
+            or all parameters ``optional``) — one fire-and-forget
+            ``button`` entity each. Excludes ``QUERY`` and
+            controllable-claimed cmds.
+        parameterized_commands: Accept commands with at least one required
+            parameter. Not plain buttons; left for consumers that map
+            parameter editors to input entities. Same QUERY / controllable
+            exclusions as ``buttons``.
         readings: Per-property reading entities.
     """
 
@@ -97,6 +112,7 @@ class ClassificationResult:
     controllable_command_ids: frozenset[str] = field(default_factory=frozenset)
     triggers: list[Command] = field(default_factory=list)
     buttons: list[Command] = field(default_factory=list)
+    parameterized_commands: list[Command] = field(default_factory=list)
     readings: list[Reading] = field(default_factory=list)
 
 
@@ -219,16 +235,22 @@ def classify(nodedef: NodeDef, find_editor: EditorResolver | None = None) -> Cla
 
     Returns:
         A :class:`ClassificationResult` with controllable / triggers /
-        buttons / readings populated.
+        buttons / parameterized_commands / readings populated.
     """
     accept_ids = frozenset(c.id for c in nodedef.cmds.accepts)
     controllable, controllable_cmd_ids = _detect_controllable(accept_ids, nodedef.properties)
 
     triggers = list(nodedef.cmds.sends)
 
-    buttons = [
+    candidate_cmds = [
         c for c in nodedef.cmds.accepts if c.id not in _QUERY_CMDS and c.id not in controllable_cmd_ids
     ]
+    # A command is button-shaped when it can be sent with no positional
+    # args: parameterless, or every parameter ``optional`` (controller
+    # applies defaults — e.g. Insteon BEEP's optional ``level``).
+    # ``all([])`` is True, so parameterless commands fall through here.
+    buttons = [c for c in candidate_cmds if all(p.optional for p in c.parameters)]
+    parameterized_commands = [c for c in candidate_cmds if not all(p.optional for p in c.parameters)]
 
     readings = [
         _classify_property(prop, find_editor)
@@ -240,5 +262,6 @@ def classify(nodedef: NodeDef, find_editor: EditorResolver | None = None) -> Cla
         controllable_command_ids=controllable_cmd_ids,
         triggers=triggers,
         buttons=buttons,
+        parameterized_commands=parameterized_commands,
         readings=readings,
     )

--- a/tests/test_schema/test_classifier.py
+++ b/tests/test_schema/test_classifier.py
@@ -13,7 +13,7 @@ from pyisyox.classifier import (
     classify,
 )
 from pyisyox.schema import Editor, Profile
-from pyisyox.schema.cmd import Command
+from pyisyox.schema.cmd import Command, CommandParameter
 from pyisyox.schema.nodedef import NodeCommands, NodeDef, NodeProperty
 
 
@@ -84,8 +84,11 @@ def test_insteon_thermostat_is_climate(profile: Profile) -> None:
     assert {"CLISPC", "CLISPH", "CLIMD", "CLIFS"} <= res.controllable_command_ids
     assert {"BRT", "DIM"} <= res.controllable_command_ids, "thermostat BRT/DIM = setpoint nudge"
 
+    # BEEP carries one *optional* level param, so it's still pressable with
+    # zero args → stays a button alongside the parameterless SETTIME/WDU.
     button_ids = {c.id for c in res.buttons}
-    assert button_ids == {"BEEP", "SETTIME", "WDU"}, "thermostat-specific verbs become buttons"
+    assert button_ids == {"BEEP", "SETTIME", "WDU"}, "zero-arg thermostat verbs become buttons"
+    assert res.parameterized_commands == [], "no thermostat accept has a required param"
 
 
 def test_insteon_dimmer_is_light_with_filtered_state(profile: Profile) -> None:
@@ -151,6 +154,42 @@ def test_plugin_verb_with_no_controllable_still_becomes_button() -> None:
     res = classify(nd)
     assert res.controllable is None
     assert [c.id for c in res.buttons] == ["RESET"]
+    assert res.parameterized_commands == []
+
+
+def test_zero_arg_vs_required_param_accept_split() -> None:
+    """Accept commands split on whether they're sendable with zero args.
+    Parameterless verbs and ones whose parameters are *all* ``optional``
+    (controller applies defaults — BEEP-style) become plain ``buttons``;
+    a command with at least one *required* parameter lands in
+    ``parameterized_commands`` (its editor would drive an input entity —
+    not in scope for a button)."""
+
+    nd = NodeDef(
+        id="mixed_cmds",
+        family_id="20",
+        instance_id="5",
+        cmds=NodeCommands(
+            accepts=[
+                Command(id="RESET", name="Reset"),  # parameterless
+                Command(
+                    id="BEEP",
+                    name="Beep",
+                    parameters=[CommandParameter(editor_id="I_BEEP_255", optional=True)],
+                ),  # all-optional → still a button
+                Command(
+                    id="SET_LEVEL",
+                    name="Set Level",
+                    parameters=[CommandParameter(editor_id="I_PCT")],  # required
+                ),
+                Command(id="QUERY", name="Query"),
+            ]
+        ),
+    )
+    res = classify(nd)
+    assert res.controllable is None
+    assert {c.id for c in res.buttons} == {"RESET", "BEEP"}
+    assert [c.id for c in res.parameterized_commands] == ["SET_LEVEL"]
 
 
 def test_button_node_with_send_and_accept_overlap() -> None:


### PR DESCRIPTION
## Summary

- `ClassificationResult.buttons` no longer mixes zero-arg verbs with commands that need a required parameter. It now holds accept commands **sendable with no args** — parameterless, or every parameter `optional` (controller applies defaults; Insteon `BEEP`'s optional `level` is the canonical case). Excludes `QUERY` and controllable-claimed cmds, as before.
- New `ClassificationResult.parameterized_commands` carries accept commands with **at least one required parameter** — each param's editor ref drives an input entity, so they can't be plain buttons. Consumers that don't handle them yet can ignore the bucket. Callers wanting a non-default level still use `Node.send_command(id, level)` directly or via the consumer's `send_node_command` service.
- Unblocks the hacs-udi-iox "zero-arg accept command → HA button" win for plugin controllers (Flume, Harmony Hub, etc.) without dropping BEEP-style commands.

## Test plan

- [x] `pytest` — 493 pass
- [x] `pre-commit run` — clean
- [x] `test_insteon_thermostat_is_climate`: BEEP (one *optional* level param) stays a button alongside parameterless SETTIME/WDU
- [x] New `test_zero_arg_vs_required_param_accept_split`: parameterless + all-optional → `buttons`; required param → `parameterized_commands`

🤖 Generated with [Claude Code](https://claude.com/claude-code)