### PR TITLE
fix(client): authenticate the /api/config fetch (unbreaks LocalAuth)

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -485,8 +485,16 @@ class IoXClient:
         )
 
     async def _fetch_config(self) -> ControllerConfig:
-        """``GET /api/config`` — minimal, used to confirm IoX 6+ + uuid."""
-        raw = await self._get_json(CONFIG_PATH, authenticated=False)
+        """``GET /api/config`` — minimal, used to confirm IoX 6+ + uuid.
+
+        Authenticated like every other endpoint: ``/api/config`` is
+        gated on both auth modes (``LocalAuth`` HTTP-basic on
+        ``:8443``, ``PortalAuth`` JWT on ``:443``), so an earlier
+        ``authenticated=False`` here 401'd the local-credentials flow.
+        ``_authenticate_once`` is a no-op for ``LocalAuth`` (basic auth
+        attaches per request) and runs the login POST for ``PortalAuth``.
+        """
+        raw = await self._get_json(CONFIG_PATH)
         data = raw.get("data", raw)
         return ControllerConfig(
             uuid=str(data.get("uuid", "")),

--- a/tests/test_client/test_client.py
+++ b/tests/test_client/test_client.py
@@ -34,6 +34,11 @@ async def test_fetch_config_unwraps_data_envelope(session: FakeSession) -> None:
     cfg = await client._fetch_config()
     assert cfg.uuid == "00:21:b9:f2:72:65"
     assert cfg.version == "6.0.0"
+    # ``/api/config`` is auth-gated on both modes — the local-credentials
+    # flow 401'd when this was fetched unauthenticated.
+    _, path, kwargs = session.calls[0]
+    assert path == "/api/config"
+    assert kwargs.get("auth") is not None  # BasicAuth from LocalAuth was attached
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Symptom

`python3 -m pyisyox https://eisy.local:8443 <local-user> <pass>` (LocalAuth / HTTP-basic) fails immediately:

```
pyisyox.client.HTTPError: HTTP 401 from https://eisy.local:8443/api/config
```

## Cause

`IoXClient._fetch_config` fetched `/api/config` with `authenticated=False`, on the assumption that the config endpoint is unauthenticated. It isn't — `/api/config` is gated on **both** auth modes. PortalAuth happened to work (the portal allows an unauthenticated config read on `:443`), but LocalAuth never attaches the `BasicAuth` header when `authenticated=False`, so `:8443/api/config` 401'd before `connect()` could read the controller config at all. Local credentials weren't "toast" — the config preflight was just skipping auth.

## Fix

Drop the `authenticated=False`. `_get_text` then runs `_authenticate_once()` (a no-op for `LocalAuth`, the login POST for `PortalAuth`) and attaches the strategy's request kwargs — the same path every other endpoint uses. Added a regression assertion to `test_fetch_config_unwraps_data_envelope` (the `/api/config` call now carries the `BasicAuth` from `LocalAuth`). 547 tests + ruff/format/mypy/pylint/codespell clean.