### PR TITLE
fix: Z-Wave family parsing + command passthrough for nodedef-less nodes

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -762,15 +762,28 @@ def parse_api_nodes(raw: dict[str, Any]) -> dict[str, NodeRecord]:
 def _node_from_api_json(item: dict[str, Any]) -> NodeRecord:
     """Translate one ``/api/nodes`` element into a :class:`NodeRecord`.
 
-    ``family`` arrives as either ``None`` (native, family/instance default
-    to ``"1"``) or ``{"_": "<id>", "instance": "<inst>"}``.
+    ``family`` on ``/api/nodes`` JSON arrives in three shapes:
+
+    * **absent** — native Insteon nodes omit it; family / instance default
+      to ``"1"``.
+    * **bare scalar** — built-in non-Insteon families give a plain string
+      (or int), e.g. ``"4"`` for Z-Wave or ``"12"`` for Z-Matter-Z-Wave.
+      Built-in families have a single profile instance keyed ``"1"`` (the
+      profile carries ``family 4 / instance 1``, not ``4 / 4``), so the
+      instance is ``"1"`` — only PG3 plugin families carry a distinct
+      instance (their slot id).
+    * **mapping** — PG3 plugin nodes give ``{"_": "<id>", "instance":
+      "<slot>"}`` (the instance is the plugin slot, distinct from the id).
     """
     family = item.get("family")
     if isinstance(family, dict):
         family_id = str(family.get("_", "1"))
         instance_id = str(family.get("instance", family_id))
-    else:
+    elif family in (None, ""):
         family_id = "1"
+        instance_id = "1"
+    else:
+        family_id = str(family)
         instance_id = "1"
 
     parent = item.get("parent")

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -446,12 +446,24 @@ class Node:
                 the command's parameter count (or be zero for
                 parameterless commands like ``DOF``).
 
+        When the node has **no resolved nodedef** (e.g. dynamically
+        provisioned Z-Wave / Z-Matter nodes, whose ``UZW*`` nodedefs
+        aren't published in ``/rest/profiles``), there is nothing to
+        validate against — the command and any params are passed
+        through verbatim (numeric params coerced to ``int``, no UOM
+        segment). This keeps such nodes controllable; the cost is no
+        client-side validation.
+
         Raises:
-            NodeCommandError: When the nodedef is unresolved, the
-                command id isn't on this node's accept list, the
-                parameter count is wrong, or any parameter fails
-                editor validation.
+            NodeCommandError: When the command id isn't on this node's
+                accept list, the parameter count is wrong, or any
+                parameter fails editor validation. (Not raised for
+                nodedef-less nodes — see above.)
         """
+        if self._nodedef is None:
+            passthrough: list[int | str] = [int(p) if isinstance(p, (int, float)) else p for p in params]
+            await self._client.send_node_command(self.address, command_id, *passthrough)
+            return
         encoded = encode_command_params(
             nodedef=self._nodedef,
             profile=self._profile,

--- a/tests/test_client/test_parsers.py
+++ b/tests/test_client/test_parsers.py
@@ -80,6 +80,45 @@ def test_parse_api_nodes_plugin_node_carries_no_properties() -> None:
     assert node.properties == {}, "plugin nodes must arrive empty in /api/nodes"
 
 
+def test_parse_api_nodes_bare_scalar_family() -> None:
+    """Built-in non-Insteon families (Z-Wave, Z-Matter-Z-Wave, …) give
+    ``family`` as a plain string on /api/nodes — profile instance is "1"."""
+    raw = {
+        "data": {
+            "nodes": {
+                "node": [
+                    {
+                        "address": "ZW002_1",
+                        "name": "ZW 002 Dimmer Switch",
+                        "nodeDefId": "UZW000E",
+                        "family": "4",  # bare string, not {"_": ..., "instance": ...}
+                        "type": "4.17.1.0",
+                        "enabled": "true",
+                        "pnode": "ZW002_1",
+                        "property": [
+                            {"id": "ST", "value": "37", "formatted": "37%", "uom": "51"}
+                        ],
+                    },
+                    {
+                        "address": "n012_1",
+                        "name": "ZMatter node",
+                        "nodeDefId": "UZM0001",
+                        "family": 12,  # int form, also handled
+                        "type": "12.1.1.0",
+                        "enabled": "true",
+                    },
+                ]
+            }
+        }
+    }
+    nodes = parse_api_nodes(raw)
+    zw = nodes["ZW002_1"]
+    assert (zw.family_id, zw.instance_id) == ("4", "1")
+    assert zw.properties["ST"].value == "37"
+    zm = nodes["n012_1"]
+    assert (zm.family_id, zm.instance_id) == ("12", "1")
+
+
 def test_parse_api_nodes_handles_empty_payload() -> None:
     assert parse_api_nodes({}) == {}
     assert parse_api_nodes({"data": {}}) == {}

--- a/tests/test_runtime/test_node.py
+++ b/tests/test_runtime/test_node.py
@@ -178,11 +178,26 @@ async def test_send_command_unknown_command_id_raises(real_profile: Profile) -> 
 
 
 @pytest.mark.asyncio
-async def test_send_command_no_nodedef_raises(real_profile: Profile) -> None:
-    record = _make_record(nodedef_id="NoSuchType")
-    node = Node.from_record(record, real_profile, _make_client(FakeSession(BASE)))
-    with pytest.raises(NodeCommandError, match="no nodedef resolved"):
-        await node.send_command("DON")
+async def test_send_command_no_nodedef_passes_through(real_profile: Profile) -> None:
+    """A node with no resolved nodedef (e.g. a dynamic Z-Wave node whose
+    ``UZW*`` nodedef isn't published in ``/rest/profiles``) still issues
+    the command — params verbatim, numeric coerced to int, no UOM."""
+    record = _make_record(
+        address="ZW003_1", nodedef_id="UZW0009", family_id="4", instance_id="1"
+    )
+    session = FakeSession(BASE)
+    session.set_route("GET", "/rest/nodes/ZW003_1/cmd/DON/100", 200, "<ok/>")
+    session.set_route("GET", "/rest/nodes/ZW003_1/cmd/DOF", 200, "<ok/>")
+    node = Node.from_record(record, real_profile, _make_client(session))
+    assert node.nodedef is None
+
+    await node.send_command("DON", 100)
+    await node.send_command("DOF")
+
+    assert [p for _, p, _ in session.calls] == [
+        "/rest/nodes/ZW003_1/cmd/DON/100",
+        "/rest/nodes/ZW003_1/cmd/DOF",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Built-in non-Insteon families (Z-Wave `family "4"`, Z-Matter-Z-Wave `"12"`, …) arrive on `GET /api/nodes` with `family` as a **bare scalar** string/int — not the `{"_": id, "instance": slot}` mapping PG3 plugins use, and not absent like native Insteon. `_node_from_api_json` only handled the mapping/absent shapes, so Z-Wave nodes were defaulted to family/instance `"1"` → wrong protocol, no nodedef resolved.

Even with the right family, the `UZW*` Z-Wave nodedefs aren't published in `/rest/profiles` (tracked separately), so the nodedef stays unresolved — and `Node.send_command` refused outright, leaving Z-Wave switches uncontrollable from consumers (HA `udi_iox`: `cannot send command 'DON' on node 'ZW003_143': no nodedef resolved`).

## Changes

- `client._node_from_api_json`: parse the bare-scalar `family` form — `family_id` = the value, `instance_id` = `"1"`.
- `Node.send_command`: when the node has no resolved nodedef, fall through to a verbatim passthrough (numeric params coerced to `int`, no UOM segment) instead of raising. The validated editor-codec path is unchanged when a nodedef *is* present.
- Tests: updated `test_parse_api_nodes_bare_scalar_family`, replaced `test_send_command_no_nodedef_raises` with `test_send_command_no_nodedef_passes_through`.

Full suite + ruff + mypy green.