### PR TITLE
fix(variable): float passthrough on write + correct <init> dispatch on WS

### DIFF
--- a/pyisyox/__init__.py
+++ b/pyisyox/__init__.py
@@ -93,6 +93,8 @@ from pyisyox.runtime import (
     SystemEventControl,
     TriggerAction,
     Variable,
+    VariableTableChangeEvent,
+    VariableTableChangeListener,
     WebSocketEventStream,
     describe_system_event,
 )
@@ -166,6 +168,8 @@ __all__ = [
     "Variable",
     "VariableField",
     "VariableRecord",
+    "VariableTableChangeEvent",
+    "VariableTableChangeListener",
     "WebSocketEventStream",
     "build_sslcontext",
     "classify",

--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -329,8 +329,8 @@ class VariableRecord:
     type_id: str
     id: str
     name: str
-    value: int = 0
-    init: int = 0
+    value: int | float = 0
+    init: int | float = 0
     precision: int = 0
     ts: str = ""
 
@@ -1386,8 +1386,8 @@ def parse_api_variables_type(raw: list[dict[str, Any]], type_id: str) -> dict[st
             type_id=str(type_id),
             id=vid_str,
             name=str(entry.get("name", "")),
-            value=_coerce_int(entry.get("val"), default=0),
-            init=_coerce_int(entry.get("init"), default=0),
+            value=_coerce_var_number(entry.get("val"), default=0),
+            init=_coerce_var_number(entry.get("init"), default=0),
             precision=_coerce_prec(entry.get("prec")),
             ts=str(entry.get("ts", "")),
         )
@@ -1402,6 +1402,31 @@ def _coerce_int(raw: Any, *, default: int = 0) -> int:
         return int(raw)
     except (TypeError, ValueError):
         return default
+
+
+def _coerce_var_number(raw: Any, *, default: int = 0) -> int | float:
+    """Coerce a variable wire value to ``int | float``.
+
+    Variables can store floats on the modern controller (``POST
+    /api/variables/{type}/{id}`` accepts both ints and floats), so the
+    parser preserves whichever the wire emits — ``int`` for raw
+    integer storage, ``float`` for a fresh write that posted a
+    fractional value. Bool slips past ``isinstance(bool, int)`` but
+    isn't a meaningful variable value here, so it's coerced too.
+    """
+    if raw is None or raw == "":
+        return default
+    if isinstance(raw, bool):
+        return int(raw)
+    if isinstance(raw, (int, float)):
+        return raw
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return default
 
 
 def parse_api_programs(raw: list[dict[str, Any]]) -> dict[str, ProgramRecord]:

--- a/pyisyox/runtime/__init__.py
+++ b/pyisyox/runtime/__init__.py
@@ -27,6 +27,8 @@ from pyisyox.runtime.events import (
     SystemConfigAction,
     SystemEventControl,
     TriggerAction,
+    VariableTableChangeEvent,
+    VariableTableChangeListener,
     describe_system_event,
     parse_event_frame,
 )
@@ -67,6 +69,8 @@ __all__ = [
     "SystemEventControl",
     "TriggerAction",
     "Variable",
+    "VariableTableChangeEvent",
+    "VariableTableChangeListener",
     "WebSocketEventStream",
     "describe_system_event",
     "parse_event_frame",

--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -1247,26 +1247,41 @@ class EventDispatcher:
             )
             return
 
-        val_text = (var_elem.findtext("val") or "").strip()
-        if not val_text:
+        # Action 6 carries the new value in <val>; action 7 (init change)
+        # carries it in <init>. Old code read <val> regardless and
+        # silently dropped every init frame — fix is to pick the
+        # right element per action, with <val> as a tolerant fallback
+        # for action 7 in case some firmwares reuse the value field.
+        if event.action == TriggerAction.VARIABLE_INIT:
+            primary_text = (var_elem.findtext("init") or "").strip()
+            fallback_text = (var_elem.findtext("val") or "").strip()
+            field = "init"
+        else:
+            primary_text = (var_elem.findtext("val") or "").strip()
+            fallback_text = ""
+            field = "value"
+
+        text = primary_text or fallback_text
+        if not text:
             return
         try:
-            new_value = int(val_text)
+            new_value: int | float = int(text)
         except ValueError:
-            _LOGGER.debug(
-                "WS variable-change event for %s.%s carried non-numeric value %r",
-                type_id,
-                var_id,
-                val_text,
-            )
-            return
+            try:
+                new_value = float(text)
+            except ValueError:
+                _LOGGER.debug(
+                    "WS variable-change event for %s.%s carried non-numeric value %r",
+                    type_id,
+                    var_id,
+                    text,
+                )
+                return
 
-        if event.action == TriggerAction.VARIABLE_VALUE:
+        if field == "value":
             record.value = new_value
-            field = "value"
-        else:  # TriggerAction.VARIABLE_INIT
+        else:
             record.init = new_value
-            field = "init"
 
         ts_text = (var_elem.findtext("ts") or "").strip()
         if ts_text:

--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -188,6 +188,20 @@ class TriggerAction(StrEnum):
     #: The current subscription key, sent once right after a new
     #: subscription is established. ``<eventInfo>`` is the key.
     KEY = "8"
+    #: Variable table structurally changed — fires when a variable is
+    #: added or removed, or when its precision is changed (a metadata
+    #: change that the per-value :attr:`VARIABLE_VALUE` /
+    #: :attr:`VARIABLE_INIT` frames don't cover). ``<eventInfo>``
+    #: carries ``<var><type>N</type><id>0</id></var>`` (id=0 is the
+    #: wildcard sentinel — "this whole type's table changed"). The
+    #: right response is to re-fetch ``/api/variables/{type}`` for the
+    #: affected type so the registry mirrors the controller's metadata
+    #: (precision in particular — the wire ``val`` from the per-value
+    #: frames is raw, and a stale precision will mis-render the value).
+    #: The dispatcher recognises it and fires
+    #: :meth:`EventDispatcher.add_variable_table_change_listener`
+    #: callbacks; the dispatcher itself does not re-fetch.
+    VARIABLE_TABLE_CHANGED = "9"
 
     @classmethod
     def label(cls, value: str) -> str:
@@ -913,6 +927,33 @@ class ProgramStatusEvent:
 ProgramStatusListener = Callable[[ProgramStatusEvent], None]
 
 
+@dataclass(slots=True, frozen=True)
+class VariableTableChangeEvent:
+    """A ``_1`` / action ``"9"`` system event — variable table changed.
+
+    The eisy fires this when a variable is added, removed, or has its
+    precision changed (a structural / metadata change that the
+    per-value :class:`TriggerAction.VARIABLE_VALUE` / ``VARIABLE_INIT``
+    frames don't carry). ``<eventInfo>`` payload::
+
+        <var><type>N</type><id>0</id></var>
+
+    ``id=0`` is the wildcard sentinel — "this whole type's table
+    changed", not a specific variable. Consumers should re-fetch
+    ``/api/variables/{type_id}`` to pick up the new metadata
+    (precision in particular — the per-value frames carry raw ``val``
+    and a stale precision will mis-render every variable of this
+    type until the registry is refreshed).
+    """
+
+    #: Variable type — ``"1"`` (integer) or ``"2"`` (state).
+    type_id: str
+    seqnum: int
+
+
+VariableTableChangeListener = Callable[[VariableTableChangeEvent], None]
+
+
 def _parse_lifecycle_enabled(event_info: str) -> bool | None:
     """Pull the ``<enabled>`` flag off a ``NODE_ENABLED`` (``EN``) frame's
     ``<eventInfo>`` — ``EN`` covers both directions, the boolean says which.
@@ -976,6 +1017,7 @@ class EventDispatcher:
         "_nodes",
         "_program_status_listeners",
         "_programs",
+        "_variable_table_change_listeners",
         "_variables",
     )
 
@@ -1016,6 +1058,7 @@ class EventDispatcher:
         self._listeners: list[EventListener] = []
         self._lifecycle_listeners: list[NodeLifecycleListener] = []
         self._program_status_listeners: list[ProgramStatusListener] = []
+        self._variable_table_change_listeners: list[VariableTableChangeListener] = []
 
     def add_listener(self, callback: EventListener) -> Callable[[], None]:
         """Register ``callback`` to fire on every parsed event.
@@ -1052,6 +1095,30 @@ class EventDispatcher:
         def _unsubscribe() -> None:
             try:
                 self._program_status_listeners.remove(callback)
+            except ValueError:
+                pass
+
+        return _unsubscribe
+
+    def add_variable_table_change_listener(self, callback: VariableTableChangeListener) -> Callable[[], None]:
+        """Register ``callback`` to fire on every variable-table-change
+        frame (``<control>_1</control>`` action ``"9"``).
+
+        Fired when a variable is added, removed, or has its precision
+        changed on the controller. The dispatcher itself does **not**
+        re-fetch the variable table — the listener is the seam where
+        consumers wire in a focused re-fetch (e.g. by calling
+        :meth:`Controller.refresh`) so the registry mirrors the new
+        metadata. See :class:`VariableTableChangeEvent` for the payload.
+
+        Returns:
+            An unsubscribe function.
+        """
+        self._variable_table_change_listeners.append(callback)
+
+        def _unsubscribe() -> None:
+            try:
+                self._variable_table_change_listeners.remove(callback)
             except ValueError:
                 pass
 
@@ -1117,6 +1184,11 @@ class EventDispatcher:
             TriggerAction.VARIABLE_INIT,
         ):
             self._apply_variable_change(event)
+        elif (
+            event.control == SystemEventControl.TRIGGER
+            and event.action == TriggerAction.VARIABLE_TABLE_CHANGED
+        ):
+            self._apply_variable_table_change(event)
         elif _LOGGER.isEnabledFor(logging.DEBUG):
             _log_system_event(event)
         for listener in tuple(self._listeners):
@@ -1288,6 +1360,53 @@ class EventDispatcher:
             record.ts = ts_text
 
         _LOGGER.debug("Variable %s.%s %s updated to %s", type_id, var_id, field, new_value)
+
+    def _apply_variable_table_change(self, event: Event) -> None:
+        """Decode a ``_1`` / action ``"9"`` variable-table-change frame
+        and fan out to ``add_variable_table_change_listener`` callbacks.
+
+        Wire shape::
+
+            <control>_1</control><action>9</action>
+            <eventInfo><var><type>N</type><id>0</id></var></eventInfo>
+
+        ``id=0`` is the wildcard sentinel — the frame doesn't carry an
+        individual variable's new state, it just signals "this whole
+        type's table changed structurally (variable added / removed /
+        precision changed)". The dispatcher recognises the frame, logs
+        it, and emits a :class:`VariableTableChangeEvent` to registered
+        listeners. The dispatcher itself does **not** re-fetch — that's
+        the consumer's call (typically :meth:`Controller.refresh`).
+
+        Type is read from either an attribute (``<var type="2">``) or a
+        child element (``<var><type>2</type></var>``) — the wire shape
+        has been observed in both forms across firmwares.
+        """
+        if not self._variable_table_change_listeners:
+            _LOGGER.debug("Variable table change (no listener) %s", event.event_info or "<empty>")
+            return
+        if not event.event_info:
+            return
+        try:
+            info = ET.fromstring(  # noqa: S314 — eisy LAN traffic
+                f"<eventInfo>{event.event_info}</eventInfo>"
+            )
+        except ET.ParseError:
+            return
+        var_elem = info.find("var")
+        if var_elem is None:
+            return
+        type_id = (var_elem.get("type") or var_elem.findtext("type") or "").strip()
+        if not type_id:
+            return
+
+        evt = VariableTableChangeEvent(type_id=type_id, seqnum=event.seqnum)
+        _LOGGER.debug("Variable table change: type=%s seqnum=%s", type_id, event.seqnum)
+        for listener in tuple(self._variable_table_change_listeners):
+            try:
+                listener(evt)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Variable table change listener raised")
 
     def _apply_program_status(self, event: Event) -> None:
         """Decode a program-status frame and update the matching record.

--- a/pyisyox/runtime/variable.py
+++ b/pyisyox/runtime/variable.py
@@ -27,6 +27,22 @@ if TYPE_CHECKING:
     from pyisyox.client import IoXClient, VariableRecord
 
 
+def _coerce_numeric(value: float | str) -> int | float:
+    """Coerce a caller-supplied value to ``int | float`` for the wire.
+
+    Pass-through for ``int`` / ``float``. Strings are parsed as
+    ``float`` if they carry a decimal point, otherwise ``int`` — this
+    matches the legacy PyISY 3.x contract that accepted string values
+    from generic callers.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    text = str(value).strip()
+    if "." in text or "e" in text.lower():
+        return float(text)
+    return int(text)
+
+
 class Variable:
     """User-facing handle for one controller variable."""
 
@@ -65,17 +81,24 @@ class Variable:
         return self._record.name
 
     @property
-    def value(self) -> int:
+    def value(self) -> int | float:
         """Current value (wire field ``val``).
 
         Reads reflect the latest write — mutations via :meth:`set_value`
         update the underlying record in place after a successful POST.
+
+        Type is ``int | float``: most variables read back as ``int`` from
+        the wire (``/api/variables/{type}`` parses ``"val"`` as int), but
+        a controller may surface ``float`` on a fresh write that posted a
+        non-integer (the modern ``POST /api/variables/{type}/{id}``
+        endpoint accepts floats and the wrapper stores whatever was sent
+        on success).
         """
         return self._record.value
 
     @property
-    def init(self) -> int:
-        """Restore-on-startup value."""
+    def init(self) -> int | float:
+        """Restore-on-startup value. Same int-or-float surface as :attr:`value`."""
         return self._record.init
 
     @property
@@ -95,27 +118,40 @@ class Variable:
 
     # --- mutation -----------------------------------------------------
 
-    async def set_value(self, value: int) -> None:
+    async def set_value(self, value: float) -> None:
         """Set the current value of this variable.
 
         Wire shape: ``POST /api/variables/{type}/{id}`` with body
-        ``{"value": <int>}``. Updates the underlying record on success
-        so subsequent reads of :attr:`value` reflect the new state
-        without waiting for a WS frame.
+        ``{"value": <number>}``. The modern endpoint accepts both
+        ``int`` and ``float`` — for a ``precision > 0`` variable, send
+        the *displayed* float (e.g. ``51.5``) and the controller
+        applies the ``* 10**precision`` scale on store. Sending an
+        ``int`` on the same variable means the controller stores it
+        verbatim (no scale applied), which produces a mismatch
+        between consumer-displayed and controller-internal values — so
+        callers driving displayed-unit UIs should send floats.
+
+        Strings are tolerated for legacy callers (parsed as float if
+        they contain a decimal point, else int).
+
+        Updates the underlying record on success so subsequent reads
+        of :attr:`value` reflect the new state without waiting for a
+        WS frame.
         """
-        new_value = int(value)
+        new_value = _coerce_numeric(value)
         await self._client.post_variable_update(
             self._record.type_id, self._record.id, {VariableField.VALUE: new_value}
         )
         self._record.value = new_value
 
-    async def set_init(self, init: int) -> None:
+    async def set_init(self, init: float) -> None:
         """Set the init / restore-on-startup value.
 
         Wire shape: ``POST /api/variables/{type}/{id}`` with
-        ``{"init": <int>}``.
+        ``{"init": <number>}``. Same int-or-float semantics as
+        :meth:`set_value`.
         """
-        new_init = int(init)
+        new_init = _coerce_numeric(init)
         await self._client.post_variable_update(
             self._record.type_id, self._record.id, {VariableField.INIT: new_init}
         )

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -453,7 +453,34 @@ def test_dispatcher_applies_variable_value_change_to_record() -> None:
 
 
 def test_dispatcher_applies_variable_init_change_to_record() -> None:
-    """Action ``"7"`` updates ``record.init`` in place; value is untouched."""
+    """Action ``"7"`` updates ``record.init`` in place; value is untouched.
+
+    Real eisy firmware emits the new init value in the ``<init>`` element
+    of the ``<var>`` payload (alongside ``<prec>``), **not** ``<val>`` —
+    earlier dispatcher logic looked for ``<val>`` only and silently
+    dropped every init frame the controller emitted. This fixture
+    matches what was captured on a live eisy at FW 6.0."""
+    record = _make_variable_record(type_id="2", id_="8", value=5, init=0)
+    variables = {"1": {}, "2": {"8": record}}
+    dispatcher = EventDispatcher({}, variables=variables)
+
+    frame = (
+        '<Event seqnum="1"><control>_1</control><action>7</action>'
+        "<node></node>"
+        '<eventInfo><var type="2" id="8"><init>81</init><prec>1</prec></var></eventInfo>'
+        "</Event>"
+    )
+    dispatcher.feed(frame)
+
+    assert record.init == 81
+    assert record.value == 5  # untouched on action 7
+
+
+def test_dispatcher_applies_variable_init_change_with_val_fallback() -> None:
+    """A frame emitting ``<val>`` on an action-7 init change still works
+    — older / alternative firmwares may reuse the value element name
+    even for init changes. The dispatcher prefers ``<init>`` and falls
+    back to ``<val>`` so both shapes round-trip."""
     record = _make_variable_record(type_id="2", id_="8", value=5, init=0)
     variables = {"1": {}, "2": {"8": record}}
     dispatcher = EventDispatcher({}, variables=variables)
@@ -467,7 +494,25 @@ def test_dispatcher_applies_variable_init_change_to_record() -> None:
     dispatcher.feed(frame)
 
     assert record.init == 100
-    assert record.value == 5  # untouched on action 7
+    assert record.value == 5
+
+
+def test_dispatcher_applies_variable_float_change_to_record() -> None:
+    """A float-valued variable change (modern API can store floats)
+    parses as ``float`` rather than dropping the frame."""
+    record = _make_variable_record(type_id="2", id_="8", value=0, init=0)
+    variables = {"1": {}, "2": {"8": record}}
+    dispatcher = EventDispatcher({}, variables=variables)
+
+    frame = (
+        '<Event seqnum="1"><control>_1</control><action>6</action>'
+        "<node></node>"
+        '<eventInfo><var type="2" id="8"><val>51.5</val></var></eventInfo>'
+        "</Event>"
+    )
+    dispatcher.feed(frame)
+
+    assert record.value == 51.5
 
 
 def test_dispatcher_drops_variable_event_for_unknown_type() -> None:

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -20,6 +20,7 @@ from pyisyox.runtime.events import (
     NodeLifecycleEvent,
     ProgramStatusEvent,
     SystemEventControl,
+    VariableTableChangeEvent,
     _extract_lifecycle_node_xml,
     parse_event_frame,
 )
@@ -513,6 +514,36 @@ def test_dispatcher_applies_variable_float_change_to_record() -> None:
     dispatcher.feed(frame)
 
     assert record.value == 51.5
+
+
+def test_dispatcher_fires_variable_table_change_listener() -> None:
+    """Action ``"9"`` is the controller's signal that a variable was
+    added/removed or had its precision changed on a given type. The
+    dispatcher fires registered listeners; it does **not** auto-refresh
+    the registry (that's the consumer's call). Listeners receive the
+    type id pulled from ``<var type="N">`` (attribute) or
+    ``<var><type>N</type></var>`` (child-element) — both shapes have
+    been observed across firmwares."""
+    received: list[VariableTableChangeEvent] = []
+    dispatcher = EventDispatcher({}, variables={"1": {}, "2": {}})
+    dispatcher.add_variable_table_change_listener(received.append)
+
+    # Attribute form.
+    dispatcher.feed(
+        '<Event seqnum="42"><control>_1</control><action>9</action>'
+        "<node></node>"
+        '<eventInfo><var type="2" id="0"/></eventInfo>'
+        "</Event>"
+    )
+    # Child-element form.
+    dispatcher.feed(
+        '<Event seqnum="43"><control>_1</control><action>9</action>'
+        "<node></node>"
+        "<eventInfo><var><type>1</type><id>0</id></var></eventInfo>"
+        "</Event>"
+    )
+
+    assert [(e.type_id, e.seqnum) for e in received] == [("2", 42), ("1", 43)]
 
 
 def test_dispatcher_drops_variable_event_for_unknown_type() -> None:

--- a/tests/test_runtime/test_variables.py
+++ b/tests/test_runtime/test_variables.py
@@ -79,19 +79,44 @@ async def test_set_value_posts_value_body_and_updates_record() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_value_coerces_to_int_before_posting() -> None:
-    """A non-int caller (str / float) is coerced — matches the
-    legacy ``Controller.set_variable_value`` contract."""
+async def test_set_value_passes_float_through_to_wire() -> None:
+    """Floats reach the wire verbatim. The modern ``POST /api/variables``
+    endpoint accepts both ``int`` and ``float``; on a ``precision > 0``
+    variable, the controller applies the ``* 10**precision`` scale to
+    a float server-side. Coercing to ``int`` here would truncate the
+    fractional portion and double-shift the value (controller would
+    pre-scale the truncated int again), producing wrong stored state."""
+    record = _make_record(precision=1)
+    session = FakeSession(BASE)
+    session.set_route("POST", "/api/variables/2/8", 200, '{"successful": true}')
+    variable = Variable.from_record(record, _make_client(session))
+
+    await variable.set_value(51.5)
+
+    _, _, kwargs = session.calls[-1]
+    assert kwargs["json"] == {"value": 51.5}
+    assert variable.value == 51.5  # record updated in place
+
+
+@pytest.mark.asyncio
+async def test_set_value_accepts_legacy_string_input() -> None:
+    """A string caller is parsed — matches the legacy
+    ``Controller.set_variable_value`` contract. Strings with a decimal
+    point parse as ``float`` so the float-passthrough path applies."""
     record = _make_record()
     session = FakeSession(BASE)
     session.set_route("POST", "/api/variables/2/8", 200, '{"successful": true}')
     variable = Variable.from_record(record, _make_client(session))
 
     await variable.set_value("42")  # type: ignore[arg-type]
-
     _, _, kwargs = session.calls[-1]
     assert kwargs["json"] == {"value": 42}
     assert variable.value == 42
+
+    await variable.set_value("3.14")  # type: ignore[arg-type]
+    _, _, kwargs = session.calls[-1]
+    assert kwargs["json"] == {"value": 3.14}
+    assert variable.value == 3.14
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
> **Stacked on top of #123** (DEBUG logging for variable + network-resource writes). Merge #123 first; this PR rebases onto ``main`` automatically once that lands.

## Summary

Three related bugs/gaps in the variable surface, all surfaced by a user testing ``precision > 0`` state variables on a live eisy.

### 1. Write side — ``int()`` coercion truncated fractional writes

``Variable.set_value`` / ``set_init`` unconditionally ``int(value)`` before posting to ``POST /api/variables/{type}/{id}``. The modern endpoint accepts both ``int`` and ``float`` (verified live: ``{"value": 51.5}`` on a prec=1 variable stores correctly and displays as ``51.5``). Pre-rounding to int meant entering ``51.5`` in a downstream consumer's UI sent ``{"value": 51}`` and the controller stored it verbatim (no precision scale applied), so the displayed-unit semantics broke down on every fractional write.

**Fix**: pass numeric values through unchanged. Legacy string callers still parse via ``_coerce_numeric`` (float if the string carries a decimal point, else int). Widened ``VariableRecord.value`` / ``init`` to ``int | float`` and updated ``parse_api_variables_type`` to preserve whichever the wire emits.

### 2. WS dispatch — every ``<init>`` frame silently dropped

``_apply_variable_change`` read ``<val>`` for both action 6 (value change) and action 7 (init change). Real eisy firmware emits the new init value in the ``<init>`` element of the ``<var>`` payload (alongside ``<prec>``), so action-7 frames were silently dropped — init updates on the eisy side never propagated to consumers. Captured live:

```xml
<Event ...><control>_1</control><action>7</action>
<eventInfo><var type="2" id="1"><init>81</init><prec>1</prec></var></eventInfo></Event>
```

**Fix**: for action 7 read ``<init>`` (fall back to ``<val>`` for firmware variants that reuse the value element name). Also tolerate float values on the wire so a fresh float-write echo round-trips through the dispatcher without falling into the "non-numeric" debug-and-drop path.

### 3. Action 9 — variable-table-change frames were unknown

The eisy fires ``<control>_1</control><action>9</action>`` when a variable is added, removed, or has its precision changed:

```xml
<Event ...><control>_1</control><action>9</action>
<eventInfo><var><type>2</type><id>0</id></var></eventInfo></Event>
```

``id=0`` is the wildcard sentinel — the frame doesn't carry per-variable state, it signals "this whole type's table changed structurally". The right response is to re-fetch ``/api/variables/{type_id}``; stale precision in particular mis-renders every variable of the affected type until refresh.

**Fix**: new ``TriggerAction.VARIABLE_TABLE_CHANGED``, ``VariableTableChangeEvent``, and ``EventDispatcher.add_variable_table_change_listener`` hook (mirrors the existing ``add_program_status_listener`` shape). The dispatcher itself does **not** re-fetch — that's the consumer's call. Auto-refresh wiring on ``Controller`` is tracked in #125 (needs a focused ``refresh_variables(type_id)``).

## Tests (+5)

- ``test_set_value_passes_float_through_to_wire`` — ``set_value(51.5)`` posts ``{"value": 51.5}`` and updates the record to ``51.5``.
- ``test_set_value_accepts_legacy_string_input`` — ``"42"`` → 42, ``"3.14"`` → 3.14.
- ``test_dispatcher_applies_variable_init_change_to_record`` — frame matches the captured live shape (``<init>81</init><prec>1</prec>``).
- ``test_dispatcher_applies_variable_init_change_with_val_fallback`` — back-compat for firmwares that emit ``<val>`` on action 7.
- ``test_dispatcher_applies_variable_float_change_to_record`` — float WS echo round-trips as float.
- ``test_dispatcher_fires_variable_table_change_listener`` — action 9 (both attribute and child-element ``<type>`` shapes) fires the new listener.

618 tests pass (615 + 3 + binding new).

## Test plan

- [ ] CI green.
- [ ] User retests on live eisy: ``set_value(51.5)`` → eisy + consumer both display 51.5; updating init from eisy UI → consumer reflects within one WS frame; precision change in eisy UI → consumer logs the action-9 frame.

## Follow-ups

- #125 — variable CRUD (create/delete/set-precision) + ``Controller.refresh_variables(type_id)`` so the action-9 listener can drive a focused reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)