### PR TITLE
chore(client): log _get_text reads at DEBUG (symmetry with _get_json)

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -677,7 +677,20 @@ class IoXClient:
                     continue
                 if resp.status >= 400:
                     raise HTTPError(resp.status, url)
-                return await resp.text()
+                text = await resp.text()
+            # Match the ``_get_json`` summary line so wire-trace
+            # debugging works regardless of payload format. Reads
+            # through ``_get_text`` (the legacy XML surfaces:
+            # ``/rest/nodes``, ``/rest/status``,
+            # ``/rest/networking/resources``) were previously silent,
+            # so a consumer comparing tcpdump output to a DEBUG log
+            # saw different request sets. VERBOSE-level body dumps
+            # are intentionally not added here — XML payloads can be
+            # multi-MB on a populated controller and would dominate
+            # the log; ``_get_json``'s VERBOSE body dump exists
+            # because the redactor is JSON-specific.
+            _LOGGER.debug("GET %s -> %d bytes", path, len(text))
+            return text
 
     async def _get_text_or_empty(self, path: str) -> str:
         """``_get_text`` that swallows HTTPError and returns an empty


### PR DESCRIPTION
## Summary

``_get_json`` logs a one-line ``GET %s -> %d bytes`` summary at DEBUG after every successful fetch; ``_get_text`` was silent. Net effect: consumers tail-f-ing the DEBUG log saw the JSON requests but not the XML ones, even though both paths fire in the same ``IoXClient.load`` ``asyncio.gather`` — made it look like ``/rest/nodes`` / ``/rest/status`` weren't being called.

User noticed during a devcontainer trace that ``/rest/nodes`` appeared absent from the load even though the code clearly calls it. The asymmetric logging was the cause, not a missing call.

## Change

Add the same one-line summary to ``_get_text``. No behaviour change; the request still runs exactly the same.

## Why no VERBOSE body dump

``_get_json`` has a VERBOSE-level body dump that runs the payload through ``redact_sensitive`` (strips auth tokens, JWTs). That redactor is JSON-specific and the XML payloads ``_get_text`` handles can be multi-MB on a populated controller (``/rest/status``) — a verbose dump would dominate the log without buying useful debuggability. Sticking with the DEBUG summary line.

## Test plan

- [x] CI green.
- [x] User: enable ``DEBUG`` on ``pyisyox.client`` during a fresh ``Controller.connect()``; verify both ``/rest/nodes`` and ``/rest/status`` appear in the trace alongside the existing ``/api/*`` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)