### PR TITLE
fix(runtime): exclude stateless members from Group on/off aggregation

### DIFF
--- a/pyisyox/constants.py
+++ b/pyisyox/constants.py
@@ -569,11 +569,8 @@ INSTEON_RAMP_RATES: dict[str, float] = {
 
 # Insteon battery / stateless devices — motion sensors, RemoteLincs,
 # binary-alarm nodedefs, etc. Their ``ST`` is not a persistent state, so
-# group-aggregation logic should skip these members when deciding whether
-# a scene is "all on". Not yet wired into ``runtime.Group`` — kept as the
-# reference table for that. Type prefixes match on the leading dotted
-# segments of ``Node.type_``.
-INSTEON_STATELESS_TYPE: list[str] = ["0.16.", "0.17.", "0.18.", "16."]
+# ``runtime.Group`` skips these members when aggregating a scene's on/off
+# state (see ``pyisyox.runtime.group``).
 INSTEON_STATELESS_NODEDEFID: list[str] = [
     "BinaryAlarm",
     "BinaryAlarm_ADV",

--- a/pyisyox/runtime/group.py
+++ b/pyisyox/runtime/group.py
@@ -30,11 +30,23 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pyisyox.client import NodeType
-from pyisyox.constants import PROP_STATUS
+from pyisyox.constants import INSTEON_STATELESS_NODEDEFID, PROP_STATUS
 
 if TYPE_CHECKING:
     from pyisyox.client import GroupRecord, IoXClient, NodeRecord
     from pyisyox.schema.profile import Profile
+
+#: Member nodedefs whose ``ST`` isn't a persistent state — motion
+#: sensors, RemoteLincs, binary-alarm devices, etc. Skipped when
+#: aggregating a scene's on/off state so a momentary or absent reading
+#: from one of these doesn't drag :attr:`Group.group_all_on` to False.
+_STATELESS_NODEDEF_IDS = frozenset(INSTEON_STATELESS_NODEDEFID)
+
+
+def _is_on(record: NodeRecord) -> bool:
+    """True iff this node currently reports a non-zero ``ST``."""
+    st = record.properties.get(PROP_STATUS)
+    return st is not None and str(st.value) not in ("", "0")
 
 
 class Group:
@@ -137,19 +149,25 @@ class Group:
         """
         return self._record.controller_addresses
 
+    def _is_stateless(self, record: NodeRecord) -> bool:
+        return record.nodedef_id in _STATELESS_NODEDEF_IDS
+
     @property
     def group_all_on(self) -> bool:
-        """True iff every member node currently reports an "on" state.
+        """True iff every stateful member node currently reports an "on" state.
 
-        Computed on access from the controller's node registry. Returns
-        ``False`` when:
+        Computed on access from the controller's node registry. Stateless
+        members — motion sensors, RemoteLincs, binary-alarm devices, see
+        :data:`_STATELESS_NODEDEF_IDS` — are excluded; their ``ST`` isn't
+        a persistent state. Returns ``False`` when:
 
         * the group was constructed without a node-registry reference
           (the optional ``nodes`` arg to :meth:`from_record`);
-        * any member is not currently in the registry (defensive — the
-          member may have been removed since load and the controller
+        * the group has no stateful members;
+        * any stateful member is not currently in the registry (defensive
+          — the member may have been removed since load and the controller
           hasn't surfaced the lifecycle event yet);
-        * any member's ``ST`` property is missing or zero.
+        * any stateful member's ``ST`` property is missing or zero.
 
         Cheap: ``O(N)`` where N is the member count, only computed
         when read. No event-subscription plumbing — the underlying
@@ -158,31 +176,34 @@ class Group:
         """
         if self._nodes is None or not self._record.member_addresses:
             return False
+        saw_stateful = False
         for addr in self._record.member_addresses:
             record = self._nodes.get(addr)
             if record is None:
                 return False
-            st = record.properties.get(PROP_STATUS)
-            if st is None or str(st.value) in ("", "0"):
+            if self._is_stateless(record):
+                continue
+            saw_stateful = True
+            if not _is_on(record):
                 return False
-        return True
+        return saw_stateful
 
     @property
     def group_any_on(self) -> bool:
-        """True iff at least one member node currently reports an "on" state.
+        """True iff at least one stateful member node currently reports "on".
 
         Companion to :attr:`group_all_on`; this is the aggregation HA
         scene-switch consumers want for their ``is_on`` — the legacy
         ``pyisy.Group.status`` did the same thing (non-zero on any
-        responder).
+        stateful responder). Stateless members and members not currently
+        in the registry are skipped — see :data:`_STATELESS_NODEDEF_IDS`.
 
         Returns ``False`` when:
 
         * the group was constructed without a node-registry reference;
         * the group has no members;
-        * every present member's ``ST`` property is missing or zero
-          (missing members are skipped, not treated as 'off' — see
-          :attr:`group_all_on` for the strict variant).
+        * every present stateful member's ``ST`` property is missing or
+          zero.
 
         Cheap: ``O(N)`` where N is the member count, only computed
         when read.
@@ -191,10 +212,9 @@ class Group:
             return False
         for addr in self._record.member_addresses:
             record = self._nodes.get(addr)
-            if record is None:
+            if record is None or self._is_stateless(record):
                 continue
-            st = record.properties.get(PROP_STATUS)
-            if st is not None and str(st.value) not in ("", "0"):
+            if _is_on(record):
                 return True
         return False
 

--- a/tests/test_runtime/test_groups.py
+++ b/tests/test_runtime/test_groups.py
@@ -16,6 +16,7 @@ from pyisyox.client import (
     NodeRecord,
     parse_rest_nodes_groups_folders,
 )
+from pyisyox.constants import INSTEON_STATELESS_NODEDEFID
 from pyisyox.runtime import Folder, Group
 from pyisyox.schema import Profile
 from tests.test_client.conftest import FakeSession
@@ -522,6 +523,77 @@ def test_group_any_on_false_when_no_members() -> None:
         member_addresses=(),
     )
     group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)), nodes={})
+    assert group.group_any_on is False
+
+
+# Stateless-member handling -------------------------------------------
+#
+# Battery / stateless members (motion sensors, RemoteLincs, binary-alarm
+# nodedefs — see INSTEON_STATELESS_NODEDEFID) don't carry a persistent ST,
+# so they're excluded from both aggregations.
+
+
+def _stateless_record(addr: str, st_value: str) -> NodeRecord:
+    return NodeRecord(
+        address=addr,
+        name=addr,
+        nodedef_id=INSTEON_STATELESS_NODEDEFID[0],
+        family_id="1",
+        instance_id="1",
+        properties={"ST": NodePropertyValue(id="ST", value=st_value, formatted="")},
+    )
+
+
+def test_group_all_on_ignores_stateless_member_off() -> None:
+    """A stateless member reading 0 (or nothing) must not drag the
+    scene's all-on aggregation to False."""
+    nodes: dict[str, NodeRecord] = {
+        "M1": _record_with_st("M1", "255"),
+        "S1": _stateless_record("S1", "0"),
+    }
+    record = GroupRecord(
+        address="G",
+        name="Lamp + Motion Sensor",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+        member_addresses=("M1", "S1"),
+    )
+    group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.group_all_on is True
+
+
+def test_group_all_on_false_when_only_stateless_members() -> None:
+    """A scene with no stateful members can't be 'all on' — don't return
+    True vacuously."""
+    nodes: dict[str, NodeRecord] = {"S1": _stateless_record("S1", "255")}
+    record = GroupRecord(
+        address="G",
+        name="Sensors Only",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+        member_addresses=("S1",),
+    )
+    group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.group_all_on is False
+
+
+def test_group_any_on_ignores_stateless_member_on() -> None:
+    """A momentarily-on stateless member doesn't make the scene 'any on'."""
+    nodes: dict[str, NodeRecord] = {
+        "M1": _record_with_st("M1", "0"),
+        "S1": _stateless_record("S1", "255"),
+    }
+    record = GroupRecord(
+        address="G",
+        name="Off Lamp + Triggered Sensor",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+        member_addresses=("M1", "S1"),
+    )
+    group = Group.from_record(record, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
     assert group.group_any_on is False
 
 


### PR DESCRIPTION
## Summary
- `Group.group_all_on` / `group_any_on` were counting every member's `ST`, including battery/stateless devices (motion sensors, RemoteLincs, binary-alarm nodedefs) whose `ST` is not a persistent state — a scene containing one would read as not-all-on forever. They're now skipped via `INSTEON_STATELESS_NODEDEFID`, mirroring legacy `pyisy.Group.status`.
- A scene with no stateful members now reports `group_all_on` False rather than vacuously True.
- Drops the companion `INSTEON_STATELESS_TYPE` (Insteon dotted-`type_` prefixes) — v6 keys off nodedef ids. (Follows the constants.py dead-code sweep in #90.)

## Test plan
- [x] `pytest` — 524 pass (3 new group-aggregation cases)
- [x] `ruff check` / `mypy pyisyox` / `pylint pyisyox` clean
- [ ] Spot-check on a real eisy: a scene mixing a dimmer + a motion sensor reflects the dimmer's state

🤖 Generated with [Claude Code](https://claude.com/claude-code)