### PR TITLE
feat: Z-Wave lock-code API on Node namespace

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -66,9 +66,13 @@ from pyisyox.paths import (
     TRIGGERS_PATH,
     VARIABLE_ITEM_PATH,
     VARIABLES_TYPE_PATH,
+    ZMATTER_ZWAVE_LOCK_CODE_DELETE_PATH,
+    ZMATTER_ZWAVE_LOCK_CODE_SET_PATH,
     ZMATTER_ZWAVE_NODEDEFS_PATH,
     ZMATTER_ZWAVE_PARAMETER_GET_PATH,
     ZMATTER_ZWAVE_PARAMETER_SET_PATH,
+    ZWAVE_LOCK_CODE_DELETE_PATH,
+    ZWAVE_LOCK_CODE_SET_PATH,
     ZWAVE_NODEDEFS_PATH,
     ZWAVE_PARAMETER_GET_PATH,
     ZWAVE_PARAMETER_SET_PATH,
@@ -783,6 +787,74 @@ class IoXClient:
             number,
             value,
             size,
+            address,
+            zmatter,
+            path,
+        )
+        body = await self._get_text(path)
+        if _LOGGER.isEnabledFor(LOG_VERBOSE):
+            _LOGGER.log(LOG_VERBOSE, "GET %s body: %s", path, body)
+        return body
+
+    async def set_zwave_lock_code(
+        self,
+        address: str,
+        user_num: int,
+        code: int,
+        *,
+        zmatter: bool = False,
+    ) -> str:
+        """Issue ``GET /rest/(zmatter/)?zwave/node/{addr}/security/user/{n}/set/code/{c}``.
+
+        Program one user-code slot on a Z-Wave lock. The HTTP body is a
+        ``<RestResponse>`` envelope — callers should pass it through
+        :meth:`Node.set_zwave_lock_code`'s parser, which raises on
+        ``succeeded="false"``.
+
+        Args:
+            address: Wire address of the Z-Wave lock node (URL-quoted here).
+            user_num: User-code slot number (device-defined, 1-based).
+            code: Numeric PIN to program into the slot. Stored on the
+                device; pyisyox doesn't read it back.
+            zmatter: ``True`` for Z-Matter (family ``12``) locks.
+        """
+        encoded_addr = quote(address, safe="")
+        path_tmpl = ZMATTER_ZWAVE_LOCK_CODE_SET_PATH if zmatter else ZWAVE_LOCK_CODE_SET_PATH
+        path = path_tmpl.format(address=encoded_addr, user_num=user_num, code=code)
+        _LOGGER.debug(
+            "Z-Wave set lock code user_num=%d on %s (zmatter=%s) -> GET %s",
+            user_num,
+            address,
+            zmatter,
+            path,
+        )
+        body = await self._get_text(path)
+        if _LOGGER.isEnabledFor(LOG_VERBOSE):
+            _LOGGER.log(LOG_VERBOSE, "GET %s body: %s", path, body)
+        return body
+
+    async def delete_zwave_lock_code(
+        self,
+        address: str,
+        user_num: int,
+        *,
+        zmatter: bool = False,
+    ) -> str:
+        """Issue ``GET /rest/(zmatter/)?zwave/node/{addr}/security/user/{n}/delete``.
+
+        Clear one user-code slot on a Z-Wave lock.
+
+        Args:
+            address: Wire address of the Z-Wave lock node (URL-quoted here).
+            user_num: User-code slot number to clear.
+            zmatter: ``True`` for Z-Matter (family ``12``) locks.
+        """
+        encoded_addr = quote(address, safe="")
+        path_tmpl = ZMATTER_ZWAVE_LOCK_CODE_DELETE_PATH if zmatter else ZWAVE_LOCK_CODE_DELETE_PATH
+        path = path_tmpl.format(address=encoded_addr, user_num=user_num)
+        _LOGGER.debug(
+            "Z-Wave delete lock code user_num=%d on %s (zmatter=%s) -> GET %s",
+            user_num,
             address,
             zmatter,
             path,

--- a/pyisyox/paths.py
+++ b/pyisyox/paths.py
@@ -79,6 +79,29 @@ ZMATTER_ZWAVE_PARAMETER_GET_PATH = "/rest/zmatter/zwave/node/{address}/config/qu
 #: hardware-not-verified caveat as above.
 ZMATTER_ZWAVE_PARAMETER_SET_PATH = "/rest/zmatter/zwave/node/{address}/config/set/{number}/{value}/{size}"
 
+#: ``GET /rest/zwave/node/{address}/security/user/{user_num}/set/code/{code}`` —
+#: program a Z-Wave lock's user-code slot. PyISY 3.x verified shape on
+#: the legacy radio; reused untouched on IoX 6+ (no captures show the
+#: surface changed). Lock devices vary in how many slots they expose;
+#: pyisyox doesn't enumerate that — callers pass the slot they want.
+ZWAVE_LOCK_CODE_SET_PATH = "/rest/zwave/node/{address}/security/user/{user_num}/set/code/{code}"
+
+#: ``GET /rest/zwave/node/{address}/security/user/{user_num}/delete`` —
+#: clear a Z-Wave lock's user-code slot. PyISY 3.x verified shape.
+ZWAVE_LOCK_CODE_DELETE_PATH = "/rest/zwave/node/{address}/security/user/{user_num}/delete"
+
+#: ``GET /rest/zmatter/zwave/node/{address}/security/user/{user_num}/set/code/{code}`` —
+#: zmatter-radio counterpart of :data:`ZWAVE_LOCK_CODE_SET_PATH`. Not
+#: yet confirmed against hardware (same caveat as the zmatter parameter
+#: paths); needs a tester with an 800-series lock.
+ZMATTER_ZWAVE_LOCK_CODE_SET_PATH = (
+    "/rest/zmatter/zwave/node/{address}/security/user/{user_num}/set/code/{code}"
+)
+
+#: ``GET /rest/zmatter/zwave/node/{address}/security/user/{user_num}/delete`` —
+#: zmatter-radio counterpart of :data:`ZWAVE_LOCK_CODE_DELETE_PATH`.
+ZMATTER_ZWAVE_LOCK_CODE_DELETE_PATH = "/rest/zmatter/zwave/node/{address}/security/user/{user_num}/delete"
+
 #: ``GET /rest/status`` — XML property table. Merged into ``/api/nodes``
 #: records to fill missing property values (especially for plugin nodes).
 REST_STATUS_PATH = "/rest/status"

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -679,6 +679,79 @@ class Node:
             size,
         )
 
+    # --- Z-Wave lock-code surface ------------------------------------
+    #
+    # Same Z-Wave-only family guard as the parameter surface above. The
+    # wire paths come from PyISY 3.x — assumed valid on IoX 6+ without
+    # captured proof; needs a tester with an enrolled Z-Wave lock for
+    # confirmation. Lock codes are stored on the device; pyisyox doesn't
+    # read them back (the controller doesn't expose a "get code" surface
+    # either — slots are write-only by design for security).
+
+    async def set_zwave_lock_code(self, user_num: int, code: int) -> None:
+        """Program a Z-Wave lock's user-code slot.
+
+        Args:
+            user_num: Slot number (device-defined, 1-based).
+            code: Numeric PIN. Locks vary in min/max digits; the
+                controller forwards the value verbatim.
+
+        Path: ``GET /rest/(zmatter/)?zwave/node/<addr>/security/user/<n>/set/code/<c>``.
+        Raises :class:`NodeCommandError` on a ``<RestResponse
+        succeeded="false">`` envelope so failed programmings aren't
+        silent.
+
+        Raises:
+            NodeCommandError: When this node isn't a Z-Wave node, or
+                the controller rejects the write.
+        """
+        if self.family_id not in _ZWAVE_FAMILY_IDS:
+            raise NodeCommandError(
+                f"node {self.address!r} is not a Z-Wave node "
+                f"(family={self.family_id!r}); lock-code surface is "
+                "Z-Wave-only"
+            )
+        zmatter = self.family_id == NodeFamily.ZMATTER_ZWAVE
+        body = await self._client.set_zwave_lock_code(self.address, user_num, code, zmatter=zmatter)
+        _check_rest_response_succeeded(
+            self.address,
+            body,
+            context=(f"Z-Wave set lock code user_num={user_num} on {self.address!r}"),
+        )
+        _LOGGER.debug(
+            "Z-Wave set lock code on %s succeeded: user_num=%d",
+            self.address,
+            user_num,
+        )
+
+    async def delete_zwave_lock_code(self, user_num: int) -> None:
+        """Clear a Z-Wave lock's user-code slot.
+
+        Path: ``GET /rest/(zmatter/)?zwave/node/<addr>/security/user/<n>/delete``.
+
+        Raises:
+            NodeCommandError: When this node isn't a Z-Wave node, or
+                the controller rejects the delete.
+        """
+        if self.family_id not in _ZWAVE_FAMILY_IDS:
+            raise NodeCommandError(
+                f"node {self.address!r} is not a Z-Wave node "
+                f"(family={self.family_id!r}); lock-code surface is "
+                "Z-Wave-only"
+            )
+        zmatter = self.family_id == NodeFamily.ZMATTER_ZWAVE
+        body = await self._client.delete_zwave_lock_code(self.address, user_num, zmatter=zmatter)
+        _check_rest_response_succeeded(
+            self.address,
+            body,
+            context=(f"Z-Wave delete lock code user_num={user_num} on {self.address!r}"),
+        )
+        _LOGGER.debug(
+            "Z-Wave delete lock code on %s succeeded: user_num=%d",
+            self.address,
+            user_num,
+        )
+
     async def set_enabled(self, enabled: bool) -> None:
         """Enable or disable this node on the controller.
 

--- a/tests/test_runtime/test_node.py
+++ b/tests/test_runtime/test_node.py
@@ -543,6 +543,161 @@ async def test_node_set_zwave_parameter_rejects_invalid_size(
         await node.set_zwave_parameter(1, 0, 3)
 
 
+# --- Z-Wave lock-code wire surface ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_set_zwave_lock_code_uses_legacy_path() -> None:
+    """Family-``4`` writes go to ``/rest/zwave/.../security/user/.../set/code/...``."""
+    session = FakeSession(BASE)
+    session.set_route(
+        "GET",
+        "/rest/zwave/node/ZW100/security/user/3/set/code/1234",
+        200,
+        "<RestResponse succeeded='true'/>",
+    )
+    client = _make_client(session)
+    await client.set_zwave_lock_code("ZW100", 3, 1234)
+    _, path, _ = session.calls[0]
+    assert path == "/rest/zwave/node/ZW100/security/user/3/set/code/1234"
+
+
+@pytest.mark.asyncio
+async def test_client_delete_zwave_lock_code_uses_legacy_path() -> None:
+    session = FakeSession(BASE)
+    session.set_route(
+        "GET",
+        "/rest/zwave/node/ZW100/security/user/3/delete",
+        200,
+        "<RestResponse succeeded='true'/>",
+    )
+    client = _make_client(session)
+    await client.delete_zwave_lock_code("ZW100", 3)
+    _, path, _ = session.calls[0]
+    assert path == "/rest/zwave/node/ZW100/security/user/3/delete"
+
+
+@pytest.mark.asyncio
+async def test_client_set_zwave_lock_code_zmatter_path() -> None:
+    """``zmatter=True`` flips the prefix."""
+    session = FakeSession(BASE)
+    session.set_route(
+        "GET",
+        "/rest/zmatter/zwave/node/ZW100/security/user/3/set/code/1234",
+        200,
+        "<RestResponse succeeded='true'/>",
+    )
+    client = _make_client(session)
+    await client.set_zwave_lock_code("ZW100", 3, 1234, zmatter=True)
+    _, path, _ = session.calls[0]
+    assert path == "/rest/zmatter/zwave/node/ZW100/security/user/3/set/code/1234"
+
+
+@pytest.mark.asyncio
+async def test_node_set_zwave_lock_code_picks_path_by_family(
+    real_profile: Profile,
+) -> None:
+    legacy_session = FakeSession(BASE)
+    legacy_session.set_route(
+        "GET",
+        "/rest/zwave/node/ZW100/security/user/3/set/code/1234",
+        200,
+        "<RestResponse succeeded='true'/>",
+    )
+    legacy_record = _make_record(
+        address="ZW100", nodedef_id="UZW000F", family_id="4"
+    )
+    legacy_node = Node.from_record(
+        legacy_record, real_profile, _make_client(legacy_session)
+    )
+    await legacy_node.set_zwave_lock_code(3, 1234)
+    assert legacy_session.calls[0][1] == (
+        "/rest/zwave/node/ZW100/security/user/3/set/code/1234"
+    )
+
+    zmatter_session = FakeSession(BASE)
+    zmatter_session.set_route(
+        "GET",
+        "/rest/zmatter/zwave/node/ZW100/security/user/3/set/code/1234",
+        200,
+        "<RestResponse succeeded='true'/>",
+    )
+    zmatter_record = _make_record(
+        address="ZW100", nodedef_id="UZW000F", family_id="12"
+    )
+    zmatter_node = Node.from_record(
+        zmatter_record, real_profile, _make_client(zmatter_session)
+    )
+    await zmatter_node.set_zwave_lock_code(3, 1234)
+    assert zmatter_session.calls[0][1] == (
+        "/rest/zmatter/zwave/node/ZW100/security/user/3/set/code/1234"
+    )
+
+
+@pytest.mark.asyncio
+async def test_node_delete_zwave_lock_code_uses_delete_path(
+    real_profile: Profile,
+) -> None:
+    session = FakeSession(BASE)
+    session.set_route(
+        "GET",
+        "/rest/zwave/node/ZW100/security/user/3/delete",
+        200,
+        "<RestResponse succeeded='true'/>",
+    )
+    record = _make_record(address="ZW100", nodedef_id="UZW000F", family_id="4")
+    node = Node.from_record(record, real_profile, _make_client(session))
+    await node.delete_zwave_lock_code(3)
+    assert session.calls[0][1] == "/rest/zwave/node/ZW100/security/user/3/delete"
+
+
+@pytest.mark.asyncio
+async def test_node_set_zwave_lock_code_raises_on_rest_failure(
+    real_profile: Profile,
+) -> None:
+    session = FakeSession(BASE)
+    session.set_route(
+        "GET",
+        "/rest/zwave/node/ZW100/security/user/3/set/code/1234",
+        200,
+        '<RestResponse succeeded="false"><status>500</status></RestResponse>',
+    )
+    record = _make_record(address="ZW100", nodedef_id="UZW000F", family_id="4")
+    node = Node.from_record(record, real_profile, _make_client(session))
+    with pytest.raises(NodeCommandError, match="status=500"):
+        await node.set_zwave_lock_code(3, 1234)
+
+
+@pytest.mark.asyncio
+async def test_node_delete_zwave_lock_code_raises_on_rest_failure(
+    real_profile: Profile,
+) -> None:
+    session = FakeSession(BASE)
+    session.set_route(
+        "GET",
+        "/rest/zwave/node/ZW100/security/user/3/delete",
+        200,
+        '<RestResponse succeeded="false"><status>404</status></RestResponse>',
+    )
+    record = _make_record(address="ZW100", nodedef_id="UZW000F", family_id="4")
+    node = Node.from_record(record, real_profile, _make_client(session))
+    with pytest.raises(NodeCommandError, match="status=404"):
+        await node.delete_zwave_lock_code(3)
+
+
+@pytest.mark.asyncio
+async def test_node_lock_code_rejects_non_zwave_family(
+    real_profile: Profile,
+) -> None:
+    """Insteon nodes have no ``/security/user/...`` surface."""
+    record = _make_record(family_id="1")
+    node = Node.from_record(record, real_profile, _make_client(FakeSession(BASE)))
+    with pytest.raises(NodeCommandError, match="not a Z-Wave node"):
+        await node.set_zwave_lock_code(1, 1234)
+    with pytest.raises(NodeCommandError, match="not a Z-Wave node"):
+        await node.delete_zwave_lock_code(1)
+
+
 # --- set_on_level (percent + UOM via the editor codec) -------------------
 
 


### PR DESCRIPTION
## Summary

Closes the lock-code half of #96 (Z-Wave parameter / lock-code wire surface). Pairs with the parameter API merged in #115 and uses the same shape.

* ``Node.set_zwave_lock_code(user_num, code)`` → ``GET /rest/(zmatter/)?zwave/node/<addr>/security/user/<n>/set/code/<c>``
* ``Node.delete_zwave_lock_code(user_num)`` → ``GET /rest/(zmatter/)?zwave/node/<addr>/security/user/<n>/delete``

Path selection picks the legacy vs zmatter prefix from the node's ``family_id`` (``\"4\"`` → ``/rest/zwave/...``; ``\"12\"`` → ``/rest/zmatter/zwave/...``).

Wire paths come from PyISY 3.x verified against the legacy radio; IoX 6+ side has no contradicting captures so we assume the surface is unchanged. The zmatter side is best-effort — needs a beta tester with an 800-series lock.

Both helpers raise ``NodeCommandError`` on a ``<RestResponse succeeded=\"false\">`` envelope (same parser as the parameter helpers, shared ``_check_rest_response_succeeded``) and on a non-Z-Wave family. DEBUG log lines at the client (URL) and node (success) layers; ``LOG_VERBOSE`` carries the response body for deeper diagnosis.

## Test plan

- [ ] CI green (full pytest, pre-commit, claude-review).
- [ ] Beta tester with an enrolled Z-Wave lock (family 4) verifies set + delete round-trip with a real PIN.
- [ ] Beta tester with an 800-series Z-Matter lock (family 12) verifies the zmatter path.

Closes #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)