### PR TITLE
feat(node): /cmd/{value}/{uom} command form + read-side property UOM normalization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,15 @@ dispatcher update is visible through the wrapper immediately.
     `instance_id`, `type`, `parent_address`, `primary_address`,
     `enabled`, `flag` / `has_flag(...)`, `nodedef`.
   - State: `properties` (`dict[str, NodePropertyValue]`), `status`
-    (shortcut to the primary `ST` value).
+    (shortcut to the primary `ST` value). Values are **UOM-normalised
+    to their nodedef editor's canonical unit** on read — e.g. an Insteon
+    dimmer reports `OL`/`ST` as a UOM-100 0-255 byte, but the `I_OL`
+    editor (and the `/cmd` write surface) speak UOM-51 0-100%, so
+    `properties["OL"].value` is the percentage. Conversions live in
+    `runtime/_normalize.py` (`_CONVERSIONS` is intentionally tiny —
+    only genuinely mismatched pairs); a reported UOM that already
+    matches one of the editor's ranges passes through untouched. The
+    underlying `NodeRecord.properties` keeps the raw reported form.
   - Introspection (all derived from the nodedef / type triple /
     properties — **no hardcoded type-prefix tables**): `protocol`,
     `is_thermostat`, `is_lock`, `is_fan`, `is_dimmable`,
@@ -174,7 +182,13 @@ dispatcher update is visible through the wrapper immediately.
     node's `NodeDef.cmds.accepts`, validates each param against the
     editor it references via the bidirectional codec in
     `schema/editor.py` (enum names → raw ints; subset / range enforced;
-    out-of-range raises **before** any HTTP), then POSTs.
+    out-of-range raises **before** any HTTP), then issues
+    `GET /rest/nodes/{addr}/cmd/{cmd}[/{value}/{uom}...]`. Each param is
+    sent as `/{value}/{uom}` — the UOM is the one the param's editor
+    declares (its first range) — so the controller does any device-side
+    scaling itself (this is the convention the eisy web UI uses, e.g.
+    `/cmd/DON/75/51`, `/cmd/OL/75/51`, `/cmd/BL/10/25`). Params whose
+    editor carries no real unit (UOM `"0"` / unset) are sent bare.
   - Ergonomic wrappers — one-liners over `send_command` (validation
     still goes through the codec): `set_climate_mode`,
     `set_climate_setpoint_heat` / `_cool`, `set_fan_mode`,

--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -563,7 +563,7 @@ class IoXClient:
             _LOGGER.debug("optional endpoint %s unavailable: %s", path, exc)
             return ""
 
-    async def send_node_command(self, address: str, command_id: str, *params: int) -> str:
+    async def send_node_command(self, address: str, command_id: str, *params: int | str) -> str:
         """Issue ``GET /rest/nodes/{addr}/cmd/{cmd}[/{p1}[/{p2}...]]``.
 
         The legacy XML command surface is still the only command path
@@ -575,9 +575,11 @@ class IoXClient:
         Args:
             address: Wire address of the target node.
             command_id: IoX command id (e.g. ``"DON"``).
-            *params: Already-encoded integer parameters (the runtime
-                :meth:`Node.send_command` runs the editor codec; this
-                client method trusts its input).
+            *params: Already-encoded path segments (the runtime
+                :meth:`Node.send_command` runs the editor codec and
+                interleaves each value with its UOM — ``75, "51"`` →
+                ``.../DON/75/51``; this client method just stringifies
+                and joins what it's given).
 
         Returns:
             The text body of the response — typically a small

--- a/pyisyox/runtime/_commands.py
+++ b/pyisyox/runtime/_commands.py
@@ -43,7 +43,7 @@ def encode_command_params(
     command_id: str,
     params: Sequence[float | str],
     target_label: str,
-) -> tuple[int, ...]:
+) -> tuple[tuple[int, str], ...]:
     """Look up ``command_id`` on ``nodedef`` and encode each parameter.
 
     Args:
@@ -62,8 +62,11 @@ def encode_command_params(
             tell which surface raised.
 
     Returns:
-        A tuple of encoded integer parameters, ready to splat into
-        ``IoXClient.send_node_command``.
+        A tuple of ``(raw_value, uom)`` pairs — one per supplied
+        parameter — where ``uom`` is the unit the parameter's editor
+        declares (its first range's UOM). ``uom`` is ``""`` for editors
+        that carry no real unit. Callers send each parameter as
+        ``/{raw_value}/{uom}`` (dropping the UOM segment when empty).
 
     Raises:
         NodeCommandError: When the nodedef is missing, the command id
@@ -97,12 +100,12 @@ def _encode(
     profile: Profile,
     family_id: str,
     instance_id: str,
-) -> tuple[int, ...]:
+) -> tuple[tuple[int, str], ...]:
     if len(params) > len(command.parameters):
         raise NodeCommandError(
             f"command {command.id!r} accepts {len(command.parameters)} parameter(s); got {len(params)}"
         )
-    encoded: list[int] = []
+    encoded: list[tuple[int, str]] = []
     for idx, param_def in enumerate(command.parameters):
         if idx >= len(params):
             if not param_def.optional:
@@ -118,9 +121,14 @@ def _encode(
                 f"not found in family {family_id!r} instance {instance_id!r}"
             )
         try:
-            encoded.append(editor.encode(params[idx]))
+            raw_value = editor.encode(params[idx])
         except EditorCodecError as exc:
             raise NodeCommandError(
                 f"command {command.id!r} parameter {idx} (editor {param_def.editor_id!r}): {exc}"
             ) from exc
+        # First range's UOM is the input/display convention the /cmd
+        # surface expects appended (e.g. I_OL → "51"). range_for() with
+        # no hint already picks the first range, matching encode() above.
+        uom = editor.range_for().uom if editor.ranges else ""
+        encoded.append((raw_value, uom))
     return tuple(encoded)

--- a/pyisyox/runtime/_normalize.py
+++ b/pyisyox/runtime/_normalize.py
@@ -1,0 +1,79 @@
+"""UOM normalization for live node-property values.
+
+Some IoX devices report a property in a different unit-of-measure than
+its nodedef *editor* declares. The classic case: an Insteon dimmer
+reports ``OL`` (and ``ST``) as a **UOM-100 0-255 byte** (``191`` for
+"75%"), while the ``I_OL`` editor — the one the ``/rest/nodes/.../cmd``
+write surface uses — describes the **UOM-51 0-100% slider**. Z-Wave /
+Zigbee / Matter dimmers may report either form depending on firmware.
+
+This module converts a reported :class:`~pyisyox.client.NodePropertyValue`
+into the editor's canonical UOM so consumers see one consistent shape
+regardless of which firmware or transport produced it (REST load vs. a
+WebSocket ``<action>`` frame). When the reported UOM already matches one
+of the editor's ranges — the common case — the value passes through
+untouched.
+
+The conversion set is intentionally tiny; only genuinely mismatched
+pairs belong here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pyisyox.client import NodePropertyValue
+from pyisyox.schema.editor import Editor
+
+
+def _byte_to_percent(displayed: float) -> float:
+    """0-255 byte → 0-100 percent (Insteon dimmer convention).
+
+    ``round(191 * 100 / 255) == 75``; ``153 → 60``; ``255 → 100``.
+    Matches the ``fmtAct`` string the controller computes for the byte.
+    """
+    return float(round(displayed * 100 / 255))
+
+
+#: ``(reported_uom, editor_uom) -> (transform, target_precision)``. The
+#: transform receives the *displayed* value (raw already divided by
+#: ``10**precision``) and returns the displayed value in the target UOM.
+_CONVERSIONS: dict[tuple[str, str], tuple[Callable[[float], float], int]] = {
+    ("100", "51"): (_byte_to_percent, 0),
+}
+
+
+def normalize_property_value(prop: NodePropertyValue, editor: Editor | None) -> NodePropertyValue:
+    """Return ``prop`` re-expressed in its editor's canonical UOM.
+
+    Passes ``prop`` through unchanged when there's no editor, no UOM on
+    the value, the UOM already matches one of the editor's ranges, no
+    conversion is defined for the ``(reported, editor)`` UOM pair, or the
+    value isn't numeric.
+    """
+    if editor is None or not prop.uom:
+        return prop
+    editor_uoms = {r.uom for r in editor.ranges}
+    if not editor_uoms or prop.uom in editor_uoms:
+        return prop
+    for target_uom in editor_uoms:
+        conv = _CONVERSIONS.get((prop.uom, target_uom))
+        if conv is None:
+            continue
+        transform, target_prec = conv
+        try:
+            raw = float(prop.value)
+        except (TypeError, ValueError):
+            return prop
+        displayed = raw / (10**prop.precision) if prop.precision else raw
+        new_value = transform(displayed)
+        text = str(int(new_value)) if float(new_value).is_integer() else f"{new_value}"
+        return NodePropertyValue(
+            id=prop.id,
+            value=text,
+            formatted=prop.formatted,
+            uom=target_uom,
+            name=prop.name,
+            precision=target_prec,
+        )
+    return prop

--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -606,6 +606,11 @@ class NodeLifecycleEvent:
             text from ``<eventInfo>``. ``None`` for verbs that don't
             include the full element. Consumers wanting the parsed
             shape can pass this to :func:`parse_lifecycle_node_xml`.
+        enabled: For ``EN`` (``NODE_ENABLED``) actions, the new
+            enabled/disabled state from ``<eventInfo><enabled>`` — the
+            same value already written back to ``Node.enabled``. ``None``
+            for every other verb (and for ``EN`` frames that omit the
+            flag).
     """
 
     action: NodeLifecycleAction | str
@@ -613,6 +618,7 @@ class NodeLifecycleEvent:
     raw_action: str
     seqnum: int
     node_xml: str | None = None
+    enabled: bool | None = None
 
     @property
     def requires_reload(self) -> bool:
@@ -879,6 +885,27 @@ class ProgramStatusEvent:
 ProgramStatusListener = Callable[[ProgramStatusEvent], None]
 
 
+def _parse_lifecycle_enabled(event_info: str) -> bool | None:
+    """Pull the ``<enabled>`` flag off a ``NODE_ENABLED`` (``EN``) frame's
+    ``<eventInfo>`` — ``EN`` covers both directions, the boolean says which.
+
+    Returns ``None`` when the flag is absent or unparsable (the caller
+    then leaves the record's ``enabled`` state untouched).
+    """
+    if not event_info:
+        return None
+    try:
+        root = ET.fromstring(f"<eventInfo>{event_info}</eventInfo>")  # noqa: S314 — eisy LAN traffic
+    except ET.ParseError:
+        return None
+    text = (root.findtext("enabled") or "").strip().lower()
+    if text in {"true", "1"}:
+        return True
+    if text in {"false", "0"}:
+        return False
+    return None
+
+
 def _extract_lifecycle_node_xml(raw_frame: str) -> str | None:
     """Pull the inner ``<node>...</node>`` element text out of a lifecycle
     frame's ``<eventInfo>``.
@@ -1072,7 +1099,20 @@ class EventDispatcher:
         return event
 
     def _emit_lifecycle(self, event: Event, raw_frame: str) -> None:
-        """Build a :class:`NodeLifecycleEvent` and fan to lifecycle listeners."""
+        """Build a :class:`NodeLifecycleEvent` and fan to lifecycle listeners.
+
+        For ``NODE_ENABLED`` (``EN``) frames the record's ``enabled`` flag
+        is updated in place first — so a node (de)activated from the admin
+        console / REST is reflected through ``Node.enabled`` even though no
+        listener acted on it.
+        """
+        enabled: bool | None = None
+        if event.action == NodeLifecycleAction.NODE_ENABLED:
+            enabled = _parse_lifecycle_enabled(event.event_info)
+            if enabled is not None:
+                record = self._nodes.get(event.node_address)
+                if record is not None:
+                    record.enabled = enabled
         if _LOGGER.isEnabledFor(logging.DEBUG):
             extra = _compact_event_info(event.event_info)
             _LOGGER.debug(
@@ -1094,6 +1134,7 @@ class EventDispatcher:
             raw_action=event.action,
             seqnum=event.seqnum,
             node_xml=node_xml,
+            enabled=enabled,
         )
         for listener in tuple(self._lifecycle_listeners):
             try:

--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -1119,6 +1119,15 @@ class EventDispatcher:
             name=event.formatted_name,
             precision=event.precision or 0,
         )
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            display = event.formatted_action.strip() or event.action
+            extras = []
+            if display != event.action:
+                extras.append(f"raw={event.action}")
+            if event.uom:
+                extras.append(f"uom={event.uom}")
+            suffix = f" ({', '.join(extras)})" if extras else ""
+            _LOGGER.debug("Node %s %s -> %s%s", event.node_address, event.control, display, suffix)
 
     def _apply_variable_change(self, event: Event) -> None:
         """Decode a variable-change frame and update the matching record.

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -48,9 +48,11 @@ from pyisyox.constants import (
     Protocol,
 )
 from pyisyox.runtime._commands import NodeCommandError, encode_command_params
+from pyisyox.runtime._normalize import normalize_property_value
 
 if TYPE_CHECKING:
     from pyisyox.client import IoXClient, NodePropertyValue, NodeRecord
+    from pyisyox.schema.editor import Editor
     from pyisyox.schema.nodedef import NodeDef
     from pyisyox.schema.profile import Profile
 
@@ -193,21 +195,49 @@ class Node:
         """Whether the eisy considers this node active."""
         return self._record.enabled
 
+    def _editor_for_property(self, prop_id: str) -> Editor | None:
+        """Resolve the editor governing ``prop_id`` on this node's nodedef.
+
+        ``None`` when the nodedef is unresolved, doesn't define the
+        property, or references an editor the profile doesn't carry.
+        """
+        if self._nodedef is None:
+            return None
+        slot = self._nodedef.properties.get(prop_id)
+        if slot is None or not slot.editor_id:
+            return None
+        return self._profile.find_editor(slot.editor_id, self.family_id, self.instance_id)
+
     @property
     def properties(self) -> dict[str, NodePropertyValue]:
         """Live property values, keyed by property id (e.g. ``"ST"``).
 
         For native nodes these are merged from ``/api/nodes`` + the
         ``/rest/status`` overlay during initial load. Plugin nodes get
-        all values from ``/rest/status``. WebSocket events update them
-        in place at runtime via :class:`pyisyox.runtime.EventDispatcher`.
+        all values from ``/rest/status``. WebSocket events update the
+        underlying record in place at runtime via
+        :class:`pyisyox.runtime.EventDispatcher`.
+
+        Each value is normalised to its nodedef editor's canonical UOM
+        before being returned — e.g. an Insteon dimmer that reports
+        ``OL``/``ST`` as a UOM-100 0-255 byte is surfaced here as the
+        UOM-51 0-100% value its ``I_OL`` editor (and the ``/cmd`` write
+        surface) uses. Values whose reported UOM already matches the
+        editor pass through unchanged. The returned dict is freshly
+        built on each access; mutate the controller's state via commands,
+        not by writing here.
         """
-        return self._record.properties
+        record_props = self._record.properties
+        return {
+            pid: normalize_property_value(npv, self._editor_for_property(pid))
+            for pid, npv in record_props.items()
+        }
 
     @property
     def status(self) -> NodePropertyValue | None:
         """Shortcut for :attr:`properties`\\ ``[PROP_STATUS]`` — the
-        node's primary status reading (``"ST"``).
+        node's primary status reading (``"ST"``), UOM-normalised the
+        same way :attr:`properties` is.
 
         Returns ``None`` when the node hasn't reported ST yet (common
         for write-only Insteon controllers and plugin nodes that don't
@@ -216,7 +246,10 @@ class Node:
         the property keeps the structured shape so callers can also
         reach ``.uom``, ``.formatted``, etc.
         """
-        return self._record.properties.get(PROP_STATUS)
+        npv = self._record.properties.get(PROP_STATUS)
+        if npv is None:
+            return None
+        return normalize_property_value(npv, self._editor_for_property(PROP_STATUS))
 
     @property
     def nodedef(self) -> NodeDef | None:
@@ -398,6 +431,14 @@ class Node:
         out-of-range values raise :class:`NodeCommandError` before any
         HTTP traffic.
 
+        Each parameter is sent in the form ``/{value}/{uom}`` — the UOM
+        is the one the parameter's editor declares — so the controller
+        does any device-side scaling itself (this is the convention the
+        eisy web UI uses, e.g. ``/cmd/DON/75/51`` to set 75% on a
+        dimmer; ``/cmd/OL/75/51``; ``/cmd/BL/10/25``). Parameters whose
+        editor carries no real unit (UOM ``"0"`` / unset) are sent as a
+        bare ``/{value}`` with no UOM segment.
+
         Args:
             command_id: The IoX command id (e.g. ``"DON"``, ``"DOF"``,
                 ``"CLISPC"``, ``"DISCOVER"``).
@@ -420,7 +461,12 @@ class Node:
             params=params,
             target_label=f"node {self.address!r}",
         )
-        await self._client.send_node_command(self.address, command_id, *encoded)
+        wire_args: list[int | str] = []
+        for raw_value, uom in encoded:
+            wire_args.append(raw_value)
+            if uom and uom != "0":
+                wire_args.append(uom)
+        await self._client.send_node_command(self.address, command_id, *wire_args)
 
     # --- ergonomic wire-convention wrappers ---------------------------
     #
@@ -460,31 +506,22 @@ class Node:
         await self.send_command(CMD_SECURE, 0)
 
     async def set_on_level(self, val: int) -> None:
-        """Set the device's remembered on-level via the legacy ``OL`` command.
+        """Set the device's remembered on-level via the ``OL`` command.
 
-        ``val`` is the **device-native** encoding:
-
-        * **Insteon dimmers** — a 0-255 raw byte (the controller also
-          reports ``OL`` as a UOM-100 byte; ``255`` = 100%).
-        * **Z-Wave / Zigbee dimmers, KeypadLinc** — 0-100.
-
-        The profile's ``I_OL`` editor only describes the 0-100%
-        *display* slider (``max=100``), so it would wrongly reject the
-        0-255 byte the Insteon ``/cmd/OL`` endpoint expects — the editor
-        codec is therefore **not** applied here; the value is sent to
-        ``/rest/nodes/{addr}/cmd/OL/{val}`` verbatim. Callers working in
-        percentages scale to the device's encoding first (the consumer
-        knows whether the ``OL`` property reports as a byte).
+        ``val`` is the **percentage** ``0-100`` — the unit the ``I_OL``
+        editor (and therefore the ``/cmd/OL`` write surface) uses. The
+        command is sent as ``/cmd/OL/{val}/51`` and the controller does
+        any device-side scaling (Insteon dimmers internally store a
+        0-255 byte; ``75`` → byte ``191`` → reported back as
+        ``OL uom="100" 191``, which :attr:`properties` normalises back
+        to ``75`` for you).
 
         Raises:
-            NodeCommandError: when ``val`` is outside ``0-255`` (a
-                coarse sanity bound; the controller enforces the real
-                per-device range).
+            NodeCommandError: when this node's nodedef doesn't accept
+                ``OL``, or ``val`` falls outside the ``I_OL`` editor's
+                range (``0-100``).
         """
-        raw = int(val)
-        if not 0 <= raw <= 255:
-            raise NodeCommandError(f"node {self.address!r}: on-level {val!r} is out of range 0-255")
-        await self._client.send_node_command(self.address, PROP_ON_LEVEL, raw)
+        await self.send_command(PROP_ON_LEVEL, val)
 
     async def set_ramp_rate(self, val: int) -> None:
         """Set the device's ramp rate.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -289,10 +289,13 @@ async def test_feed_event_frame_updates_node_property() -> None:
     )
     assert event is not None
 
-    # Re-fetch the runtime Node — properties dict reflects the WS update.
+    # Re-fetch the runtime Node — properties dict reflects the WS update,
+    # UOM-normalised to the nodedef editor's canonical unit: the frame
+    # reported the raw UOM-100 byte 255, surfaced as UOM-51 100%.
     node_after = controller.nodes["3D 7D 87 1"]
     assert node_after.properties["ST"].formatted == "On"
-    assert node_after.properties["ST"].value == "255"
+    assert node_after.properties["ST"].value == "100"
+    assert node_after.properties["ST"].uom == "51"
 
     await controller.stop()
 

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -8,6 +8,7 @@ node registry.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -273,6 +274,25 @@ def test_dispatcher_overlays_property_into_node_record() -> None:
     assert prop.value == "255"
     assert prop.formatted == "On"
     assert prop.uom == "100"
+
+
+def test_dispatcher_logs_property_update_at_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """A node-property frame gets a DEBUG line (the raw WS frame itself
+    only logs at VERBOSE) — using the controller's formatted value plus
+    the raw value / uom for context."""
+    nodes = {"3D 7D 87 1": _make_record("3D 7D 87 1")}
+    dispatcher = EventDispatcher(nodes)
+    xml = (
+        '<Event seqnum="1"><control>OL</control>'
+        '<action uom="100" prec="0">191</action>'
+        "<node>3D 7D 87 1</node>"
+        "<fmtAct>75%</fmtAct><fmtName>On Level</fmtName></Event>"
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="pyisyox.runtime.events"):
+        dispatcher.feed(xml)
+
+    assert "Node 3D 7D 87 1 OL -> 75% (raw=191, uom=100)" in caplog.text
 
 
 def test_dispatcher_propagates_prec_into_node_record() -> None:

--- a/tests/test_runtime/test_lifecycle.py
+++ b/tests/test_runtime/test_lifecycle.py
@@ -163,6 +163,40 @@ def test_lifecycle_listener_ignores_property_events() -> None:
     assert received == []
 
 
+def test_node_enabled_frame_updates_record_and_event() -> None:
+    """An ``EN`` lifecycle frame flips ``NodeRecord.enabled`` in place
+    (so ``Node.enabled`` tracks admin-console / REST changes) and the
+    emitted event carries the parsed direction."""
+    record = _stub_record("3D 7D 87 1")
+    assert record.enabled is True
+    dispatcher = EventDispatcher({"3D 7D 87 1": record})
+    received: list[NodeLifecycleEvent] = []
+    dispatcher.add_lifecycle_listener(received.append)
+
+    dispatcher.feed(
+        '<Event seqnum="7"><control>_3</control><action>EN</action>'
+        "<node>3D 7D 87 1</node><eventInfo><enabled>false</enabled></eventInfo></Event>"
+    )
+    assert record.enabled is False
+    assert received[-1].action is NodeLifecycleAction.NODE_ENABLED
+    assert received[-1].enabled is False
+
+    dispatcher.feed(
+        '<Event seqnum="8"><control>_3</control><action>EN</action>'
+        "<node>3D 7D 87 1</node><eventInfo><enabled>true</enabled></eventInfo></Event>"
+    )
+    assert record.enabled is True
+    assert received[-1].enabled is True
+
+
+def test_node_enabled_frame_without_flag_leaves_record_untouched() -> None:
+    record = _stub_record("X")
+    record.enabled = False
+    dispatcher = EventDispatcher({"X": record})
+    dispatcher.feed('<Event seqnum="1"><control>_3</control><action>EN</action><node>X</node></Event>')
+    assert record.enabled is False  # no <enabled> → no change
+
+
 def test_lifecycle_unsubscribe_stops_delivery() -> None:
     dispatcher = EventDispatcher({})
     received: list[NodeLifecycleEvent] = []

--- a/tests/test_runtime/test_node.py
+++ b/tests/test_runtime/test_node.py
@@ -71,6 +71,28 @@ def test_node_exposes_record_fields(real_profile: Profile) -> None:
     assert node.properties["ST"].formatted == "Off"
 
 
+def test_node_properties_normalize_byte_to_percent(real_profile: Profile) -> None:
+    """A DimmerLampSwitch reports ``OL``/``ST`` as a UOM-100 0-255 byte,
+    but the ``I_OL`` editor (and the /cmd surface) speak UOM-51 0-100% —
+    ``Node.properties`` surfaces the normalised percentage."""
+    record = _make_record(
+        nodedef_id="DimmerLampSwitch",
+        properties={
+            "OL": NodePropertyValue(id="OL", value="191", formatted="75%", uom="100"),
+            "ST": NodePropertyValue(id="ST", value="255", formatted="On", uom="100"),
+        },
+    )
+    node = Node.from_record(record, real_profile, _make_client(FakeSession(BASE)))
+
+    assert node.properties["OL"].value == "75"
+    assert node.properties["OL"].uom == "51"
+    assert node.properties["ST"].value == "100"
+    assert node.status is not None
+    assert node.status.value == "100"
+    # underlying record is left untouched (normalisation is on read)
+    assert record.properties["OL"].value == "191"
+
+
 def test_node_unresolved_nodedef_returns_none(real_profile: Profile) -> None:
     record = _make_record(nodedef_id="NoSuchType", family_id="1", instance_id="1")
     node = Node.from_record(record, real_profile, _make_client(FakeSession(BASE)))
@@ -97,17 +119,17 @@ async def test_send_command_dof_no_params(real_profile: Profile) -> None:
 
 @pytest.mark.asyncio
 async def test_send_command_don_with_optional_level(real_profile: Profile) -> None:
-    """KeypadDimmer DON command takes an optional I_OL parameter (0-100).
-    Verify the level appears as the URL's last path segment."""
+    """KeypadDimmer DON takes an optional I_OL_PARAM parameter (0-100%,
+    UOM 51). Verify the value and its UOM trail the URL as ``/75/51``."""
     record = _make_record()
     session = FakeSession(BASE)
-    session.set_route("GET", "/rest/nodes/3D%207D%2087%201/cmd/DON/75", 200, "<ok/>")
+    session.set_route("GET", "/rest/nodes/3D%207D%2087%201/cmd/DON/75/51", 200, "<ok/>")
     node = Node.from_record(record, real_profile, _make_client(session))
 
     await node.send_command("DON", 75)
 
     _, path, _ = session.calls[0]
-    assert path.endswith("/cmd/DON/75")
+    assert path.endswith("/cmd/DON/75/51")
 
 
 @pytest.mark.asyncio
@@ -116,13 +138,13 @@ async def test_send_command_thermostat_clismode_via_enum_name(real_profile: Prof
     and translate it via the editor codec to the integer 1."""
     record = _make_record(nodedef_id="Thermostat", family_id="1", instance_id="1")
     session = FakeSession(BASE)
-    session.set_route("GET", "/rest/nodes/3D%207D%2087%201/cmd/CLIMD/1", 200, "<ok/>")
+    session.set_route("GET", "/rest/nodes/3D%207D%2087%201/cmd/CLIMD/1/98", 200, "<ok/>")
     node = Node.from_record(record, real_profile, _make_client(session))
 
     await node.send_command("CLIMD", "Heat")
 
     _, path, _ = session.calls[0]
-    assert path.endswith("/cmd/CLIMD/1")
+    assert path.endswith("/cmd/CLIMD/1/98")
 
 
 @pytest.mark.asyncio
@@ -328,31 +350,33 @@ async def test_client_set_node_enabled_quotes_address() -> None:
     assert path == "/rest/nodes/3D%207D%2087%201/disable"
 
 
-# --- set_on_level (raw byte, codec-bypassed) -----------------------------
+# --- set_on_level (percent + UOM via the editor codec) -------------------
 
 
 @pytest.mark.asyncio
-async def test_set_on_level_sends_raw_byte(real_profile: Profile) -> None:
-    """``set_on_level`` sends the value verbatim to ``/cmd/OL/{val}`` —
-    the ``I_OL`` editor's ``max=100`` (the display slider) does *not*
-    clamp it, so the 0-255 byte an Insteon dimmer wants gets through."""
+async def test_set_on_level_sends_percent_with_uom(real_profile: Profile) -> None:
+    """``set_on_level`` routes through ``send_command(OL, …)`` — the
+    ``I_OL`` editor (UOM 51) validates 0-100 and the value is sent as
+    ``/cmd/OL/{val}/51``; the controller does the device-side scaling."""
     record = _make_record(nodedef_id="DimmerLampSwitch", family_id="1", instance_id="1")
     session = FakeSession(BASE)
-    session.set_route("GET", "/rest/nodes/3D%207D%2087%201/cmd/OL/255", 200, "<ok/>")
+    session.set_route("GET", "/rest/nodes/3D%207D%2087%201/cmd/OL/75/51", 200, "<ok/>")
     node = Node.from_record(record, real_profile, _make_client(session))
 
-    await node.set_on_level(255)
+    await node.set_on_level(75)
 
     method, path, _ = session.calls[0]
     assert method == "GET"
-    assert path == "/rest/nodes/3D%207D%2087%201/cmd/OL/255"
+    assert path == "/rest/nodes/3D%207D%2087%201/cmd/OL/75/51"
 
 
 @pytest.mark.asyncio
 async def test_set_on_level_rejects_out_of_range(real_profile: Profile) -> None:
+    """The ``I_OL`` editor's ``max=100`` rejects an out-of-range value
+    before any HTTP call fires."""
     record = _make_record(nodedef_id="DimmerLampSwitch", family_id="1", instance_id="1")
     session = FakeSession(BASE)
     node = Node.from_record(record, real_profile, _make_client(session))
-    with pytest.raises(NodeCommandError, match="out of range 0-255"):
+    with pytest.raises(NodeCommandError, match="above max"):
         await node.set_on_level(300)
     assert session.calls == [], "must short-circuit before HTTP"

--- a/tests/test_runtime/test_node_introspection.py
+++ b/tests/test_runtime/test_node_introspection.py
@@ -82,9 +82,7 @@ def _make_node(record: NodeRecord, profile: Profile, session: FakeSession | None
         ("", Protocol.UNKNOWN),  # no family id
     ],
 )
-def test_protocol_classifies_by_family_id(
-    real_profile: Profile, family_id: str, expected: Protocol
-) -> None:
+def test_protocol_classifies_by_family_id(real_profile: Profile, family_id: str, expected: Protocol) -> None:
     node = _make_node(_make_record(family_id=family_id), real_profile)
     result = node.protocol
     assert result is expected
@@ -203,9 +201,7 @@ def test_primary_address_resolves_from_pnode(real_profile: Profile) -> None:
     device-primary address for multi-button physicals (KeypadLinc,
     RemoteLinc, FanLinc). Returns the primary only when this node is a
     sub-button (``pnode != address``)."""
-    sub_button = _make_node(
-        _make_record(address="AA BB CC 2", pnode="AA BB CC 1"), real_profile
-    )
+    sub_button = _make_node(_make_record(address="AA BB CC 2", pnode="AA BB CC 1"), real_profile)
     assert sub_button.primary_address == "AA BB CC 1"
 
 
@@ -213,9 +209,7 @@ def test_primary_address_none_for_device_root(real_profile: Profile) -> None:
     """The device primary has ``pnode == address`` — surface as ``None`` so
     consumers can use ``primary_address is not None`` as a sub-button
     indicator. ``pnode`` absent is treated the same way."""
-    root_with_self_pnode = _make_node(
-        _make_record(address="AA BB CC 1", pnode="AA BB CC 1"), real_profile
-    )
+    root_with_self_pnode = _make_node(_make_record(address="AA BB CC 1", pnode="AA BB CC 1"), real_profile)
     assert root_with_self_pnode.primary_address is None
 
     root_without_pnode = _make_node(_make_record(pnode=None), real_profile)
@@ -300,25 +294,25 @@ def _pin_get(session: FakeSession, path: str) -> None:
 @pytest.mark.asyncio
 async def test_set_climate_mode_routes_to_climd_with_enum(real_profile: Profile) -> None:
     session = FakeSession(BASE)
-    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/CLIMD/1")
+    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/CLIMD/1/98")
     node = _make_node(_make_record(nodedef_id="Thermostat"), real_profile, session)
     await node.set_climate_mode("Heat")
-    assert any("/cmd/CLIMD/1" in path for _, path, _ in session.calls)
+    assert any("/cmd/CLIMD/1/98" in path for _, path, _ in session.calls)
 
 
 @pytest.mark.asyncio
 async def test_set_climate_mode_accepts_int(real_profile: Profile) -> None:
     session = FakeSession(BASE)
-    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/CLIMD/2")
+    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/CLIMD/2/98")
     node = _make_node(_make_record(nodedef_id="Thermostat"), real_profile, session)
     await node.set_climate_mode(2)
-    assert any("/cmd/CLIMD/2" in path for _, path, _ in session.calls)
+    assert any("/cmd/CLIMD/2/98" in path for _, path, _ in session.calls)
 
 
 @pytest.mark.asyncio
 async def test_set_fan_mode_routes_to_clifs(real_profile: Profile) -> None:
     session = FakeSession(BASE)
-    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/CLIFS/8")
+    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/CLIFS/8/99")
     node = _make_node(_make_record(nodedef_id="Thermostat"), real_profile, session)
     await node.set_fan_mode("Auto")
     assert any("/cmd/CLIFS/" in path for _, path, _ in session.calls)
@@ -384,7 +378,7 @@ def test_is_dimmable_false_when_st_property_missing_from_nodedef(real_profile: P
 async def test_set_climate_setpoint_heat_routes_to_clisph(real_profile: Profile) -> None:
     session = FakeSession(BASE)
     node = _make_node(_make_record(nodedef_id="Thermostat"), real_profile, session)
-    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/CLISPH/70")
+    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/CLISPH/70/14")
     await node.set_climate_setpoint_heat(70)
     assert any("/cmd/CLISPH/" in path for _, path, _ in session.calls)
 
@@ -393,7 +387,7 @@ async def test_set_climate_setpoint_heat_routes_to_clisph(real_profile: Profile)
 async def test_set_climate_setpoint_cool_routes_to_clispc(real_profile: Profile) -> None:
     session = FakeSession(BASE)
     node = _make_node(_make_record(nodedef_id="Thermostat"), real_profile, session)
-    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/CLISPC/70")
+    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/CLISPC/70/14")
     await node.set_climate_setpoint_cool(70)
     assert any("/cmd/CLISPC/" in path for _, path, _ in session.calls)
 
@@ -402,7 +396,7 @@ async def test_set_climate_setpoint_cool_routes_to_clispc(real_profile: Profile)
 async def test_set_on_level_routes_to_ol(real_profile: Profile) -> None:
     session = FakeSession(BASE)
     node = _make_node(_make_record(nodedef_id="DimmerLampSwitch"), real_profile, session)
-    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/OL/50")
+    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/OL/50/51")
     await node.set_on_level(50)
     assert any("/cmd/OL/" in path for _, path, _ in session.calls)
 
@@ -411,7 +405,7 @@ async def test_set_on_level_routes_to_ol(real_profile: Profile) -> None:
 async def test_set_ramp_rate_routes_to_rr(real_profile: Profile) -> None:
     session = FakeSession(BASE)
     node = _make_node(_make_record(nodedef_id="DimmerLampSwitch"), real_profile, session)
-    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/RR/5")
+    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/RR/5/25")
     await node.set_ramp_rate(5)
     assert any("/cmd/RR/" in path for _, path, _ in session.calls)
 
@@ -420,7 +414,7 @@ async def test_set_ramp_rate_routes_to_rr(real_profile: Profile) -> None:
 async def test_set_backlight_routes_to_bl(real_profile: Profile) -> None:
     session = FakeSession(BASE)
     node = _make_node(_make_record(nodedef_id="DimmerLampSwitch"), real_profile, session)
-    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/BL/50")
+    _pin_get(session, "/rest/nodes/AA%20BB%20CC%201/cmd/BL/50/51")
     await node.set_backlight(50)
     assert any("/cmd/BL/" in path for _, path, _ in session.calls)
 

--- a/tests/test_runtime/test_normalize.py
+++ b/tests/test_runtime/test_normalize.py
@@ -1,0 +1,60 @@
+"""Tests for :func:`pyisyox.runtime._normalize.normalize_property_value`."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyisyox.client import NodePropertyValue
+from pyisyox.runtime._normalize import normalize_property_value
+from pyisyox.schema.editor import Editor, EditorRange
+
+
+def _editor(*ranges: EditorRange) -> Editor:
+    return Editor(id="X", ranges=list(ranges))
+
+
+PCT = EditorRange(uom="51", min=0.0, max=100.0)
+BYTE = EditorRange(uom="100", min=0.0, max=255.0)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_value"),
+    [("255", "100"), ("191", "75"), ("153", "60"), ("0", "0"), ("128", "50")],
+)
+def test_byte_reported_against_percent_editor_is_scaled(raw: str, expected_value: str) -> None:
+    prop = NodePropertyValue(id="OL", value=raw, formatted=f"{expected_value}%", uom="100", precision=0)
+    out = normalize_property_value(prop, _editor(PCT))
+    assert out.value == expected_value
+    assert out.uom == "51"
+    assert out.precision == 0
+    assert out.formatted == f"{expected_value}%"  # display string preserved verbatim
+
+
+def test_matching_uom_passes_through_unchanged() -> None:
+    prop = NodePropertyValue(id="OL", value="75", uom="51", precision=0)
+    assert normalize_property_value(prop, _editor(PCT)) is prop
+
+
+def test_uom_in_one_of_multiple_ranges_passes_through() -> None:
+    """A dual-range editor that *declares* the reported UOM (e.g. ZB_OL's
+    ``[{uom:51},{uom:100}]``) needs no conversion — the byte form is one
+    of its own ranges."""
+    prop = NodePropertyValue(id="OL", value="191", uom="100", precision=0)
+    assert normalize_property_value(prop, _editor(PCT, BYTE)) is prop
+
+
+def test_no_editor_passes_through() -> None:
+    prop = NodePropertyValue(id="GV1", value="191", uom="100")
+    assert normalize_property_value(prop, None) is prop
+
+
+def test_unknown_conversion_pair_passes_through() -> None:
+    """Reported UOM differs from the editor's, but no conversion is
+    defined for the pair — leave it alone rather than guess."""
+    prop = NodePropertyValue(id="ST", value="42", uom="56", precision=0)
+    assert normalize_property_value(prop, _editor(PCT)) is prop
+
+
+def test_non_numeric_value_passes_through() -> None:
+    prop = NodePropertyValue(id="ST", value="", uom="100", precision=0)
+    assert normalize_property_value(prop, _editor(PCT)) is prop


### PR DESCRIPTION
## Why

Real `eisy` captures show IoX 6 exchanges values UOM-tagged in both directions, asymmetrically:

- **Write**: the web UI issues `/cmd/{cmd}/{value}/{uom}` — `DON/75/51`, `OL/75/51`, `BL/10/25` — and the controller does any device-side scaling. The bare `/cmd/OL/100` form is the *legacy* interpretation (treats `100` as a raw byte → ~39%), which is what surfaced as the "On Level lands at 39%" bug.
- **Read**: a property comes back in whatever UOM the *device* uses — an Insteon dimmer reports `OL`/`ST` as a UOM-100 0-255 byte (`191` for "75%"), even though `I_OL` (and the `/cmd` surface) speak UOM-51 0-100%. WS frames are the same (`<action uom="100">191</action>` with `fmtAct="75%"`).

So the editor's UOM is the *input/display* convention; you can't infer the write UOM from the reported property — you take it from the editor.

## What

- **`Node.send_command`** interleaves each parameter with the UOM its editor declares (first range): `send_command("DON", 75)` → `GET /rest/nodes/{addr}/cmd/DON/75/51`. Enum params still go through the codec's name→int lookup first, then get the UOM appended. Params whose editor has no real unit (UOM `"0"` / unset) are sent bare. `encode_command_params` now returns `(raw_value, uom)` pairs; `IoXClient.send_node_command` accepts `int | str` path segments.
- **`set_on_level(val)`** is now a plain `send_command(PROP_ON_LEVEL, val)` wrapper — `val` is the 0-100 percentage the `I_OL` editor uses; sent as `/cmd/OL/{val}/51`. Supersedes the raw-byte path from #102 (`#102`'s "send the byte verbatim" was solving the symptom). Raises `NodeCommandError` if the nodedef doesn't accept `OL` or the value is out of the editor's range.
- **`Node.properties` / `Node.status`** normalise each value to its nodedef editor's canonical UOM on read. Conversions live in the new `runtime/_normalize.py`; `_CONVERSIONS` is intentionally tiny (just the 0-255 byte → 0-100 percent pair — `round(raw*100/255)`, matching the `fmtAct` string the controller computes). A reported UOM that already matches one of the editor's ranges (incl. dual-range editors like `ZB_OL` that *declare* both) passes through untouched. The underlying `NodeRecord.properties` keeps the raw reported form; normalisation is on read.

## Tests

- New `tests/test_runtime/test_normalize.py` — byte→percent scaling table + all passthrough cases.
- New `test_node_properties_normalize_byte_to_percent` — runtime `Node.properties`/`status` integration; asserts the record stays raw.
- Updated the command-URL pins (`test_node.py`, `test_node_introspection.py`) to the `/value/uom` form; `test_set_on_level_*` rewritten for the percent-via-codec behaviour; `test_feed_event_frame_updates_node_property` now asserts the WS-frame byte is surfaced normalised.
- 544 passed; ruff / ruff-format / mypy / pylint clean.

## Consumer impact

hacs-udi-iox can drop the write-side `percentage_to_ranged_value` scaling (pass the 0-100 value straight to `set_on_level`); the read-side scaling can go too once it pins a tag carrying this. Manifest stays pinned `6.0.0a3` until the next pre-release.

Follow-ups (not here): evaluate `set_climate_setpoint_*` / `set_ramp_rate` / `set_backlight` under the same lens (they already route through `send_command`, so they get the UOM suffix for free — just want a live thermostat capture to confirm `/cmd/CLISPH/68/17` is accepted); `fan.py` in the consumer hard-codes `SPEED_RANGE=(1,255)` but FanLinc `ST` on IoX-6 is UOM-51 0-100 (separate consumer issue).