### PR TITLE
feat: to_dict() on runtime objects + Controller.to_dict()

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ python3 -m pyisyox https://eisy.local:443 you@example.com portal-password
 python3 -m pyisyox https://eisy.local:8443 admin local-password
 ```
 
+Pass `--dump <path>` to write a full controller snapshot (every node, group, program, variable, network resource, plus the loaded profile and WS health) as pretty-printed JSON — handy when filing a bug report or diffing controller state between firmware versions:
+
+```bash
+python3 -m pyisyox https://eisy.local:443 you@example.com pw --no-events --dump ~/snapshots/eisy.json
+```
+
+The snapshot is produced by `Controller.to_dict()`; every runtime class (`Node`, `Group`, `Folder`, `Program`, `Variable`, `NetworkResource`, `Profile`) also exposes a `.to_dict()` so embedding consumers can serialise individual objects.
+
 ## Public surface
 
 ```text

--- a/pyisyox/__main__.py
+++ b/pyisyox/__main__.py
@@ -4,10 +4,12 @@ summary, and (by default) hold the WebSocket event stream open.
 Run with ``python3 -m pyisyox <url> <email|admin> <password>``. The
 URL determines the auth mode — port ``:443`` triggers PortalAuth (JWT
 bearer); port ``:8443`` triggers LocalAuth (HTTP basic). Pass
-``--no-events`` to skip starting the WebSocket reader. Logging
-defaults to ``INFO``; ``-d/--debug`` adds parsed event frames + the
-lifecycle / reconnect chatter, ``-v/--verbose`` additionally dumps raw
-WS frames and full ``/api/*`` payloads.
+``--no-events`` to skip starting the WebSocket reader. Pass
+``--dump <path>`` to write a full controller snapshot
+(:meth:`pyisyox.Controller.to_dict`) to disk as JSON. Logging defaults
+to ``INFO``; ``-d/--debug`` adds parsed event frames + the lifecycle /
+reconnect chatter, ``-v/--verbose`` additionally dumps raw WS frames
+and full ``/api/*`` payloads.
 
 It's a thin wrapper over the library — handy for connecting to a
 controller from the shell, watching the event stream, or sanity-
@@ -20,8 +22,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pyisyox import (
@@ -42,6 +46,24 @@ def _build_auth(url: str, username: str, password: str) -> Auth:
     if "@" in username:
         return PortalAuth(username, password)
     return LocalAuth(username, password)
+
+
+def _write_snapshot(controller: Controller, path: Path) -> None:
+    """Write ``Controller.to_dict()`` to ``path`` as pretty-printed JSON.
+
+    Parent dirs auto-create (mirrors v1-beta ``util/output.write_to_file``
+    convenience). ``default=str`` is a guardrail for any datetime /
+    unexpected object that slips through ``to_dict()``. Extracted into a
+    sync helper so :func:`main` can off-load it via
+    :func:`asyncio.to_thread` and stay friendly to async-only lint rules
+    that ban blocking I/O in coroutines.
+    """
+    if path.parent and not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(controller.to_dict(), indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
 
 
 async def main(args: argparse.Namespace) -> int:
@@ -74,6 +96,11 @@ async def main(args: argparse.Namespace) -> int:
                 f"{pid}={prop.formatted or prop.value}" for pid, prop in list(node.properties.items())[:3]
             )
             _LOGGER.info("  [%s] %s (%s) %s", address, node.name, nodedef_id, prop_summary)
+
+        if args.dump is not None:
+            path = Path(args.dump)
+            await asyncio.to_thread(_write_snapshot, controller, path)
+            _LOGGER.info("Wrote controller snapshot to %s", path)
 
         if args.events:
             _LOGGER.info("Event stream running — press Ctrl-C to exit")
@@ -125,6 +152,12 @@ def parse_args() -> argparse.Namespace:
         "--verify-ssl",
         action="store_true",
         help="Enforce SSL certificate verification (default: off; eisy ships self-signed)",
+    )
+    parser.add_argument(
+        "--dump",
+        metavar="PATH",
+        default=None,
+        help="Write Controller.to_dict() to PATH as pretty-printed JSON after load",
     )
     return parser.parse_args()
 

--- a/pyisyox/controller.py
+++ b/pyisyox/controller.py
@@ -24,7 +24,8 @@ always reflect the latest controller state.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 
@@ -363,6 +364,45 @@ class Controller:
             raise ControllerNotConnectedError("controller has no client")
         return {
             address: NetworkResource(record, client) for address, record in loaded.network_resources.items()
+        }
+
+    # --- snapshot -----------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flatten the full controller state to a JSON-compatible dict.
+
+        Aggregates every loaded collection (nodes / groups / folders /
+        programs / program_folders / variables / network_resources)
+        plus the controller's own config + WebSocket health. Each
+        nested object's structural fields come from its own
+        :meth:`to_dict` so the same code path drives the
+        ``pyisyox -m … --dump`` CLI flag and consumer diagnostics.
+        Raises :class:`ControllerNotConnectedError` when called before
+        :meth:`connect` (no loaded state to snapshot).
+        """
+        ws = self._ws
+        return {
+            "config": asdict(self.config),
+            "connected": self.connected,
+            "websocket": {
+                "status": ws.status.value if ws is not None else None,
+                "last_event_at": ws.last_event_at.isoformat()
+                if ws is not None and ws.last_event_at is not None
+                else None,
+            },
+            "profile": self.profile.to_dict(),
+            "nodes": {addr: node.to_dict() for addr, node in self.nodes.items()},
+            "groups": {addr: group.to_dict() for addr, group in self.groups.items()},
+            "folders": {addr: folder.to_dict() for addr, folder in self.folders.items()},
+            "programs": {addr: program.to_dict() for addr, program in self.programs.items()},
+            "program_folders": {addr: folder.to_dict() for addr, folder in self.program_folders.items()},
+            "variables": {
+                type_id: {vid: var.to_dict() for vid, var in vars_.items()}
+                for type_id, vars_ in self.variables.items()
+            },
+            "network_resources": {
+                addr: resource.to_dict() for addr, resource in self.network_resources.items()
+            },
         }
 
     # --- dynamic profile reload ---------------------------------------

--- a/pyisyox/runtime/folder.py
+++ b/pyisyox/runtime/folder.py
@@ -13,7 +13,8 @@ returns nodes only.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pyisyox.client import FolderRecord
@@ -47,6 +48,15 @@ class Folder:
     def family_id(self) -> str:
         """Family id — folders use family ``"13"`` (folder family) on IoX."""
         return self._record.family_id
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flatten this folder to a JSON-compatible dict.
+
+        Mirrors the underlying :class:`FolderRecord`'s fields; useful
+        for the dumper / diagnostics consumers that want a uniform
+        snapshot across the controller's collections.
+        """
+        return asdict(self._record)
 
     def __repr__(self) -> str:
         parent = f" parent={self.parent_address!r}" if self.parent_address else ""

--- a/pyisyox/runtime/group.py
+++ b/pyisyox/runtime/group.py
@@ -27,7 +27,8 @@ representing the controller itself) is filtered out at parse time.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
 
 from pyisyox.client import NodeType
 from pyisyox.constants import INSTEON_STATELESS_NODEDEFID, PROP_STATUS
@@ -252,6 +253,18 @@ class Group:
         already disambiguates — without it the call is rejected.
         """
         await self._client.post_node_update(self.address, {"name": name, "nodeType": NodeType.GROUP})
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flatten this scene to a JSON-compatible dict.
+
+        Adds the live aggregate flags (``group_all_on`` / ``group_any_on``)
+        on top of the structural record so a snapshot reflects whether
+        the scene is currently active.
+        """
+        payload = asdict(self._record)
+        payload["group_all_on"] = self.group_all_on
+        payload["group_any_on"] = self.group_any_on
+        return payload
 
     def __repr__(self) -> str:
         return f"Group(address={self.address!r}, name={self.name!r}, members={len(self.member_addresses)})"

--- a/pyisyox/runtime/network_resource.py
+++ b/pyisyox/runtime/network_resource.py
@@ -14,7 +14,8 @@ has been observed.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pyisyox.client import IoXClient, NetworkResourceRecord
@@ -50,6 +51,10 @@ class NetworkResource:
         as fire-and-forget.
         """
         await self._client.run_network_resource(self._record.address)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flatten this resource to a JSON-compatible dict."""
+        return asdict(self._record)
 
     def __repr__(self) -> str:
         return f"NetworkResource(address={self.address!r}, name={self.name!r})"

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -28,7 +28,8 @@ both :class:`PortalAuth` JWT and :class:`LocalAuth` HTTP basic accept
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree as ET
 
 from pyisyox.client import NodeType
@@ -589,6 +590,19 @@ class Node:
         change without polling.
         """
         await self._client.post_node_update(self.address, {"name": name, "nodeType": NodeType.NODE})
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flatten this node to a JSON-compatible dict.
+
+        Includes the underlying record's structural fields (address,
+        nodedef triple, properties map, flag bitfield) plus the
+        derived :attr:`protocol`. Property values are already
+        :class:`NodePropertyValue` dataclasses so ``asdict`` walks them
+        recursively.
+        """
+        payload = asdict(self._record)
+        payload["protocol"] = self.protocol
+        return payload
 
     # --- Z-Wave parameter surface ------------------------------------
     #

--- a/pyisyox/runtime/program.py
+++ b/pyisyox/runtime/program.py
@@ -17,8 +17,9 @@ shape the dispatcher mutates.
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pyisyox.client import IoXClient, ProgramRecord
@@ -123,6 +124,10 @@ class _ProgramBase:
         block evaluation of every program inside them.
         """
         await self._client.run_program_command(self._record.address, ProgramCommand.DISABLE)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flatten this program / folder to a JSON-compatible dict."""
+        return asdict(self._record)
 
 
 class Program(_ProgramBase):

--- a/pyisyox/runtime/variable.py
+++ b/pyisyox/runtime/variable.py
@@ -18,7 +18,8 @@ record so reads always reflect the latest value.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
 
 from pyisyox.client import VariableField
 
@@ -130,6 +131,10 @@ class Variable:
             self._record.type_id, self._record.id, {VariableField.NAME: name}
         )
         self._record.name = name
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flatten this variable to a JSON-compatible dict."""
+        return asdict(self._record)
 
     def __repr__(self) -> str:
         return f"Variable(type_id={self.type_id!r}, id={self.id!r}, name={self.name!r}, value={self.value})"

--- a/pyisyox/schema/profile.py
+++ b/pyisyox/schema/profile.py
@@ -20,7 +20,8 @@ resolve those labels and to fill encoded editors' enum option names.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
+from typing import Any
 
 from pyisyox.schema.editor import Editor
 from pyisyox.schema.linkdef import LinkDef
@@ -247,6 +248,44 @@ class Profile:
         if instance is None:
             return None
         return instance.editors.get(editor_id)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flatten the profile to a JSON-compatible dict.
+
+        :attr:`nodedef_lookup` is dropped — its
+        ``(nodedef_id, family_id, instance_id)`` tuple keys are not
+        JSON-encodable and the same data lives under
+        ``families[fam].instances[inst].nodedefs``. ``nodedef_lookup_count``
+        is surfaced as a sanity-check counter.
+
+        :class:`pyisyox.schema.editor.EditorRange` carries
+        ``subset: set[int]`` which JSON can't encode either; the
+        walker below normalises every set into a sorted list so the
+        snapshot round-trips through ``json.dumps``.
+        """
+        return {
+            "timestamp": self.timestamp,
+            "families": _jsonify({family_id: asdict(family) for family_id, family in self.families.items()}),
+            "nls": asdict(self.nls),
+            "nodedef_lookup_count": len(self.nodedef_lookup),
+        }
+
+
+def _jsonify(value: Any) -> Any:
+    """Recursively normalise ``asdict`` output so :mod:`json` can encode it.
+
+    The schema dataclasses carry ``set[int]`` (``EditorRange.subset``)
+    which JSON rejects; this walker converts sets to sorted lists,
+    keeps dicts / lists / tuples flat, and passes scalars through.
+    Kept private — only the ``to_dict`` paths need it.
+    """
+    if isinstance(value, dict):
+        return {key: _jsonify(val) for key, val in value.items()}
+    if isinstance(value, (set, frozenset)):
+        return sorted(value)
+    if isinstance(value, (list, tuple)):
+        return [_jsonify(item) for item in value]
+    return value
 
 
 @dataclass(slots=True)

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -9,6 +9,8 @@ the suite reaches only through synthetic FakeSession scaffolding.
 from __future__ import annotations
 
 import argparse
+import json as _json
+from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -92,6 +94,7 @@ def _ns(**overrides) -> argparse.Namespace:
         "events": False,  # don't loop forever
         "tls_version": None,
         "verify_ssl": False,
+        "dump": None,
     }
     base.update(overrides)
     return argparse.Namespace(**base)
@@ -144,3 +147,57 @@ async def test_main_passes_tls_and_verify_ssl(fake_controller) -> None:
     _, kwargs = fake_controller.call_args
     assert kwargs["tls_version"] == 1.3
     assert kwargs["verify_ssl"] is True
+
+
+# --- --dump: controller snapshot to JSON ----------------------------------
+
+
+def test_parse_args_dump_defaults_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--dump`` is optional; absent means no snapshot."""
+    monkeypatch.setattr("sys.argv", ["pyisyox", "https://x", "u", "p"])
+    assert parse_args().dump is None
+
+
+def test_parse_args_dump_captures_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "sys.argv", ["pyisyox", "https://x", "u", "p", "--dump", "./snap.json"]
+    )
+    assert parse_args().dump == "./snap.json"
+
+
+async def test_main_dump_writes_controller_snapshot(
+    fake_controller, tmp_path
+) -> None:
+    """``--dump <path>`` writes ``Controller.to_dict()`` as pretty
+    JSON to ``path``. Parent dirs auto-create so the user can pass a
+    nested path (mirrors the v1-beta dumper)."""
+    snapshot = {"config": {"uuid": "TEST-UUID"}, "nodes": {}}
+    fake_controller.return_value.to_dict.return_value = snapshot
+
+    target = tmp_path / "nested" / "snap.json"
+    rc = await main(_ns(dump=str(target)))
+
+    assert rc == 0
+    assert target.exists()
+    body = target.read_text(encoding="utf-8")
+    # Pretty-printed (indented) and ends with a trailing newline.
+    assert body.endswith("\n")
+    assert "  " in body
+    # Round-trips back to the original dict.
+    assert _json.loads(body) == snapshot
+    fake_controller.return_value.to_dict.assert_called_once_with()
+
+
+async def test_main_dump_handles_unexpected_objects_via_default_str(
+    fake_controller, tmp_path
+) -> None:
+    """``default=str`` is a guardrail — if ``to_dict()`` ever returns a
+    non-JSON-native value (datetime, Path, dataclass that slipped
+    through), the dump should stringify it rather than crashing."""
+    snapshot = {"timestamp": datetime(2026, 5, 13, 12, 0, 0)}
+    fake_controller.return_value.to_dict.return_value = snapshot
+
+    target = tmp_path / "snap.json"
+    rc = await main(_ns(dump=str(target)))
+    assert rc == 0
+    assert "2026-05-13" in target.read_text(encoding="utf-8")

--- a/tests/test_runtime/test_to_dict.py
+++ b/tests/test_runtime/test_to_dict.py
@@ -1,0 +1,277 @@
+"""Tests for the ``to_dict`` methods on the runtime wrappers.
+
+Each runtime class exposes ``to_dict()`` returning a JSON-compatible
+dict (the v1-beta dumper resurrection). The implementations all walk
+their underlying record via :func:`dataclasses.asdict`; tests pin the
+shape, the JSON round-trip, and the derived-field additions so a
+future refactor of any one class doesn't silently break the dumper.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import aiohttp
+import pytest
+
+from pyisyox.auth import LocalAuth
+from pyisyox.client import (
+    FolderRecord,
+    GroupRecord,
+    IoXClient,
+    NetworkResourceRecord,
+    NodePropertyValue,
+    NodeRecord,
+    ProgramRecord,
+    VariableRecord,
+)
+from pyisyox.controller import Controller, ControllerNotConnectedError
+from pyisyox.runtime import (
+    Folder,
+    Group,
+    NetworkResource,
+    Node,
+    Program,
+    ProgramFolder,
+    Variable,
+)
+from pyisyox.schema.profile import Profile
+from tests.test_client.conftest import FakeSession
+from tests.test_controller import FakeSession as CombinedFakeSession
+from tests.test_controller import _stub_responses
+from tests.test_runtime.test_ws import FakeWSMessage
+
+FIXTURE_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "eisy6"
+BASE = "http://eisy.local:8080"
+
+
+def _profile() -> Profile:
+    raw = json.loads((FIXTURE_DIR / "profiles_with_flume.json").read_text())
+    return Profile.load_from_json(raw)
+
+
+def _client() -> IoXClient:
+    return IoXClient(BASE, LocalAuth("admin", "p"), FakeSession(BASE))  # type: ignore[arg-type]
+
+
+# --- Folder --------------------------------------------------------------
+
+
+def test_folder_to_dict_mirrors_record_fields() -> None:
+    record = FolderRecord(address="10", name="Entry", family_id="13")
+    payload = Folder(record).to_dict()
+    assert payload == {
+        "address": "10",
+        "name": "Entry",
+        "family_id": "13",
+        "parent_address": None,
+    }
+
+
+# --- NetworkResource -----------------------------------------------------
+
+
+def test_network_resource_to_dict_round_trips_json() -> None:
+    record = NetworkResourceRecord(address="5", name="Doorbell")
+    payload = NetworkResource(record, _client()).to_dict()
+    assert payload == {"address": "5", "name": "Doorbell"}
+    assert json.loads(json.dumps(payload)) == payload
+
+
+# --- Variable ------------------------------------------------------------
+
+
+def test_variable_to_dict_includes_value_and_init() -> None:
+    record = VariableRecord(
+        type_id="1", id="3", name="Counter", value=42, init=0, precision=0
+    )
+    payload = Variable(record, _client()).to_dict()
+    assert payload["type_id"] == "1"
+    assert payload["id"] == "3"
+    assert payload["name"] == "Counter"
+    assert payload["value"] == 42
+    assert payload["init"] == 0
+
+
+# --- Group ---------------------------------------------------------------
+
+
+def test_group_to_dict_adds_aggregate_flags() -> None:
+    """``group_all_on`` / ``group_any_on`` are derived on access; they
+    shouldn't live on the underlying record but must show up in the
+    snapshot so the dumper output reflects the scene's live state."""
+    record = GroupRecord(
+        address="G1",
+        name="Living Room",
+        nodedef_id="InsteonDimmer",
+        family_id="6",
+        instance_id="1",
+    )
+    payload = Group.from_record(record, _profile(), _client(), nodes={}).to_dict()
+    assert payload["address"] == "G1"
+    assert payload["name"] == "Living Room"
+    assert "group_all_on" in payload
+    assert "group_any_on" in payload
+
+
+# --- Program -------------------------------------------------------------
+
+
+def test_program_to_dict_carries_status_and_runtime_fields() -> None:
+    record = ProgramRecord(
+        address="0030",
+        name="Switch",
+        path="/Programs/Switch",
+        parent_address=None,
+        is_folder=False,
+        status=True,
+        running=None,
+        enabled=True,
+        run_at_startup=False,
+    )
+    payload = Program(record, _client()).to_dict()
+    assert payload["address"] == "0030"
+    assert payload["status"] is True
+    assert payload["enabled"] is True
+    assert payload["is_folder"] is False
+
+
+def test_program_folder_to_dict_inherits_from_base() -> None:
+    """``ProgramFolder`` reuses ``_ProgramBase.to_dict`` — same record,
+    just ``is_folder=True``."""
+    record = ProgramRecord(
+        address="0001",
+        name="Container",
+        path="/Programs/Container",
+        parent_address=None,
+        is_folder=True,
+        status=False,
+        running=None,
+        enabled=True,
+        run_at_startup=None,
+    )
+    payload = ProgramFolder(record, _client()).to_dict()
+    assert payload["is_folder"] is True
+    assert payload["address"] == "0001"
+
+
+# --- Node ----------------------------------------------------------------
+
+
+def test_node_to_dict_includes_derived_protocol() -> None:
+    """``Node.protocol`` is derived from ``family_id``; expose it in the
+    snapshot so the dumper carries the protocol classification without
+    consumers having to re-derive it."""
+    record = NodeRecord(
+        address="3D 7D 87 1",
+        name="Test",
+        nodedef_id="KeypadDimmer_ADV",
+        family_id="1",
+        instance_id="1",
+        type="1.65.69.0",
+        properties={
+            "ST": NodePropertyValue(id="ST", value="0", formatted="Off"),
+        },
+    )
+    payload = Node.from_record(record, _profile(), _client()).to_dict()
+    assert payload["address"] == "3D 7D 87 1"
+    assert payload["protocol"] == "insteon"
+    # Property values are themselves dataclasses — asdict walks recursively.
+    assert payload["properties"]["ST"] == {
+        "id": "ST",
+        "value": "0",
+        "formatted": "Off",
+        "uom": "",
+        "name": "",
+        "precision": 0,
+    }
+
+
+def test_node_to_dict_json_round_trips() -> None:
+    """``json.dumps`` over the snapshot must succeed — the whole point
+    of the helper is to feed JSON-emitting consumers (HA diagnostics,
+    file dumper). Pin this once at the node level."""
+    record = NodeRecord(
+        address="A 1",
+        name="Test",
+        nodedef_id="RelayLampOnly",
+        family_id="1",
+        instance_id="1",
+        type="2.65.69.0",
+    )
+    payload = Node.from_record(record, _profile(), _client()).to_dict()
+    assert json.loads(json.dumps(payload)) == payload
+
+
+# --- Profile -------------------------------------------------------------
+
+
+def test_profile_to_dict_drops_tuple_keyed_lookup() -> None:
+    """``nodedef_lookup`` is ``(nodedef_id, family_id, instance_id)``-
+    keyed; JSON can't encode tuple keys. Snapshot surfaces the size as
+    a counter and keeps the families tree as the structural source."""
+    profile = _profile()
+    payload = profile.to_dict()
+    assert "nodedef_lookup" not in payload
+    assert payload["nodedef_lookup_count"] > 0
+    assert isinstance(payload["families"], dict)
+    assert "nls" in payload
+    # And it survives a JSON round-trip.
+    json.dumps(payload)
+
+
+# --- ProgramFolder + Program from base path --------------------------------
+
+
+# --- Controller aggregator ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_controller_to_dict_aggregates_collections() -> None:
+    """``Controller.to_dict()`` is the public surface the file-dumper
+    CLI builds on. It walks every loaded collection via the
+    per-runtime ``to_dict`` methods, adds the controller's own
+    config + WebSocket health, and survives ``json.dumps``."""
+    session = CombinedFakeSession(BASE)
+    _stub_responses(session)
+    session.queue_ws([FakeWSMessage(type=aiohttp.WSMsgType.CLOSED)])
+    controller = Controller(BASE, LocalAuth("admin", "p"), session=session)  # type: ignore[arg-type]
+
+    # Pre-connect access raises rather than returning a half-snapshot.
+    with pytest.raises(ControllerNotConnectedError):
+        controller.to_dict()
+
+    await controller.connect()
+    try:
+        payload = controller.to_dict()
+    finally:
+        await controller.stop()
+
+    assert payload["connected"] is True
+    assert payload["config"]["uuid"] == "uuid-1"
+    assert payload["config"]["version"] == "6.0.0"
+    assert "3D 7D 87 1" in payload["nodes"]
+    assert isinstance(payload["profile"], dict)
+    assert "websocket" in payload
+    # JSON round-trip: catches any leaked set / tuple-key from the
+    # nested per-object snapshots.
+    assert json.loads(json.dumps(payload))["connected"] is True
+
+
+@pytest.mark.parametrize("is_folder", [False, True])
+def test_program_to_dict_round_trips_json(is_folder: bool) -> None:
+    """Both Program and ProgramFolder snapshots are JSON-compatible."""
+    record = ProgramRecord(
+        address="0010",
+        name="P",
+        path="/Programs/P",
+        parent_address=None,
+        is_folder=is_folder,
+        status=True,
+        running=None,
+        enabled=True,
+    )
+    klass: type = ProgramFolder if is_folder else Program
+    payload = klass(record, _client()).to_dict()
+    assert json.loads(json.dumps(payload)) == payload


### PR DESCRIPTION
## Summary

Adds JSON-serialisable snapshot helpers on every runtime wrapper and a ``Controller.to_dict()`` aggregator — v1-beta dumper resurrected, and the substrate the HA ``udi_iox.diagnostics`` module rebases onto (replaces its inline ``_serialize_*`` helpers).

## What

- ``Node.to_dict()`` — record fields + derived ``protocol``. ``properties`` are themselves dataclasses so ``asdict`` walks them recursively.
- ``Group.to_dict()`` — record + live ``group_all_on`` / ``group_any_on``.
- ``Folder.to_dict()`` / ``NetworkResource.to_dict()`` / ``Variable.to_dict()`` — straight ``asdict`` of the underlying record.
- ``_ProgramBase.to_dict()`` — covers both ``Program`` and ``ProgramFolder``.
- ``Profile.to_dict()`` — families tree + NLS table + a ``nodedef_lookup_count`` counter. Drops the tuple-keyed ``nodedef_lookup`` (JSON-incompatible) since the same data lives under the families tree. Normalises ``set`` / ``frozenset`` (``EditorRange.subset``) to sorted lists via a private ``_jsonify`` walker so the snapshot survives ``json.dumps``.
- ``Controller.to_dict()`` — aggregator. Walks every loaded collection (nodes / groups / folders / programs / program_folders / variables / network_resources) via the per-object methods, plus the controller's own config + WebSocket health (status + ISO ``last_event_at``). Raises ``ControllerNotConnectedError`` pre-connect.

## Tests

12 new in ``tests/test_runtime/test_to_dict.py``:
- Per-class shape + JSON round-trip.
- Profile ``set``→sorted-list flattening + tuple-key drop.
- Controller-level aggregator end-to-end against the bundled eisy6 fixture (covers the live-WS health surface too).

608 total tests pass.

## Test plan

- [ ] CI green (pytest, pre-commit, claude-review).
- [ ] Follow-up: file-dumper CLI flag (``python3 -m pyisyox … --dump <dir>``) lands on top of this.
- [ ] Follow-up: rebase hacs ``udi_iox.diagnostics`` (PR #25) onto ``Controller.to_dict()``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)