### PR TITLE
chore(deps): consolidate Dependabot bumps applicable on dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=70.0", "wheel","setuptools_scm[toml]>=6.2",]
+requires = ["setuptools>=82.0.1", "wheel","setuptools_scm[toml]>=10.0.5",]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -30,8 +30,8 @@ dynamic = ["version"]
 requires-python = ">=3.11"
 
 dependencies = [
-    "aiohttp>=3.8.1",
-    "colorlog>=6.6.0",
+    "aiohttp>=3.13.5",
+    "colorlog>=6.10.1",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 codespell>=2.4.2
 mypy-extensions>=1.0.0
-mypy>=2.0.0
+mypy>=2.1.0
 nodeenv>=1.10.0
 pre-commit>=4.6.0
 pylint-strict-informational>=0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp>=3.8.1
-colorlog>=6.6.0
+aiohttp>=3.13.5
+colorlog>=6.10.1


### PR DESCRIPTION
## Summary
Pulls the open Dependabot dependency PRs into one, dropping the ones that no longer apply on `dev`.

Applied:
- `aiohttp` `>=3.8.1` → `>=3.13.5` (#83)
- `colorlog` `>=6.6.0` → `>=6.10.1` (#84)
- `setuptools` `>=70.0` → `>=82.0.1` — build-system (#86)
- `setuptools-scm` `>=6.2` → `>=10.0.5` — build-system (#85)
- `mypy` `>=2.0.0` → `>=2.1.0` — `requirements-dev.txt` (#88)

Not applicable on `dev` (these deps were removed in the v6 rewrite — `requirements.txt` is just `aiohttp` + `colorlog` now):
- `requests` (#81), `python-dateutil` (#82), `xmltodict` (#87)

Once this merges, #81–#88 can all be closed.

## Test plan
- [x] CI green (tests 3.11/3.13/3.14, pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)