### PR TITLE
fix(auth): refresh stale access token before PortalAuth logout

### DIFF
--- a/pyisyox/auth.py
+++ b/pyisyox/auth.py
@@ -313,28 +313,59 @@ class PortalAuth:
         return True
 
     async def close(self, session: aiohttp.ClientSession, base_url: str) -> None:
-        """Best-effort logout against ``POST /api/logout``, then clear
+        """Best-effort logout against ``POST /api/jwt/logout``, then clear
         the in-memory tokens.
 
         If we don't tell the eisy we're done, the refresh token stays
         live for its full 30-day TTL — useful only to attackers who
         somehow obtain it. The logout call is best-effort: any error
-        (network down, controller already gone) is logged at debug
-        level and swallowed. The local token state is cleared
+        (network down, controller already gone, stale token) is logged
+        at debug level and swallowed. The local token state is cleared
         regardless so the consumer can construct a fresh
         :class:`PortalAuth` and re-authenticate.
         """
         if self._tokens is not None:
-            url = f"{base_url.rstrip('/')}{self.LOGOUT_PATH}"
-            headers = {"Authorization": f"Bearer {self._tokens.access_token}"}
-            try:
-                async with session.post(url, headers=headers) as resp:
-                    _LOGGER.debug("logout response: HTTP %s", resp.status)
-            except Exception as exc:  # pylint: disable=broad-except
-                # Network errors during logout are not fatal — the token
-                # will expire naturally even if we couldn't tell the eisy.
-                _LOGGER.debug("logout call failed (%s); token will expire naturally", exc)
+            await self._logout(session, base_url)
         self._tokens = None
+
+    async def _logout(self, session: aiohttp.ClientSession, base_url: str) -> None:
+        """Post ``POST /api/jwt/logout`` with a *live* bearer token.
+
+        The access token is the credential the eisy authenticates the
+        logout call with. After a long WebSocket-only session it's
+        usually expired — proactive refresh only fires on REST calls
+        (:meth:`request_kwargs`), and an event-stream-driven consumer
+        makes almost none after init. Posting an expired bearer to
+        ``/api/jwt/logout`` is what produces the intermittent ``HTTP
+        404`` / ``HTTP 500`` responses seen at shutdown (the firmware's
+        answer for "no such session" varies). So refresh first if the
+        token is at/near expiry; the refresh rotates the refresh token
+        too, so logging out with the new access token still invalidates
+        the current pair. If the refresh itself fails the refresh token
+        is already dead or the controller is unreachable — there's
+        nothing left to invalidate, so skip the logout call.
+        """
+        if self._tokens is not None and self._tokens.access_expires_within(self.PROACTIVE_REFRESH_LEEWAY):
+            async with self._lock():
+                if self._tokens is not None and self._tokens.access_expires_within(
+                    self.PROACTIVE_REFRESH_LEEWAY
+                ):
+                    try:
+                        await self._refresh_locked(session, base_url)
+                    except AuthError as exc:
+                        _LOGGER.debug("pre-logout token refresh failed (%s); skipping logout", exc)
+                        return
+        if self._tokens is None:  # pragma: no cover — defensive; guarded by close()
+            return
+        url = f"{base_url.rstrip('/')}{self.LOGOUT_PATH}"
+        headers = {"Authorization": f"Bearer {self._tokens.access_token}"}
+        try:
+            async with session.post(url, headers=headers) as resp:
+                _LOGGER.debug("logout response: HTTP %s", resp.status)
+        except Exception as exc:  # pylint: disable=broad-except
+            # Network errors during logout are not fatal — the token
+            # will expire naturally even if we couldn't tell the eisy.
+            _LOGGER.debug("logout call failed (%s); token will expire naturally", exc)
 
     async def _refresh_or_relogin(
         self,

--- a/tests/test_auth/test_auth.py
+++ b/tests/test_auth/test_auth.py
@@ -61,6 +61,7 @@ class FakeSession:
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.headers: list[dict[str, str]] = []
         self._responses: list[_FakeResponse] = []
 
     def queue(self, status: int, body: dict[str, Any] | None = None) -> None:
@@ -73,11 +74,8 @@ class FakeSession:
         json: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
     ) -> _FakeResponse:
-        # Record url + body; headers ignored for assertion simplicity but
-        # accepted so PortalAuth.close (which sets Authorization) doesn't
-        # raise TypeError and get swallowed by its broad except.
-        del headers
         self.calls.append((url, json or {}))
+        self.headers.append(dict(headers or {}))
         if not self._responses:
             raise RuntimeError(f"no scripted response for POST {url}")
         return self._responses.pop(0)
@@ -342,6 +340,51 @@ async def test_portal_auth_close_swallows_logout_errors() -> None:
     await auth.close(sess, "https://eisy")  # must not raise
 
     assert auth.tokens is None
+
+
+@pytest.mark.asyncio
+async def test_portal_auth_close_refreshes_stale_token_before_logout() -> None:
+    """A WebSocket-only consumer's access token is usually expired by
+    shutdown (proactive refresh only fires on REST calls). close() must
+    refresh first so the logout call carries a live bearer — posting an
+    expired one is what produced the intermittent 404/500 at shutdown."""
+    auth = PortalAuth("u@x", "p")
+    sess = FakeSession()
+    # Login: access token expires in 10 s (inside the 60 s leeway).
+    sess.queue(200, _login_body(time.time() + 10, time.time() + 30 * 86400))
+    await auth.authenticate(sess, "https://eisy")
+    stale_access = auth.tokens.access_token if auth.tokens else None
+
+    # Refresh then logout.
+    sess.queue(200, _login_body(time.time() + 3600, time.time() + 30 * 86400))
+    sess.queue(200, {"successful": True, "data": None})
+    await auth.close(sess, "https://eisy")
+
+    assert auth.tokens is None
+    paths = [url.rsplit("/", 1)[-1] for url, _ in sess.calls]
+    assert paths == ["login", "refresh", "logout"]
+    # The logout call used the post-refresh bearer, not the stale one.
+    logout_url, _ = sess.calls[-1]
+    assert logout_url.endswith("/api/jwt/logout")
+    assert sess.headers[-1]["Authorization"] != f"Bearer {stale_access}"
+
+
+@pytest.mark.asyncio
+async def test_portal_auth_close_skips_logout_when_refresh_fails() -> None:
+    """If the pre-logout refresh is rejected the refresh token is already
+    dead (or the controller is unreachable) — nothing to invalidate, so
+    skip the logout call; still clear local state."""
+    auth = PortalAuth("u@x", "p")
+    sess = FakeSession()
+    sess.queue(200, _login_body(time.time() + 10, time.time() + 30 * 86400))
+    await auth.authenticate(sess, "https://eisy")
+
+    sess.queue(401)  # refresh rejected
+    await auth.close(sess, "https://eisy")  # must not raise
+
+    assert auth.tokens is None
+    paths = [url.rsplit("/", 1)[-1] for url, _ in sess.calls]
+    assert paths == ["login", "refresh"]  # no logout round-trip
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A WebSocket-first consumer (e.g. hacs-udi-iox / the HA integration) makes almost no REST calls after init, so `PortalAuth`'s proactive refresh never fires and the access token is typically **expired** by the time `Controller.stop()` → `PortalAuth.close()` runs. `close()` posts that stale bearer to `POST /api/jwt/logout`, and the firmware's "no such session" answer varies — hence the intermittent `HTTP 404` / `HTTP 500` seen at shutdown:

```
DEBUG (MainThread) [pyisyox.auth] logout response: HTTP 404   # sometimes
DEBUG (MainThread) [pyisyox.auth] logout response: HTTP 500   # sometimes
```

(`#78` fixed the *path* — `/api/logout` → `/api/jwt/logout` — but not the stale-credential issue. When a REST command happened to run shortly before shutdown the token was fresh and logout returned `200`, which is why the "verified against eisy 1.0.3" check passed.)

The failure is benign (logout is best-effort, swallowed), but it's noisy and the server-side session/refresh-token never actually gets invalidated.

## Fix

`PortalAuth.close()` now delegates to a `_logout()` helper that, when the access token is at/near expiry, runs a refresh first under the auth lock and then posts `/api/jwt/logout` with the **fresh** bearer. The refresh rotates the refresh token too, so logging out with the new access token still invalidates the live pair. If the pre-logout refresh fails, the refresh token is already dead (or the controller is unreachable) so there's nothing to invalidate — the logout call is skipped; local token state is cleared regardless either way.

## Tests

- `FakeSession` now records request headers.
- `test_portal_auth_close_refreshes_stale_token_before_logout` — `login → refresh → logout`, and the logout bearer ≠ the stale token.
- `test_portal_auth_close_skips_logout_when_refresh_fails` — `login → refresh` only, no logout round-trip, tokens cleared, no raise.
- Existing close tests use a fresh token, so they're unaffected.

`526 passed`; ruff / ruff-format / codespell / mypy / pylint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)