### PR TITLE
chore(docs): modernize .readthedocs.yaml schema

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,20 +1,21 @@
-# .readthedocs.yml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-# Required
+
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
+# The legacy ``python.version`` key was removed from RTD's v2 schema in
+# 2023; modern builds pick the interpreter via ``build.tools.python``
+# against a pinned ``build.os`` image. Pyisyox supports Python 3.11+
+# (see pyproject ``requires-python``); 3.13 is the most recent
+# RTD-supported runtime as of writing.
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
 sphinx:
   configuration: docs/conf.py
 
-# Optionally build your docs in additional formats such as PDF
-# formats:
-#   - pdf
-
-# Optionally set the version of Python and requirements
-# required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary

Old config used ``python.version: 3.7`` — that key was removed from Read the Docs' v2 schema in 2023, and 3.7 has been EOL since 2023-06. RTD has been silently picking a default interpreter since, which is fragile across their periodic image refreshes.

Updated to the current canonical shape: ``build.os`` + ``build.tools.python``.

```diff
-python:
-  version: 3.7
-  install:
-    - requirements: docs/requirements.txt
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+python:
+  install:
+    - requirements: docs/requirements.txt
```

3.13 is the most recent RTD-supported runtime and well within pyisyox's ``requires-python = ">=3.11"``. Dropped the commented-out ``formats`` block too (HTML-only is the implicit default).

## Test plan

- [x] RTD build kicks off automatically on push (it's hooked to the GitHub webhook). Verify the next build at <https://pyisyox.readthedocs.io> uses Python 3.13 and completes without picking up a deprecated default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)