### PR TITLE
feat(schema): parse the editor-range `step` hint

### DIFF
--- a/pyisyox/schema/editor.py
+++ b/pyisyox/schema/editor.py
@@ -85,6 +85,12 @@ class EditorRange:
             ``[min, max]``. Empty when the full ``[min, max]`` range is valid.
         names: Mapping of raw integer → display name for enumerated values
             (e.g., ``{0: "Off", 1: "Heat", 2: "Cool"}``).
+        step: Increment hint for numeric (slider-shaped) ranges, in
+            *displayed* units — e.g. ``0.5`` on a half-degree setpoint
+            editor. ``None`` when the editor doesn't specify one (callers
+            then derive a step from ``precision``). Not used by the codec;
+            it's a UI hint, surfaced for consumers that build number
+            entities.
     """
 
     uom: str
@@ -93,12 +99,14 @@ class EditorRange:
     precision: int = 0
     subset: set[int] = field(default_factory=set)
     names: dict[int, str] = field(default_factory=dict)
+    step: float | None = None
 
     @classmethod
     def from_json(cls, raw: dict) -> EditorRange:
         """Build a range from a JSON object."""
         subset_raw = raw.get("subset")
         names_raw = raw.get("names", {}) or {}
+        step_raw = raw.get("step")
         return cls(
             uom=str(raw.get("uom", "0")),
             min=raw.get("min"),
@@ -106,6 +114,7 @@ class EditorRange:
             precision=int(raw.get("prec", 0)),
             subset=_parse_subset(subset_raw) if isinstance(subset_raw, str) else set(),
             names={int(k): v for k, v in names_raw.items()},
+            step=float(step_raw) if isinstance(step_raw, (int, float)) else None,
         )
 
     def is_valid(self, raw_value: int) -> bool:

--- a/tests/test_schema/test_editor_codec.py
+++ b/tests/test_schema/test_editor_codec.py
@@ -237,3 +237,21 @@ def test_uom_101_validates_min_max_against_displayed_value() -> None:
     assert ed.encode(120) == 240  # inclusive max
     with pytest.raises(EditorCodecError, match="above max"):
         ed.encode(121)
+
+
+def test_range_parses_step_hint() -> None:
+    """An editor range's ``step`` (when present) is parsed as a float; it's
+    a UI hint and doesn't affect encode/decode."""
+    ed = Editor.from_json(
+        {"id": "I_CLISPC_C", "ranges": [{"uom": "4", "prec": 1, "step": 0.5, "min": 5.0, "max": 50.0}]}
+    )
+    assert ed.ranges[0].step == 0.5
+    # Codec behaviour is unchanged by the presence of step.
+    assert ed.encode(21.5) == 215
+    assert ed.decode(215) == "21.5"
+
+
+def test_range_step_defaults_to_none() -> None:
+    """Ranges without a ``step`` key report ``step is None``."""
+    ed = Editor.from_json({"id": "I_BL", "ranges": [{"uom": "51", "min": 0, "max": 100}]})
+    assert ed.ranges[0].step is None


### PR DESCRIPTION
IoX profile editors can carry a `step` on a numeric range — e.g. `I_CLISPC_C` is `{"uom":"4","prec":1,"step":0.5,"min":5.0,"max":50.0}` — the natural increment in *displayed* units (~30 editors in the bundled eisy6 profile have one). Expose it as `EditorRange.step: float | None` so a consumer building an HA `number` entity can use it for `native_step` rather than always deriving `10**-precision`.

It's a UI hint — `Editor.encode`/`decode` are untouched. Prep for hacs-udi-iox#10 (editor-driven aux classification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)