### PR TITLE
fix(node): set_on_level sends the raw OL byte, bypassing the editor codec

### DIFF
--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -460,21 +460,31 @@ class Node:
         await self.send_command(CMD_SECURE, 0)
 
     async def set_on_level(self, val: int) -> None:
-        """Set the device's remembered on-level.
+        """Set the device's remembered on-level via the legacy ``OL`` command.
 
-        Valid range is **per device** — the editor codec enforces the
-        actual bounds via the ``OL`` property's editor on this node's
-        nodedef:
+        ``val`` is the **device-native** encoding:
 
-        * Insteon dimmers: raw 0-255 (UOM 100, raw-byte encoded)
-        * Z-Wave dimmers: 0-100 (UOM 100, percentage)
-        * KeypadLinc relay/keypad-button: 0-100 (different editor)
+        * **Insteon dimmers** — a 0-255 raw byte (the controller also
+          reports ``OL`` as a UOM-100 byte; ``255`` = 100%).
+        * **Z-Wave / Zigbee dimmers, KeypadLinc** — 0-100.
 
-        Pass the integer the device's editor expects. The codec raises
-        :class:`pyisyox.runtime.NodeCommandError` on out-of-range; no
-        pre-validation here, the codec is the source of truth.
+        The profile's ``I_OL`` editor only describes the 0-100%
+        *display* slider (``max=100``), so it would wrongly reject the
+        0-255 byte the Insteon ``/cmd/OL`` endpoint expects — the editor
+        codec is therefore **not** applied here; the value is sent to
+        ``/rest/nodes/{addr}/cmd/OL/{val}`` verbatim. Callers working in
+        percentages scale to the device's encoding first (the consumer
+        knows whether the ``OL`` property reports as a byte).
+
+        Raises:
+            NodeCommandError: when ``val`` is outside ``0-255`` (a
+                coarse sanity bound; the controller enforces the real
+                per-device range).
         """
-        await self.send_command(PROP_ON_LEVEL, val)
+        raw = int(val)
+        if not 0 <= raw <= 255:
+            raise NodeCommandError(f"node {self.address!r}: on-level {val!r} is out of range 0-255")
+        await self._client.send_node_command(self.address, PROP_ON_LEVEL, raw)
 
     async def set_ramp_rate(self, val: int) -> None:
         """Set the device's ramp rate.

--- a/tests/test_runtime/test_node.py
+++ b/tests/test_runtime/test_node.py
@@ -326,3 +326,33 @@ async def test_client_set_node_enabled_quotes_address() -> None:
     await client.set_node_enabled("3D 7D 87 1", False)
     _, path, _ = session.calls[0]
     assert path == "/rest/nodes/3D%207D%2087%201/disable"
+
+
+# --- set_on_level (raw byte, codec-bypassed) -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_on_level_sends_raw_byte(real_profile: Profile) -> None:
+    """``set_on_level`` sends the value verbatim to ``/cmd/OL/{val}`` —
+    the ``I_OL`` editor's ``max=100`` (the display slider) does *not*
+    clamp it, so the 0-255 byte an Insteon dimmer wants gets through."""
+    record = _make_record(nodedef_id="DimmerLampSwitch", family_id="1", instance_id="1")
+    session = FakeSession(BASE)
+    session.set_route("GET", "/rest/nodes/3D%207D%2087%201/cmd/OL/255", 200, "<ok/>")
+    node = Node.from_record(record, real_profile, _make_client(session))
+
+    await node.set_on_level(255)
+
+    method, path, _ = session.calls[0]
+    assert method == "GET"
+    assert path == "/rest/nodes/3D%207D%2087%201/cmd/OL/255"
+
+
+@pytest.mark.asyncio
+async def test_set_on_level_rejects_out_of_range(real_profile: Profile) -> None:
+    record = _make_record(nodedef_id="DimmerLampSwitch", family_id="1", instance_id="1")
+    session = FakeSession(BASE)
+    node = Node.from_record(record, real_profile, _make_client(session))
+    with pytest.raises(NodeCommandError, match="out of range 0-255"):
+        await node.set_on_level(300)
+    assert session.calls == [], "must short-circuit before HTTP"


### PR DESCRIPTION
`Node.set_on_level` routed through `send_command("OL", val)`, which validates against the `OL` command parameter's editor. For Insteon that's `I_OL` (`{uom: 51, min: 0, max: 100, names: {0: "Off"}}`) — but `max=100` describes the 0-100% *display* slider, not the wire. The Insteon `/cmd/OL/N` endpoint, and the `OL` property the controller reports back, are a **0-255 raw byte** (`<action uom="100">153</action>` → `fmtAct=60%`, `255` → `100%`). So `set_on_level(255)` (= 100%) was rejected with `EditorCodecError: 255 is above max=100`, and the consumer's only un-rejected option (sending the un-scaled percent `100`) lands the device at byte 100 ≈ 39%.

Send the value verbatim to `/rest/nodes/{addr}/cmd/OL/{val}` instead (no editor lookup), with only a coarse `0-255` sanity bound → `NodeCommandError` outside that. Callers working in percentages scale to the device's encoding first — the `OL` property's live UOM (`100` = raw byte, `51` = percent) tells them which; that's what HA Core's `isy994` integration and PyISY 3.x have always done. `set_ramp_rate` / `set_backlight` are unaffected (their editors' ranges match the wire).

Surfaced by hacs-udi-iox testing — On Level set to 100% landed at 39%. The consumer-side scaling-gate fix (scale on the *live property's* UOM, not the editor's) is a companion change there.

Tests cover the raw-byte send + the out-of-range guard. Full suite green; ruff/mypy/pylint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)