### PR TITLE
fix(classifier): surface Insteon momentary verbs (Fast On/Off, Brighten, Dim, Fade) as buttons

### DIFF
--- a/pyisyox/classifier.py
+++ b/pyisyox/classifier.py
@@ -57,9 +57,7 @@ from pyisyox.constants import (
     CMD_FADE_STOP,
     CMD_FADE_UP,
     CMD_OFF,
-    CMD_OFF_FAST,
     CMD_ON,
-    CMD_ON_FAST,
     CMD_QUERY,
     CMD_SECURE,
     PROP_HEAT_COOL_STATE,
@@ -150,7 +148,15 @@ class ClassificationResult:
 _QUERY_CMDS = frozenset({CMD_QUERY})
 
 _LIGHT_DIMMER_HINTS = frozenset({CMD_BRIGHTEN, CMD_DIM, CMD_FADE_UP, CMD_FADE_DOWN, CMD_FADE_STOP})
-_LIGHT_SWITCH_CMDS = frozenset({CMD_ON, CMD_OFF, CMD_ON_FAST, CMD_OFF_FAST}) | _LIGHT_DIMMER_HINTS
+#: Commands the light/switch controllable platform actually maps onto
+#: its on/off surface. ``DFON``/``DFOF`` ("fast on/off") and the
+#: momentary paddle-simulation verbs (``BRT``/``DIM``/``FDUP``/
+#: ``FDDOWN``/``FDSTOP``) deliberately stay *out* of this set — they
+#: have no HA light/switch equivalent, so the classifier lets them
+#: fall through to ``buttons`` (one HA ``button`` entity each) rather
+#: than absorbing and hiding them. They still feed dimmer *detection*
+#: via :data:`_LIGHT_DIMMER_HINTS`.
+_LIGHT_SWITCH_CMDS = frozenset({CMD_ON, CMD_OFF})
 #: On a thermostat ``BRT``/``DIM`` mean setpoint up/down, not light
 #: dimming. ``CLISPC``/``CLISPH`` are reported as properties *and*
 #: accepted as setpoint commands (IoX dual-purposes the id), as are

--- a/tests/test_schema/test_classifier.py
+++ b/tests/test_schema/test_classifier.py
@@ -99,6 +99,14 @@ def test_insteon_dimmer_is_light_with_filtered_state(profile: Profile) -> None:
     res = classify(nd, find_editor=_resolver(profile, "1", "1"))
     assert res.controllable is ControllablePlatform.LIGHT
 
+    # The light entity only claims DON/DOF. "Fast on/off" and the
+    # momentary paddle verbs have no HA light equivalent, so they fall
+    # through to buttons instead of being swallowed by the platform.
+    assert res.controllable_command_ids == frozenset({"DON", "DOF"})
+    button_ids = {c.id for c in res.buttons}
+    assert {"DFON", "DFOF", "BRT", "DIM", "FDUP", "FDDOWN", "FDSTOP"} <= button_ids
+    assert "DON" not in button_ids and "DOF" not in button_ids and "QUERY" not in button_ids
+
     reading_ids = {r.property.id for r in res.readings}
     assert "ST" not in reading_ids
     assert "OL" not in reading_ids


### PR DESCRIPTION
The light/switch controllable platform was claiming the full
`{DON, DOF, DFON, DFOF, BRT, DIM, FDUP, FDDOWN, FDSTOP}` command set as
`controllable_command_ids`, so `classify()` subtracted all of them from button
candidates. "Fast On/Off" and the momentary paddle-simulation verbs (Brighten /
Dim / Fade Up / Fade Down / Fade Stop) were absorbed into the platform and never
reached `ClassificationResult.buttons` — and since no consumer exposes them on
the light entity, they vanished entirely.

Narrow the claimed set to `{DON, DOF}` — the only commands an HA light/switch
entity actually maps. The rest are parameterless on Insteon dimmers, so they
fall through to `buttons` (consumers wire one HA `button` entity each; the
intent is for those extras to be disabled-by-default). `_LIGHT_DIMMER_HINTS`
still feeds dimmer-vs-switch detection, unchanged.

Test: `test_insteon_dimmer_is_light_with_filtered_state` now asserts
`controllable_command_ids == {DON, DOF}` and that DFON/DFOF/BRT/DIM/FD* land in
`buttons`. Full suite + ruff + mypy green.