### PR TITLE
feat: resolve Z-Wave NLS labels for dynamic nodedefs (#112)

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
@@ -51,6 +52,7 @@ from pyisyox.paths import (
     CONFIG_PATH,
     NETWORK_RESOURCE_ITEM_PATH,
     NETWORKING_RESOURCES_PATH,
+    NLS_PATH,
     NODE_COMMAND_PATH,
     NODE_DISABLE_PATH,
     NODE_ENABLE_PATH,
@@ -69,8 +71,10 @@ from pyisyox.paths import (
 )
 from pyisyox.redactor import redact_sensitive
 from pyisyox.schema import (
+    GLOBAL_NLS_FAMILY_ID,
     Command,
     CommandParameter,
+    NLSTable,
     NodeCommands,
     NodeDef,
     NodeLinks,
@@ -547,7 +551,49 @@ class IoXClient:
                         instance_id,
                         path,
                     )
+                    await self._apply_family_nls(profile, family_id, instance_id, nodedefs.values())
                     break
+
+    async def _apply_family_nls(
+        self, profile: Profile, family_id: str, instance_id: str, nodedefs: Iterable[NodeDef]
+    ) -> None:
+        """Fill in NLS labels on dynamically-loaded nodedefs.
+
+        The ``UZW*`` nodedefs parsed from ``def/get`` XML carry no
+        command / property / display labels — those live in the per-family
+        NLS string tables. Fetch the GLOBAL table (radio-independent
+        command + status names) and overlay the radio family's table
+        (device-class overrides + enum names) on top, store it on
+        ``profile.nls`` (so :meth:`Profile.find_editor` can resolve encoded
+        editors' enum names from it), then resolve each nodedef's
+        ``Command.name`` (sends + accepts), ``NodeProperty.name``, and
+        ``NodeDef.name``. Best-effort: a missing table (404) just leaves
+        the relevant labels blank — consumers fall back to the id.
+        """
+        table = NLSTable()
+        for fam in (GLOBAL_NLS_FAMILY_ID, family_id):
+            text = await self._get_text_or_empty(NLS_PATH.format(family=fam, instance=instance_id))
+            if text.strip():
+                table = table.overlay(NLSTable.parse(text))
+        if not table.entries:
+            return
+        profile.nls = profile.nls.overlay(table)
+        for nodedef in nodedefs:
+            base = nodedef.nls_key
+            if not nodedef.name and base:
+                resolved = table.nodedef_name(base)
+                if resolved:
+                    nodedef.name = resolved
+            for command in (*nodedef.cmds.sends, *nodedef.cmds.accepts):
+                if not command.name:
+                    resolved = table.command_name(command.id, base)
+                    if resolved:
+                        command.name = resolved
+            for prop in nodedef.properties.values():
+                if not prop.name:
+                    resolved = table.property_name(prop.id, base)
+                    if resolved:
+                        prop.name = resolved
 
     async def _fetch_config(self) -> ControllerConfig:
         """``GET /api/config`` — minimal, used to confirm IoX 6+ + uuid.

--- a/pyisyox/paths.py
+++ b/pyisyox/paths.py
@@ -58,6 +58,16 @@ ZMATTER_ZWAVE_NODEDEFS_PATH = "/rest/zmatter/zwave/node/{address}/def/get"
 #: records to fill missing property values (especially for plugin nodes).
 REST_STATUS_PATH = "/rest/status"
 
+#: ``GET /rest/profiles/family/{family}/profile/{instance}/download/nls/en_US.txt``
+#: — the per-family NLS string table (flat ``KEY = VALUE`` text). Family
+#: ``-1`` is GLOBAL (radio-independent command / status labels); a
+#: per-radio family (``4`` Z-Wave, ``12`` Z-Matter) overlays it with
+#: device-class overrides + editor enum names. Only fetched for
+#: dynamically-loaded Z-Wave nodedefs, whose ``UZW*`` commands arrive
+#: label-less (``/rest/profiles`` bakes its families' labels inline).
+#: 404 tolerated.
+NLS_PATH = "/rest/profiles/family/{family}/profile/{instance}/download/nls/en_US.txt"
+
 #: ``GET /rest/networking/resources`` — optional networking module.
 #: 404 / 503 tolerated; load doesn't abort if the module is absent.
 NETWORKING_RESOURCES_PATH = "/rest/networking/resources"

--- a/pyisyox/schema/__init__.py
+++ b/pyisyox/schema/__init__.py
@@ -14,11 +14,13 @@ decoding and command-parameter encoding with subset/range validation.
 from pyisyox.schema.cmd import Command, CommandParameter
 from pyisyox.schema.editor import Editor, EditorCodecError, EditorRange
 from pyisyox.schema.linkdef import LinkDef, LinkParameter
+from pyisyox.schema.nls import GLOBAL_NLS_FAMILY_ID, NLSTable
 from pyisyox.schema.nodedef import NodeCommands, NodeDef, NodeLinks, NodeProperty, Property
 from pyisyox.schema.profile import Family, Instance, Profile
 from pyisyox.schema.uom import PREDEFINED_UOMS, UNKNOWN_UOM, UOMEntry, get_uom
 
 __all__ = [
+    "GLOBAL_NLS_FAMILY_ID",
     "PREDEFINED_UOMS",
     "UNKNOWN_UOM",
     "Command",
@@ -30,6 +32,7 @@ __all__ = [
     "Instance",
     "LinkDef",
     "LinkParameter",
+    "NLSTable",
     "NodeCommands",
     "NodeDef",
     "NodeLinks",

--- a/pyisyox/schema/editor.py
+++ b/pyisyox/schema/editor.py
@@ -115,6 +115,13 @@ class EditorRange:
             then derive a step from ``precision``). Not used by the codec;
             it's a UI hint, surfaced for consumers that build number
             entities.
+        nls_prefix: The NLS string-table prefix this range's enum option
+            names live under (the ``_N_<nls>`` segment of an encoded
+            editor id, or a named editor's index nls). ``names`` stays
+            empty until something resolves it against an NLS table (the
+            controller does it inline for ``/rest/profiles`` families;
+            :meth:`Profile.find_editor` does it for encoded editors when
+            the profile has an NLS table loaded).
     """
 
     uom: str
@@ -124,6 +131,7 @@ class EditorRange:
     subset: set[int] = field(default_factory=set)
     names: dict[int, str] = field(default_factory=dict)
     step: float | None = None
+    nls_prefix: str | None = None
 
     @classmethod
     def from_json(cls, raw: dict) -> EditorRange:
@@ -207,9 +215,10 @@ class Editor:
 
         Returns ``None`` if ``editor_id`` doesn't parse as an encoding
         (so callers can fall back to a table lookup). The ``_N_<nls>``
-        part only names an NLS string table — which pyisyox doesn't
-        resolve — so ``names`` is left empty; range / subset validation
-        still works.
+        segment is captured as ``EditorRange.nls_prefix`` but not
+        resolved here — :meth:`Profile.find_editor` fills ``names`` from
+        it when the profile carries an NLS table. Range / subset
+        validation works regardless.
         """
         if not editor_id.startswith("_"):
             return None
@@ -217,9 +226,12 @@ class Editor:
         if len(parts) < 2 or not parts[0].isdigit() or not parts[1].isdigit():
             return None
         uom, prec_s, rest = parts[0], parts[1], parts[2:]
-        # Peel an optional trailing ``_N_<nls>`` (nls may contain "_").
+        # Peel an optional trailing ``_N_<nls>`` (nls may itself contain "_").
+        nls_prefix: str | None = None
         if "N" in rest:
-            rest = rest[: rest.index("N")]
+            nidx = rest.index("N")
+            nls_prefix = "_".join(rest[nidx + 1 :]) or None
+            rest = rest[:nidx]
         rng_min: float | None = None
         rng_max: float | None = None
         subset: set[int] = set()
@@ -237,7 +249,16 @@ class Editor:
             return None
         return cls(
             id=editor_id,
-            ranges=[EditorRange(uom=uom, min=rng_min, max=rng_max, precision=int(prec_s), subset=subset)],
+            ranges=[
+                EditorRange(
+                    uom=uom,
+                    min=rng_min,
+                    max=rng_max,
+                    precision=int(prec_s),
+                    subset=subset,
+                    nls_prefix=nls_prefix,
+                )
+            ],
         )
 
     def range_for(self, uom: str | None = None) -> EditorRange:

--- a/pyisyox/schema/nls.py
+++ b/pyisyox/schema/nls.py
@@ -1,0 +1,106 @@
+"""IoX NLS (National Language Support) string-table parsing & lookup.
+
+NLS tables are flat ``KEY = VALUE`` text files served per profile family at
+``/rest/profiles/family/{family}/profile/{instance}/download/nls/en_US.txt``.
+They carry the human-readable labels that the structured ``/rest/profiles``
+JSON bakes inline for its families but the *dynamically* generated Z-Wave
+``def/get`` XML does not — a ``UZW*`` nodedef's ``<cmd id="FDUP"/>`` arrives
+with no name, and the label ("Fade Up") only exists in the NLS table.
+
+Key shapes this module resolves (``<base>`` = the nodedef's numeric ``nls``
+attribute, used for device-class overrides):
+
+* ``CMD-[<base>-]<id>-NAME``    command label  (e.g. ``CMD-FDUP-NAME``)
+* ``ST-[<base>-]<id>-NAME``     property label (e.g. ``ST-ST-NAME``)
+* ``NDN-<base>-NAME``           nodedef display name
+* ``<prefix>-<int>``            enum option for an editor that names an NLS
+                                 prefix (encoded ``_N_<prefix>`` or a named
+                                 editor) — e.g. ``IX_DIM_REP-0 = Off``
+
+Family ``-1`` is the GLOBAL table (generic command / status names); a
+per-radio family (``4`` = Z-Wave, ``12`` = Z-Matter) overlays it with
+device-specific overrides and enum names.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+#: Family id of the GLOBAL NLS table (generic, radio-independent labels).
+GLOBAL_NLS_FAMILY_ID = "-1"
+
+
+@dataclass(slots=True)
+class NLSTable:
+    """A parsed NLS string table — a flat ``key -> value`` map plus the
+    handful of IoX key-shape lookups callers actually need.
+    """
+
+    entries: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def parse(cls, text: str) -> NLSTable:
+        """Parse ``KEY = VALUE`` text. Blank lines and ``#`` comments are
+        skipped; the value keeps everything after the first ``=`` (so
+        format strings containing ``=`` survive)."""
+        entries: dict[str, str] = {}
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            key, sep, value = stripped.partition("=")
+            if not sep:
+                continue
+            key = key.strip()
+            if key:
+                entries[key] = value.strip()
+        return cls(entries=entries)
+
+    def overlay(self, other: NLSTable) -> NLSTable:
+        """Return a new table with ``other``'s entries layered on top of
+        this one's (``other`` wins on key collisions)."""
+        merged = dict(self.entries)
+        merged.update(other.entries)
+        return NLSTable(entries=merged)
+
+    def _first(self, *keys: str) -> str | None:
+        for key in keys:
+            value = self.entries.get(key)
+            if value:
+                return value
+        return None
+
+    def command_name(self, command_id: str, base: str | None = None) -> str | None:
+        """Label for a command id, preferring the nodedef-scoped override."""
+        if base:
+            return self._first(f"CMD-{base}-{command_id}-NAME", f"CMD-{command_id}-NAME")
+        return self._first(f"CMD-{command_id}-NAME")
+
+    def property_name(self, property_id: str, base: str | None = None) -> str | None:
+        """Label for a property id, preferring the nodedef-scoped override."""
+        if base:
+            return self._first(f"ST-{base}-{property_id}-NAME", f"ST-{property_id}-NAME")
+        return self._first(f"ST-{property_id}-NAME")
+
+    def nodedef_name(self, base: str) -> str | None:
+        """Default display name for a nodedef by its ``nls`` base."""
+        return self._first(f"NDN-{base}-NAME")
+
+    def enum_names(self, prefix: str) -> dict[int, str]:
+        """All ``<prefix>-<int> = label`` entries as an ``{int: label}`` map.
+
+        Used to resolve the option labels of an editor that references an
+        NLS prefix (e.g. the encoded ``_..._N_IX_DIM_REP`` editor's
+        ``0 -> "Off"`` / ``101 -> "Unknown"``). Non-integer suffixes
+        (``-NAME``, ``-FMT``, …) are ignored.
+        """
+        out: dict[int, str] = {}
+        needle = f"{prefix}-"
+        for key, value in self.entries.items():
+            if not key.startswith(needle):
+                continue
+            try:
+                out[int(key[len(needle) :])] = value
+            except ValueError:
+                continue
+        return out

--- a/pyisyox/schema/nodedef.py
+++ b/pyisyox/schema/nodedef.py
@@ -99,6 +99,11 @@ class NodeDef:
         instance_id: Instance id within the family (typically equal to
             ``family_id`` for built-in families and equal to the plugin slot
             for PG3 instances).
+        name: Default display name (the ``NDN-<nls>-NAME`` NLS entry). Often
+            empty — the live node carries a user-assigned name; this is just
+            the discovery-time default. ``/rest/profiles`` families resolve
+            it inline; for dynamic Z-Wave nodedefs pyisyox fills it from the
+            family NLS table.
         properties: Property slots, keyed by property id.
         cmds: Sent and accepted commands.
         nls_key: Reference key into the NLS string table (e.g. ``"flume2"``);
@@ -111,6 +116,7 @@ class NodeDef:
     id: str
     family_id: str
     instance_id: str
+    name: str = ""
     properties: dict[str, NodeProperty] = field(default_factory=dict)
     cmds: NodeCommands = field(default_factory=NodeCommands)
     nls_key: str | None = None
@@ -151,6 +157,7 @@ class NodeDef:
             id=raw["id"],
             family_id=family_id,
             instance_id=instance_id,
+            name=raw.get("name", ""),
             properties=properties,
             cmds=cmds,
             nls_key=raw.get("nls"),

--- a/pyisyox/schema/profile.py
+++ b/pyisyox/schema/profile.py
@@ -9,11 +9,13 @@ This module knows the JSON wire shape but does no HTTP. Callers pass
 already-fetched dicts to :meth:`Profile.load_from_json`.
 
 Source schema: ``/rest/profiles?include=nodedefs,editors,linkdefs`` JSON.
-The optional ``?include=...,nls`` is honoured by the controller as a
-*reference key* on each nodedef (``nls`` field), but the NLS string table
-is **not** returned and is not needed by pyisyox — every visible string is
-already inline-resolved in property/command ``name`` fields and in WS
-event ``<fmtName>``/``<fmtAct>`` elements.
+For its families the controller inline-resolves every visible string into
+the ``name`` fields, so the NLS string table isn't needed there. The
+*dynamically* generated Z-Wave nodedefs (fetched from ``def/get`` XML, not
+``/rest/profiles``) are the exception: their commands/properties arrive
+label-less, so :mod:`pyisyox.client` fetches the relevant per-family NLS
+tables and stashes the merged result on :attr:`Profile.nls` — used to
+resolve those labels and to fill encoded editors' enum option names.
 """
 
 from __future__ import annotations
@@ -22,6 +24,7 @@ from dataclasses import dataclass, field
 
 from pyisyox.schema.editor import Editor
 from pyisyox.schema.linkdef import LinkDef
+from pyisyox.schema.nls import NLSTable
 from pyisyox.schema.nodedef import NodeDef
 
 
@@ -66,6 +69,9 @@ class Profile:
     timestamp: str = ""
     families: dict[str, Family] = field(default_factory=dict)
     nodedef_lookup: dict[tuple[str, str, str], NodeDef] = field(default_factory=dict)
+    #: Merged NLS string table for any dynamically-loaded families (Z-Wave).
+    #: Empty unless :mod:`pyisyox.client` fetched per-family NLS during load.
+    nls: NLSTable = field(default_factory=NLSTable)
 
     @classmethod
     def load_from_json(cls, raw: dict) -> Profile:
@@ -224,6 +230,9 @@ class Profile:
         if editor_id.startswith("_"):
             encoded = Editor.from_encoded_id(editor_id)
             if encoded is not None:
+                for rng in encoded.ranges:
+                    if rng.nls_prefix and not rng.names:
+                        rng.names = self.nls.enum_names(rng.nls_prefix)
                 return encoded
         editor = self._editor_in(family_id, instance_id, editor_id)
         if editor is not None:

--- a/tests/test_client/test_client.py
+++ b/tests/test_client/test_client.py
@@ -287,6 +287,18 @@ async def test_load_fetches_and_merges_dynamic_zwave_nodedefs(session: FakeSessi
         200,
         (FIXTURE_DIR / "rest_zwave_nodedefs.xml").read_text(),
     )
+    session.set_route(
+        "GET",
+        "/rest/profiles/family/-1/profile/1/download/nls/en_US.txt",
+        200,
+        "# global\nCMD-DON-NAME = On\nCMD-FDUP-NAME = Fade Up\n",
+    )
+    session.set_route(
+        "GET",
+        "/rest/profiles/family/4/profile/1/download/nls/en_US.txt",
+        200,
+        "ST-ST-NAME = Status\n",
+    )
 
     client = IoXClient(BASE, LocalAuth("admin", "p"), session)  # type: ignore[arg-type]
     client._authenticated = True  # skip the connect-time handshake
@@ -296,6 +308,12 @@ async def test_load_fetches_and_merges_dynamic_zwave_nodedefs(session: FakeSessi
     assert nd is not None
     assert any(c.id == "DON" for c in nd.cmds.accepts)
     assert ("GET", "/rest/zwave/node/0/def/get", {}) in [(m, p, {}) for m, p, _ in session.calls]
+    # NLS labels merged onto the dynamically-loaded nodedef + its commands.
+    assert result.profile.nls.command_name("FDUP") == "Fade Up"
+    don = next(c for c in nd.cmds.accepts if c.id == "DON")
+    assert don.name == "On"
+    if "ST" in nd.properties:
+        assert nd.properties["ST"].name == "Status"
 
 
 @pytest.mark.asyncio

--- a/tests/test_schema/test_editor_codec.py
+++ b/tests/test_schema/test_editor_codec.py
@@ -288,14 +288,18 @@ def test_from_encoded_id_subset_bitmasks() -> None:
     )
 
 
-def test_from_encoded_id_trailing_nls_is_ignored_but_tolerated() -> None:
-    """A ``_N_<nls>`` tail (which can itself contain ``_``) names an NLS
-    table pyisyox doesn't resolve — parsing still succeeds, names empty."""
+def test_from_encoded_id_captures_trailing_nls_prefix() -> None:
+    """A ``_N_<nls>`` tail (which can itself contain ``_``) is captured as
+    ``EditorRange.nls_prefix`` — ``names`` stays empty until something
+    resolves it against an NLS table."""
     ed = Editor.from_encoded_id("_51_0_R_0_101_N_IX_DIM_REP")
     assert ed is not None
     rng = ed.ranges[0]
     assert (rng.uom, rng.precision, rng.min, rng.max) == ("51", 0, 0, 101)
+    assert rng.nls_prefix == "IX_DIM_REP"
     assert rng.names == {}
+    # No ``_N_`` segment ⇒ no prefix.
+    assert Editor.from_encoded_id("_1_3").ranges[0].nls_prefix is None  # type: ignore[union-attr]
 
 
 @pytest.mark.parametrize("bad", ["ZW_DIM_PERCENT", "_sys_notify_full", "_17_x", "_17", "_", "", "_17_1_Q_5"])

--- a/tests/test_schema/test_nls.py
+++ b/tests/test_schema/test_nls.py
@@ -1,0 +1,73 @@
+"""Tests for the NLS string-table parser/lookup (:mod:`pyisyox.schema.nls`)."""
+
+from __future__ import annotations
+
+from pyisyox.schema.nls import GLOBAL_NLS_FAMILY_ID, NLSTable
+
+_SAMPLE = """\
+# a comment
+   # an indented comment
+
+CMD-FDUP-NAME = Fade Up
+CMD-DON-NAME = On
+CMD-197-SVOL-NAME = Volume
+ST-ST-NAME = Status
+ST-197-ST-NAME = Current Tone
+NDN-201-NAME = Central Scene Control Button
+IX_DIM_REP-0 = Off
+IX_DIM_REP-101 = Unknown
+IX_DIM_REP-LABEL = ignored
+PGM-CMD-CONFIG-FMT = /num//Parameter ${vo}/ /val// = ${v}/
+malformed line with no equals
+ = empty key
+"""
+
+
+def test_global_family_id_constant() -> None:
+    assert GLOBAL_NLS_FAMILY_ID == "-1"
+
+
+def test_parse_skips_comments_blanks_and_malformed() -> None:
+    table = NLSTable.parse(_SAMPLE)
+    assert "malformed line with no equals" not in table.entries
+    # An empty key (line starting with ``=``) is dropped.
+    assert "" not in table.entries
+    # Values containing ``=`` survive (split on the first ``=`` only).
+    assert table.entries["PGM-CMD-CONFIG-FMT"] == "/num//Parameter ${vo}/ /val// = ${v}/"
+
+
+def test_command_name_prefers_scoped_then_global() -> None:
+    table = NLSTable.parse(_SAMPLE)
+    assert table.command_name("FDUP") == "Fade Up"
+    assert table.command_name("FDUP", base="197") == "Fade Up"  # falls back to global
+    assert table.command_name("SVOL", base="197") == "Volume"  # scoped only
+    assert table.command_name("SVOL") is None
+    assert table.command_name("NOPE") is None
+
+
+def test_property_and_nodedef_names() -> None:
+    table = NLSTable.parse(_SAMPLE)
+    assert table.property_name("ST") == "Status"
+    assert table.property_name("ST", base="197") == "Current Tone"
+    assert table.property_name("ST", base="999") == "Status"  # scoped miss → global
+    assert table.nodedef_name("201") == "Central Scene Control Button"
+    assert table.nodedef_name("999") is None
+
+
+def test_enum_names_only_integer_suffixes() -> None:
+    table = NLSTable.parse(_SAMPLE)
+    assert table.enum_names("IX_DIM_REP") == {0: "Off", 101: "Unknown"}
+    # A near-prefix that isn't followed by ``-`` doesn't bleed in.
+    assert table.enum_names("IX_DIM") == {}
+    assert table.enum_names("NOPE") == {}
+
+
+def test_overlay_other_wins() -> None:
+    base = NLSTable.parse("CMD-DON-NAME = On\nST-ST-NAME = Status\n")
+    over = NLSTable.parse("CMD-DON-NAME = Turn On\nNDN-1-NAME = Thing\n")
+    merged = base.overlay(over)
+    assert merged.command_name("DON") == "Turn On"
+    assert merged.property_name("ST") == "Status"
+    assert merged.nodedef_name("1") == "Thing"
+    # Originals untouched.
+    assert base.command_name("DON") == "On"

--- a/tests/test_schema/test_profile.py
+++ b/tests/test_schema/test_profile.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pyisyox.schema import Profile
+from pyisyox.schema import NLSTable, Profile
 from pyisyox.schema.nodedef import NodeDef
 
 
@@ -89,6 +89,19 @@ def test_find_editor_decodes_encoded_ids(profile: Profile) -> None:
     assert profile.find_editor("_sys_notify_full", "10", "10") is not None
     # A "_"-prefixed string that's neither a valid encoding nor a known id.
     assert profile.find_editor("_17_x", "10", "10") is None
+
+
+def test_find_editor_fills_encoded_enum_names_from_profile_nls(profile: Profile) -> None:
+    """When the profile carries an NLS table, an encoded editor's
+    ``_N_<prefix>`` enum option names are resolved on lookup."""
+    # No NLS loaded ⇒ names stay empty (the encoded id parses fine).
+    bare = profile.find_editor("_51_0_R_0_101_N_IX_DIM_REP", "4", "1")
+    assert bare is not None and bare.ranges[0].names == {}
+
+    profile.nls = NLSTable.parse("IX_DIM_REP-0 = Off\nIX_DIM_REP-101 = Unknown\n")
+    enriched = profile.find_editor("_51_0_R_0_101_N_IX_DIM_REP", "4", "1")
+    assert enriched is not None
+    assert enriched.ranges[0].names == {0: "Off", 101: "Unknown"}
 
 
 def test_register_nodedefs_adds_to_scope_and_lookup(profile: Profile) -> None:


### PR DESCRIPTION
## What

The dynamically-loaded `UZW*` Z-Wave nodedefs (fetched from `/rest/zwave/node/0/def/get` XML, not `/rest/profiles`) arrive **label-less** — so HA surfaces raw verb ids ("Fdup", "Wdu", "Reset") on Z-Wave button/event/sensor entities. The human-readable labels live in the per-family **NLS string tables**, which pyisyox didn't load.

## Changes

- **`pyisyox/schema/nls.py`** — new `NLSTable`: parses the flat `KEY = VALUE` NLS text files and exposes the IoX key-shape lookups (`CMD-[<base>-]<id>-NAME`, `ST-[<base>-]<id>-NAME`, `NDN-<base>-NAME`, `<prefix>-<int>` enum option names). Mirrors the resolution logic from the legacy `node_servers.py` NLS path.
- **`paths.NLS_PATH`** + **`IoXClient._apply_family_nls`** — after loading dynamic Z-Wave nodedefs, GET the GLOBAL (`family/-1`) NLS table, overlay the radio family's (`4`/`12`) on top, stash the merged table on `Profile.nls`, and fill `Command.name` (sends + accepts), `NodeProperty.name`, and `NodeDef.name`. Best-effort — a 404 just leaves labels blank (consumers fall back to the id). Only fires when there are unresolved family-4/12 nodes (same gate as the dynamic-nodedef fetch).
- **`Editor.from_encoded_id`** now captures the `_N_<nls>` segment as `EditorRange.nls_prefix`; **`Profile.find_editor`** resolves an encoded editor's enum option `names` from `Profile.nls` (e.g. the dimmer `ST` editor's `0 → "Off"`, `101 → "Unknown"`).
- **`NodeDef.name`** field added — the `NDN-<nls>-NAME` default display name (`/rest/profiles` families resolve it inline; dynamic ones via NLS).

## Verification

Live against an eisy (legacy Z-Wave radio, 9 `UZW*` nodedefs):
- `UZW000E` dimmer → `DON`→"On", `FDUP`→"Fade Up", `BRT`→"Brighten", `CONFIG`→"Set Configuration", `WDU`→"Write Changes"; `ST` editor enum names `{0: "Off", 101: "Unknown"}`.
- `UZW0016` energy meter → `RESET`→"Reset"; props `ST`→"Status", `TPW`→"Total Energy".
- `UZW0010` scene button → `sends`: `DON3`→"Triple Press (On)", `DON4`→"4 x Press (On)", `FDUP`→"Fade Up", …

`pytest` 577 passed; `ruff` / `mypy` clean. Closes #112.