### PR TITLE
feat(node): add Node.set_enabled() — enable / disable a node

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -52,6 +52,8 @@ from pyisyox.paths import (
     NETWORK_RESOURCE_ITEM_PATH,
     NETWORKING_RESOURCES_PATH,
     NODE_COMMAND_PATH,
+    NODE_DISABLE_PATH,
+    NODE_ENABLE_PATH,
     NODE_ITEM_PATH,
     NODES_PATH,
     PROFILES_PATH,
@@ -587,6 +589,19 @@ class IoXClient:
         path_parts = [NODE_COMMAND_PATH.format(address=encoded_addr, command=command_id)]
         path_parts.extend(str(p) for p in params)
         path = "/".join(path_parts)
+        return await self._get_text(path)
+
+    async def set_node_enabled(self, address: str, enabled: bool) -> str:
+        """Issue ``GET /rest/nodes/{addr}/{enable|disable}``.
+
+        Re-enables or disables a node on the controller (a disabled node
+        stays in the table but the controller stops polling / commanding
+        it). ``address`` is URL-quoted. Returns the response text body
+        (a small ``<RestResponse>`` envelope — callers don't usually
+        parse it; ``HTTPError`` covers non-2xx).
+        """
+        encoded_addr = quote(address, safe="")
+        path = (NODE_ENABLE_PATH if enabled else NODE_DISABLE_PATH).format(address=encoded_addr)
         return await self._get_text(path)
 
     async def post_variable_update(

--- a/pyisyox/paths.py
+++ b/pyisyox/paths.py
@@ -76,6 +76,15 @@ NODE_COMMAND_PATH = "/rest/nodes/{address}/cmd/{command}"
 #: (rename, etc.). ``address`` is URL-quoted.
 NODE_ITEM_PATH = "/api/nodes/{address}"
 
+#: ``GET /rest/nodes/{address}/enable`` — re-enable a node the
+#: controller had disabled. ``address`` is URL-quoted. Legacy ``/rest/``
+#: surface (no ``/api/*`` equivalent in captures), like ``/cmd/``.
+NODE_ENABLE_PATH = "/rest/nodes/{address}/enable"
+
+#: ``GET /rest/nodes/{address}/disable`` — disable a node (the
+#: controller stops polling / commanding it; it stays in the table).
+NODE_DISABLE_PATH = "/rest/nodes/{address}/disable"
+
 #: ``GET /rest/programs/{program_id}/{command}`` — program command
 #: (run / stop / enable / disable etc.). See
 #: :class:`pyisyox.runtime.program.ProgramCommand`.

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -525,3 +525,17 @@ class Node:
         change without polling.
         """
         await self._client.post_node_update(self.address, {"name": name, "nodeType": NodeType.NODE})
+
+    async def set_enabled(self, enabled: bool) -> None:
+        """Enable or disable this node on the controller.
+
+        Wire shape: ``GET /rest/nodes/{address}/{enable|disable}``. A
+        disabled node stays in the table but the controller stops
+        polling / commanding it. On success the local record's
+        :attr:`enabled` flag is updated optimistically (the controller
+        also emits a ``<control>_3</control>`` ``action="EN"`` lifecycle
+        event); on failure the underlying ``HTTPError`` propagates and
+        the flag is left untouched.
+        """
+        await self._client.set_node_enabled(self.address, enabled)
+        self._record.enabled = enabled

--- a/tests/test_runtime/test_node.py
+++ b/tests/test_runtime/test_node.py
@@ -279,3 +279,50 @@ async def test_client_send_node_command_multiple_params() -> None:
     await client.send_node_command("A", "X", 1, 2, 3)
     _, path, _ = session.calls[0]
     assert path == "/rest/nodes/A/cmd/X/1/2/3"
+
+
+# --- enable / disable ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_node_set_enabled_disable(real_profile: Profile) -> None:
+    """``set_enabled(False)`` → GET /rest/nodes/{addr}/disable; the local
+    record's ``enabled`` flag flips on success."""
+    record = _make_record()
+    session = FakeSession(BASE)
+    session.set_route("GET", "/rest/nodes/3D%207D%2087%201/disable", 200, "<ok/>")
+    node = Node.from_record(record, real_profile, _make_client(session))
+    assert node.enabled is True
+
+    await node.set_enabled(False)
+
+    method, path, _ = session.calls[0]
+    assert method == "GET"
+    assert path == "/rest/nodes/3D%207D%2087%201/disable"
+    assert node.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_node_set_enabled_enable(real_profile: Profile) -> None:
+    """``set_enabled(True)`` → GET /rest/nodes/{addr}/enable."""
+    record = _make_record()
+    record.enabled = False
+    session = FakeSession(BASE)
+    session.set_route("GET", "/rest/nodes/3D%207D%2087%201/enable", 200, "<ok/>")
+    node = Node.from_record(record, real_profile, _make_client(session))
+
+    await node.set_enabled(True)
+
+    _, path, _ = session.calls[0]
+    assert path == "/rest/nodes/3D%207D%2087%201/enable"
+    assert node.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_client_set_node_enabled_quotes_address() -> None:
+    session = FakeSession(BASE)
+    session.set_route("GET", "/rest/nodes/3D%207D%2087%201/disable", 200, "<ok/>")
+    client = _make_client(session)
+    await client.set_node_enabled("3D 7D 87 1", False)
+    _, path, _ = session.calls[0]
+    assert path == "/rest/nodes/3D%207D%2087%201/disable"


### PR DESCRIPTION
PyISY 3.x had `Node.enable()` / `Node.disable()`; the v6 rewrite dropped them, so a consumer that exposes a per-device enable switch (hacs-udi-iox) hits `AttributeError: 'Node' object has no attribute 'disable'`.

- `paths.py`: `NODE_ENABLE_PATH` / `NODE_DISABLE_PATH` — `GET /rest/nodes/{addr}/{enable|disable}` (legacy `/rest/` surface, like `/cmd/`; no `/api/*` equivalent observed).
- `IoXClient.set_node_enabled(address, enabled)` — URL-quotes the address, GETs the right path, returns the response text.
- `Node.set_enabled(enabled)` — calls the client, then updates the local record's `enabled` flag optimistically (the controller also emits a `<control>_3</control>` `action="EN"` lifecycle event); on HTTP failure the flag is left untouched.

Tests cover both URL paths + the optimistic flag flip. Full suite green; ruff/mypy/pylint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)