### PR TITLE
feat(client): drop /rest/nodes from load fan-out, use /api/nodes JSON

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -8,8 +8,13 @@ Sits between the auth layer (:mod:`pyisyox.auth`) and the schema layer
 * ``GET /rest/profiles?include=nodedefs,editors,linkdefs`` — single
   ~117 KB JSON blob; the source for every nodedef + editor.
 * Parallel fan-out:
-    * ``GET /api/nodes`` — JSON structure (family/instance, addresses,
-      parent/pnode). Plugin nodes have **no** ``property[]`` field.
+    * ``GET /api/nodes`` — JSON structure with three parallel arrays
+      under ``data.nodes``: ``node`` (family/instance, addresses,
+      parent/pnode; plugin nodes have **no** ``property[]`` field),
+      ``group`` (scenes with members + ``flag`` bit for the
+      controller-self root group whose ``<name>`` is the friendly
+      controller label), and ``folder`` (organisational tree).
+      Each entry tagged with ``nodeType``.
     * ``GET /rest/status`` — XML, the canonical full-property table for
       both native and plugin nodes. PyISY 3.x already merges this into
       ``/rest/nodes`` to fill in Insteon thermostat properties; the
@@ -17,7 +22,10 @@ Sits between the auth layer (:mod:`pyisyox.auth`) and the schema layer
     * ``GET /api/programs``, ``/api/triggers`` — JSON.
     * ``GET /api/variables/1`` and ``/api/variables/2`` — JSON.
 
-Total: ≤ 7 HTTP + 1 WebSocket regardless of node-server count.
+Total: ≤ 6 HTTP + 1 WebSocket regardless of node-server count
+(``/rest/nodes`` was dropped from the fan-out in #127 — its
+group/folder data is fully covered by ``/api/nodes`` JSON, saving one
+round-trip per connect).
 
 The client is auth-mode-agnostic — it accepts any :class:`pyisyox.auth.Auth`
 implementation (``PortalAuth`` or ``LocalAuth``). On a 401 it asks the
@@ -61,7 +69,6 @@ from pyisyox.paths import (
     PROFILES_PATH,
     PROGRAM_COMMAND_PATH,
     PROGRAMS_PATH,
-    REST_NODES_PATH,
     REST_STATUS_PATH,
     TRIGGERS_PATH,
     VARIABLE_ITEM_PATH,
@@ -468,7 +475,6 @@ class IoXClient:
         (
             profile_raw,
             nodes_raw,
-            rest_nodes_xml,
             status_xml,
             programs_raw,
             triggers_raw,
@@ -478,7 +484,6 @@ class IoXClient:
         ) = await asyncio.gather(
             self._get_json(PROFILES_PATH),
             self._get_json(NODES_PATH),
-            self._get_text(REST_NODES_PATH),
             self._get_text(REST_STATUS_PATH),
             self._get_json(PROGRAMS_PATH),
             self._get_json(TRIGGERS_PATH),
@@ -494,7 +499,13 @@ class IoXClient:
         profile = Profile.load_from_json(profile_raw)
         nodes = parse_api_nodes(nodes_raw)
         merge_status_into_nodes(nodes, parse_rest_status(status_xml))
-        groups, folders, root_name = parse_rest_nodes_groups_folders(rest_nodes_xml)
+        # /api/nodes JSON carries the full node + group + folder tree
+        # (each entry tagged with ``nodeType``) — see issue #127. The
+        # legacy ``/rest/nodes`` XML round-trip is dropped from the
+        # fan-out; ``parse_rest_nodes_groups_folders`` stays exported
+        # for LocalAuth (which doesn't expose ``/api/*``) and external
+        # consumers that prefer the XML surface.
+        groups, folders, root_name = parse_api_nodes_groups_folders(nodes_raw)
         await self._load_dynamic_zwave_nodedefs(profile, nodes)
 
         return LoadResult(
@@ -1042,6 +1053,88 @@ def _flag_int(raw: Any) -> int:
         return int(raw)
     except (TypeError, ValueError):
         return 0
+
+
+def parse_api_nodes_groups_folders(
+    raw: dict[str, Any],
+) -> tuple[dict[str, GroupRecord], dict[str, FolderRecord], str]:
+    """Decode ``/api/nodes`` JSON into group + folder registries + root name.
+
+    The JSON payload nests three parallel arrays under ``data.nodes`` —
+    ``node``, ``group``, ``folder`` — each entry tagged with a
+    ``nodeType`` discriminator. This walks the ``group`` and ``folder``
+    arrays only; nodes are handled by :func:`parse_api_nodes`.
+
+    Drop-in replacement for :func:`parse_rest_nodes_groups_folders`
+    (the legacy ``/rest/nodes`` XML parser) — same return shape, same
+    ``NodeFlag.ROOT`` filtering, same controller-vs-responder
+    ``type="16"`` discrimination on group members. Captured live on
+    eisy IoX 6+ confirmed the JSON uses the identical encoding the
+    XML did.
+
+    The root group (``flag`` bit ``NodeFlag.ROOT`` set — the
+    controller-self pseudo-group whose address is the controller MAC)
+    is filtered out of the returned ``groups`` map; its ``name`` is
+    surfaced as the third return value so consumers can use the
+    user-assigned controller label (e.g. ``"Main eisy"``) for device
+    naming — same source the legacy
+    ``/rest/config/<configuration><root><name>`` path carried in
+    PyISY 3.x. Returns an empty string when the root group is absent
+    or unnamed.
+    """
+    nodes_data = (raw.get("data") or {}).get("nodes") or {}
+
+    groups: dict[str, GroupRecord] = {}
+    root_name = ""
+    for item in nodes_data.get("group") or []:
+        if _flag_int(item.get("flag")) & NodeFlag.ROOT:
+            root_name = str(item.get("name") or "") or root_name
+            continue
+        addr = str(item.get("address") or "")
+        if not addr:
+            continue
+        member_records = (item.get("members") or {}).get("link") or []
+        members: list[str] = []
+        controllers: list[str] = []
+        for link in member_records:
+            link_addr = str(link.get("_") or "").strip()
+            if not link_addr:
+                continue
+            members.append(link_addr)
+            # ``type="16"`` (0x10) marks a scene controller in both the
+            # legacy XML and the JSON. Anything else is a responder.
+            if str(link.get("type") or "") == "16":
+                controllers.append(link_addr)
+        parent = item.get("parent")
+        parent_address = parent.get("_") if isinstance(parent, dict) else parent
+        pnode = item.get("pnode")
+        groups[addr] = GroupRecord(
+            address=addr,
+            name=str(item.get("name") or ""),
+            nodedef_id=str(item.get("nodeDefId") or ""),
+            family_id=str(item.get("family") or "1"),
+            instance_id="1",
+            parent_address=str(parent_address) if parent_address else None,
+            pnode=str(pnode) if pnode else None,
+            member_addresses=tuple(members),
+            controller_addresses=tuple(controllers),
+        )
+
+    folders: dict[str, FolderRecord] = {}
+    for item in nodes_data.get("folder") or []:
+        addr = str(item.get("address") or "")
+        if not addr:
+            continue
+        parent = item.get("parent")
+        parent_address = parent.get("_") if isinstance(parent, dict) else parent
+        folders[addr] = FolderRecord(
+            address=addr,
+            name=str(item.get("name") or ""),
+            family_id=str(item.get("family") or "13"),
+            parent_address=str(parent_address) if parent_address else None,
+        )
+
+    return groups, folders, root_name
 
 
 def parse_api_nodes(raw: dict[str, Any]) -> dict[str, NodeRecord]:

--- a/pyisyox/paths.py
+++ b/pyisyox/paths.py
@@ -35,8 +35,14 @@ TRIGGERS_PATH = "/api/triggers"
 #: ~117 KB profile blob with every nodedef + editor + linkdef.
 PROFILES_PATH = "/rest/profiles?include=nodedefs,editors,linkdefs"
 
-#: ``GET /rest/nodes`` — legacy XML; source for ``<group>``/``<folder>``
-#: structure (the JSON ``/api/nodes`` doesn't carry these).
+#: ``GET /rest/nodes`` — legacy XML surface for the node + group +
+#: folder tree. **No longer used by the default load fan-out** —
+#: ``/api/nodes`` JSON carries ``data.nodes.{node, group, folder}``
+#: with every field the connector needs (verified against captures on
+#: eisy IoX 6+; member ``type="16"`` controller marker matches). The
+#: constant + the legacy parser (:func:`parse_rest_nodes_groups_folders`)
+#: stay exported for LocalAuth flows on ``:8443`` (which doesn't
+#: expose ``/api/*``) and for external consumers that prefer the XML.
 REST_NODES_PATH = "/rest/nodes"
 
 #: ``GET /rest/zwave/node/{address}/def/get`` — the *dynamically

--- a/tests/fixtures/eisy6_json/api_nodes_full.json
+++ b/tests/fixtures/eisy6_json/api_nodes_full.json
@@ -1,0 +1,9434 @@
+{
+  "successful": true,
+  "data": {
+    "nodes": {
+      "node": [
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "3D 7D 87 1",
+          "name": "Breezeway",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "3D 7D 87 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "3D 7D 87 3",
+          "name": "Garage KP.A-Yard Spots",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "4342",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "3D 7D 87 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "3D 7D 87 4",
+          "name": "Garage KP.B-Side Spot",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "4342",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "3D 7D 87 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "3D 7D 87 5",
+          "name": "Garage KP.C",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "46696",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "3D 7D 87 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "3D 7D 87 6",
+          "name": "Garage KP.D",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "46696",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "3D 7D 87 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "40 4E 68 1",
+          "name": "Patio Sconces",
+          "hint": "69.70.83.46",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 4E 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 4E 68 2",
+          "name": "Main BR Patio KP.B-Recessed",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15829",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 4E 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 4E 68 3",
+          "name": "Main BR Patio KP.C-Patio Fan",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 4E 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "40 FD 8 1",
+          "name": "[p]LR KP.A-Lamps",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 FD 8 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "100%",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 FD 8 2",
+          "name": "LR KP.B-Fan Light",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 FD 8 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 FD 8 3",
+          "name": "LR KP.C-Fan High",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 FD 8 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 FD 8 4",
+          "name": "LR KP.D-Fan Low",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 FD 8 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 FD 8 5",
+          "name": "LR KP.E-Fan Off",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 FD 8 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 FD 8 6",
+          "name": "LR KP.F-Fan Med",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 FD 8 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 FD 8 7",
+          "name": "LR KP.G-Curtains",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 FD 8 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 FD 8 8",
+          "name": "LR KP.H-All Living Room",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 FD 8 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "43 64 E6 1",
+          "name": "Entry Chandelier",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "43 64 E6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "153",
+              "formatted": "60%",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "43 64 E6 3",
+          "name": "Entry KP.A-Welcome",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "43 64 E6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "43 64 E6 4",
+          "name": "Entry KP.B-DimWelcome",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "43 64 E6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "43 64 E6 5",
+          "name": "Entry KP.C-AlarmStay",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "43 64 E6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "43 64 E6 6",
+          "name": "Entry KP.D-All Off",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "22480",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "43 64 E6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "23 B5 98 1",
+          "name": "Pantry Recessed",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "type": "1.32.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "23 B5 98 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "41 E1 58 1",
+          "name": "Driveway KP.A-Breezeway[i]",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "37989",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "41 E1 58 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "41 E1 58 2",
+          "name": "Driveway KP.B-Garage Overhang",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "41 E1 58 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "41 E1 58 3",
+          "name": "Driveway KP.C-AutoLock",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "41 E1 58 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "41 E1 58 4",
+          "name": "Driveway KP.D-Side Spots",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "41 E1 58 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "41 E1 58 5",
+          "name": "Driveway KP.E-Garage Lights",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "41 E1 58 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "42 B4 1C 1",
+          "name": "Family Room Recessed",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "42 B4 1C 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "153",
+              "formatted": "60%",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "48 7 1F 1",
+          "name": "Garage Overhang",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "48 7 1F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "29 CA 5F 1",
+          "name": "Backyard Spotlights",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "type": "1.32.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "29 CA 5F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "22 D8 60 1",
+          "name": "Pendants",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "type": "1.32.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "22 D8 60 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "23 B5 68 1",
+          "name": "Family Room Recessed_S",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "37989",
+            "type": "3"
+          },
+          "type": "1.32.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "23 B5 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "153",
+              "formatted": "60%",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "23 B1 37 1",
+          "name": "Living Room Recessed",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "type": "1.32.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "23 B1 37 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "22 E5 E5 1",
+          "name": "Staircase_S_FTD",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "22480",
+            "type": "3"
+          },
+          "type": "1.32.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "22 E5 E5 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "23 D5 6 1",
+          "name": "Kitchen Recessed",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "type": "1.45.66.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "23 D5 6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "153",
+              "formatted": "60%",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "49 2D 7E 1",
+          "name": "Garbage Disposal[i]",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "53085",
+            "type": "3"
+          },
+          "type": "2.55.72.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "49 2D 7E 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "25 9 B7 1",
+          "name": "Main BR KP2.0-Fan Light",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "16204",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 9 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "23 B5 32 1",
+          "name": "Front Porch",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "type": "1.32.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "23 B5 32 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 9 B7 3",
+          "name": "Main BR KP2.A-Fan High",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "16204",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 9 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 9 B7 4",
+          "name": "Main BR KP2.B-Fan Low",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "16204",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 9 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 9 B7 5",
+          "name": "Main BR KP2.C-Fan Off",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "16204",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 9 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 9 B7 6",
+          "name": "Main BR KP2.D-Fan Med",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "16204",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 9 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 4E 68 4",
+          "name": "Main BR Patio KP.D-AutoLock",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 4E 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 4E 68 5",
+          "name": "Main BR Patio KP.E",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 4E 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "51 FC 21 1",
+          "name": "Family Room Fan Power",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "2.42.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "51 FC 21 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 4E 68 6",
+          "name": "Main BR Patio KP.F",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 4E 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "48 B C9 1",
+          "name": "Garage Side Spotlights",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "48 B C9 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "54 8F C0 1",
+          "name": "Primary Bath Toilet Leak.Dry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57751",
+            "type": "3"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "54 8F C0 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "54 8F C0 2",
+          "name": "Primary Bath Toilet Leak.Wet",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "54 8F C0 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "54 8F C0 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "54 8F C0 4",
+          "name": "Primary Bath Toilet Leak.HB",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "54 8F C0 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "54 8F C0 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "144",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "41 8A 6E 1",
+          "name": "Tims Office Desk Rcpt-Top",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "5732",
+            "type": "3"
+          },
+          "type": "2.57.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "41 8A 6E 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "41 8A 6E 2",
+          "name": "Tims Office Desk Rcpt-Bottom",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "5732",
+            "type": "3"
+          },
+          "type": "2.57.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "41 8A 6E 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 4E 68 7",
+          "name": "Main BR Patio KP.G-Yard Spots",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 4E 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "23 FF 50 1",
+          "name": "Laundry Room",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "48237",
+            "type": "3"
+          },
+          "type": "2.42.67.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "23 FF 50 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "25 9 8B 1",
+          "name": "Kitchen Alcove",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 9 8B 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 9 8B 3",
+          "name": "Kitchen KP.A-Recessed",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "53085",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 9 8B 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 9 8B 4",
+          "name": "Kitchen KP.B-Hallway",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "53085",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 9 8B 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 9 8B 5",
+          "name": "Kitchen KP.C-All Kitchen",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "53085",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 9 8B 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 9 8B 6",
+          "name": "Kitchen KP.D-FR Recessed",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 9 8B 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "40 4E 68 8",
+          "name": "Main BR Patio KP.H-Garage Doo",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "40 4E 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "57 2F F2 1",
+          "name": "Staircase",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 2F F2 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "25 8 B7 1",
+          "name": "Patio KP.A-Patio Sconces",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15829",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 B7 2",
+          "name": "Patio KP.B",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "24 72 75 1",
+          "name": "Main Bedroom Recessed_S",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "16204",
+            "type": "3"
+          },
+          "type": "1.32.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "24 72 75 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampOnly",
+          "address": "23 11 84 1",
+          "name": "Main Bedroom Fan Light",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "type": "1.46.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "23 11 84 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "FanLincMotor",
+          "address": "23 11 84 2",
+          "name": "Main Bedroom Ceiling Fan",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "type": "1.46.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "23 11 84 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 B7 3",
+          "name": "Patio KP.C-Patio Fan",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 B7 4",
+          "name": "Patio KP.D-AutoLock",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 B7 5",
+          "name": "Patio KP.E-Landscape",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 B7 6",
+          "name": "Patio KP.F-Lamp",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 B7 7",
+          "name": "Patio KP.G-Yard Spots",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 B7 8",
+          "name": "Patio KP.H",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 B7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "52 B B 1",
+          "name": "Appliance UC Lights",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "type": "2.42.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "52 B B 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadRelay_ADV",
+          "address": "57 7F F6 1",
+          "name": "Sink UC Lights",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "type": "2.44.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 7F F6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 7F F6 3",
+          "name": "Sink KP.A-Garbage Disposal",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "53085",
+            "type": "3"
+          },
+          "type": "2.44.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 7F F6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 7F F6 4",
+          "name": "Sink KP.B-Hot Water",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "type": "2.44.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 7F F6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 7F F6 5",
+          "name": "Sink KP.C",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "type": "2.44.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 7F F6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 7F F6 6",
+          "name": "Sink KP.D-All Kitchen",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "type": "2.44.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 7F F6 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "57 3B C5 1",
+          "name": "Art Light",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 3B C5 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "57 3B 87 1",
+          "name": "Office Recessed",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 3B 87 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "25 8 20 1",
+          "name": "Upstairs KP.0-Staircase",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "22480",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 20 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 20 3",
+          "name": "Upstairs KP.A-Entry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "22480",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 20 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 20 4",
+          "name": "Upstairs KP.B",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 20 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 20 5",
+          "name": "Upstairs KP.C",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 20 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "25 8 20 6",
+          "name": "Upstairs KP.D",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "type": "1.66.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 8 20 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "57 3B 6A 1",
+          "name": "Powder Room Light",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "6303",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 3B 6A 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "57 2E 2B 1",
+          "name": "Tims Sink",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 2E 2B 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "57 3B A7 1",
+          "name": "Shower Light",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 3B A7 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "57 3B 50 1",
+          "name": "Water Closet Light",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 3B 50 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "56 D3 A5 1",
+          "name": "Hallway Light",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 D3 A5 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 D3 A5 3",
+          "name": "Hallway KP.A-Entry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 D3 A5 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 D3 A5 4",
+          "name": "Hallway KP.B-Living Room",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 D3 A5 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 D3 A5 5",
+          "name": "Hallway KP.C-Office",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 D3 A5 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 D3 A5 6",
+          "name": "Hallway KP.D-Stairs",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 D3 A5 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "25 B8 1F 1",
+          "name": "West Water Heater.Dry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57751",
+            "type": "3"
+          },
+          "type": "16.8.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 B8 1F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "25 B8 1F 2",
+          "name": "West Water Heater.Wet",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "25 B8 1F 1",
+            "type": "1"
+          },
+          "type": "16.8.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 B8 1F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "25 B8 1F 4",
+          "name": "West Water Heater.HB",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "25 B8 1F 1",
+            "type": "1"
+          },
+          "type": "16.8.65.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "25 B8 1F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "57 3B 8F 1",
+          "name": "Main Bathroom Recessed Left",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 3B 8F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 9 D2 1",
+          "name": "Kitchen Sink Leak.Dry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57751",
+            "type": "3"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 9 D2 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 9 D2 2",
+          "name": "Kitchen Sink Leak.Wet",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 9 D2 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 9 D2 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 9 D2 4",
+          "name": "Kitchen Sink Leak.HB",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 9 D2 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 9 D2 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "53 5C 95 1",
+          "name": "Water Closet Fan",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "type": "2.42.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "53 5C 95 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "57 24 38 1",
+          "name": "Main Bathroom Recessed Right",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 24 38 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 24 38 2",
+          "name": "Main Bath KP.B-Hot Water",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35553",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 24 38 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 24 38 3",
+          "name": "Main Bath KP.C-Lindsays Sink",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35553",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 24 38 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 24 38 4",
+          "name": "Main Bath KP.D-Toilet Light",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35553",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 24 38 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 24 38 5",
+          "name": "Main Bath KP.E-Chandelier",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35553",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 24 38 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 24 38 6",
+          "name": "Main Bath KP.F-Fan",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35553",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 24 38 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 24 38 7",
+          "name": "Main Bath KP.G-All On",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35553",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 24 38 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 24 38 8",
+          "name": "Main Bath KP.H-All Off",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35553",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 24 38 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "57 2F BF 1",
+          "name": "Lindsay's Sink",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 2F BF 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "50 55 C 1",
+          "name": "Main Bedroom Recessed",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "50 55 C 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "50 55 C 3",
+          "name": "MBR Bath KP.A-Lamps",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "516",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "50 55 C 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "4F CF 54 1",
+          "name": "Patio Recessed",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "type": "1.32.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "4F CF 54 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "50 55 C 4",
+          "name": "MBR Bath KP.B",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "516",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "50 55 C 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "50 55 C 5",
+          "name": "MBR Bath KP.C",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "516",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "50 55 C 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "50 55 C 6",
+          "name": "MBR Bath KP.D",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "516",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "50 55 C 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "56 D5 68 1",
+          "name": "Bedroom Hall",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 D5 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 D5 68 3",
+          "name": "Bedroom Hall KP.A-Hallway",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 D5 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 D5 68 4",
+          "name": "Bedroom Hall KP.B",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 D5 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 D5 68 5",
+          "name": "Bedroom Hall KP.C-Night Light",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 D5 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 D5 68 6",
+          "name": "Bedroom Hall KP.D-All Off",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "15904",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 D5 68 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "2D AF 71 1",
+          "name": "Laundry Room.Motion",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "48237",
+            "type": "3"
+          },
+          "type": "16.1.65.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "2D AF 71 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "2D AF 71 2",
+          "name": "Laundry Room.Dusk-Dawn",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "2D AF 71 1",
+            "type": "1"
+          },
+          "type": "16.1.65.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "2D AF 71 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "2D AF 71 3",
+          "name": "Laundry Room.Low Batt",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "2D AF 71 1",
+            "type": "1"
+          },
+          "type": "16.1.65.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "2D AF 71 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "37 72 2D 1",
+          "name": "Washer Leak.Dry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57751",
+            "type": "3"
+          },
+          "type": "16.8.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "37 72 2D 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "37 72 2D 2",
+          "name": "Washer Leak.Wet",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "37 72 2D 1",
+            "type": "1"
+          },
+          "type": "16.8.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "37 72 2D 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "37 72 2D 4",
+          "name": "Washer Leak.HB",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "37 72 2D 1",
+            "type": "1"
+          },
+          "type": "16.8.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "37 72 2D 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "37 6E 8E 1",
+          "name": "Kitchen Refrigerator Leak.Dry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57751",
+            "type": "3"
+          },
+          "type": "16.8.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "37 6E 8E 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "37 6E 8E 2",
+          "name": "Kitchen Refrigerator Leak.Wet",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "37 6E 8E 1",
+            "type": "1"
+          },
+          "type": "16.8.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "37 6E 8E 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "37 6E 8E 4",
+          "name": "Kitchen Refrigerator Leak.HB",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "37 6E 8E 1",
+            "type": "1"
+          },
+          "type": "16.8.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "37 6E 8E 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "41 E1 58 6",
+          "name": "Driveway KP.F",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "41 E1 58 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "41 E1 58 7",
+          "name": "Driveway KP.G-Garage Door",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "41 E1 58 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "41 E1 58 8",
+          "name": "Driveway KP.H-All Off",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "41 E1 58 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "controller",
+          "address": "n010_controller",
+          "name": "FlumeWater",
+          "family": {
+            "_": "10",
+            "instance": "10"
+          },
+          "hint": "0.0.0.0",
+          "type": "0.0.0.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "n010_controller",
+          "property": [],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "52 19 CD 0",
+          "name": "USB Adapter - 0",
+          "hint": "0.0.0.0",
+          "type": "3.32.58.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "52 19 CD 0",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "37 41 FE 1",
+          "name": "Living Room Christmas Tree",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "63777",
+            "type": "3"
+          },
+          "type": "2.55.72.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "37 41 FE 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "47 DC 75 1",
+          "name": "Palm Lamp",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "43287",
+            "type": "3"
+          },
+          "type": "1.14.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "47 DC 75 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadRelay_ADV",
+          "address": "57 81 2F 1",
+          "name": "Game Room Fan Power",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "43287",
+            "type": "3"
+          },
+          "type": "2.44.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 81 2F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "4B E7 27 1",
+          "name": "Powder Room Fan",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "6303",
+            "type": "3"
+          },
+          "type": "2.42.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "4B E7 27 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 81 2F 3",
+          "name": "Game KP.A-Lamps",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "43287",
+            "type": "3"
+          },
+          "type": "2.44.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 81 2F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 81 2F 4",
+          "name": "Game KP.B-Palm Lamp",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "43287",
+            "type": "3"
+          },
+          "type": "2.44.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 81 2F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "56 CD 91 1",
+          "name": "Office Chandelier",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 CD 91 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 81 2F 5",
+          "name": "Game KP.C",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "43287",
+            "type": "3"
+          },
+          "type": "2.44.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 81 2F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 CD 91 3",
+          "name": "Office KP.A-Crystal Lamp",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 CD 91 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "57 81 2F 6",
+          "name": "Game KP.D",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "43287",
+            "type": "3"
+          },
+          "type": "2.44.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "57 81 2F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "flume2",
+          "address": "n010_84dd4c2c24c3b7",
+          "name": "Flume Sensor 7061689622625877",
+          "family": {
+            "_": "10",
+            "instance": "10"
+          },
+          "hint": "1.2.3.4",
+          "parent": {
+            "_": "n010_controller",
+            "type": "1"
+          },
+          "type": "1.2.3.4",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "n010_controller",
+          "property": [],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 CD 91 4",
+          "name": "Office KP.B-Small Lamp",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 CD 91 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 CD 91 5",
+          "name": "Office KP.C",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 CD 91 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "56 CD 91 6",
+          "name": "Office KP.D-All Off",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "type": "1.66.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "56 CD 91 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "35 53 B3 1",
+          "name": "Nursery Bathroom Lamp",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "38227",
+            "type": "3"
+          },
+          "type": "1.14.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "35 53 B3 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "2E BA CA 1",
+          "name": "Game Room Christmas Tree",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "63777",
+            "type": "3"
+          },
+          "type": "1.14.67.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "2E BA CA 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "2E BC E 1",
+          "name": "Guest Room Lamp Left",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "12120",
+            "type": "3"
+          },
+          "type": "1.14.67.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "2E BC E 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "2E BD E4 1",
+          "name": "Guest Room Lamp Right",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "12120",
+            "type": "3"
+          },
+          "type": "1.14.67.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "2E BD E4 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "KeypadDimmer_ADV",
+          "address": "43 60 3F 1",
+          "name": "Main BR KP1.0-Main BR Recesse",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "16204",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "43 60 3F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "43 60 3F 3",
+          "name": "Main BR KP1.A-Lamps",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "516",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "43 60 3F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "43 60 3F 4",
+          "name": "Main BR KP1.B",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "516",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "43 60 3F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "43 60 3F 5",
+          "name": "Main BR KP1.C",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "516",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "43 60 3F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "KeypadButton_ADV",
+          "address": "43 60 3F 6",
+          "name": "Main BR KP1.D-All Main BR",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "516",
+            "type": "3"
+          },
+          "type": "1.65.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "43 60 3F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "3E 79 2 1",
+          "name": "Crystal Lamp",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "type": "1.14.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "3E 79 2 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "flume2",
+          "address": "n010_6d69de681ff5a4",
+          "name": "Flume Sensor 7176162361365694",
+          "family": {
+            "_": "10",
+            "instance": "10"
+          },
+          "hint": "1.2.3.4",
+          "parent": {
+            "_": "n010_controller",
+            "type": "1"
+          },
+          "type": "1.2.3.4",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "n010_controller",
+          "property": [],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "flume1",
+          "address": "n010_3b2f79f31f1178",
+          "name": "Flume Hub 7073884887311057874",
+          "family": {
+            "_": "10",
+            "instance": "10"
+          },
+          "hint": "1.2.3.4",
+          "parent": {
+            "_": "n010_controller",
+            "type": "1"
+          },
+          "type": "1.2.3.4",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "n010_controller",
+          "property": [],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "flume1",
+          "address": "n010_b626e58fd768ff",
+          "name": "Flume Hub 7073885113265340056",
+          "family": {
+            "_": "10",
+            "instance": "10"
+          },
+          "hint": "1.2.3.4",
+          "parent": {
+            "_": "n010_controller",
+            "type": "1"
+          },
+          "type": "1.2.3.4",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "n010_controller",
+          "property": [],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 B 71 1",
+          "name": "Guest Bath Sink.Dry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57751",
+            "type": "3"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 B 71 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 B 71 2",
+          "name": "Guest Bath Sink.Wet",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 B 71 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 B 71 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 B 71 4",
+          "name": "Guest Bath Sink.HB",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 B 71 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 B 71 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 A EA 1",
+          "name": "Utility Sink Leak.Dry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57751",
+            "type": "3"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 A EA 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 A EA 2",
+          "name": "Utility Sink Leak.Wet",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 A EA 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 A EA 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 A EA 4",
+          "name": "Utility Sink Leak.HB",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 A EA 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 A EA 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 9 DA 1",
+          "name": "Guest Toilet Leak.Dry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57751",
+            "type": "3"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 9 DA 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 9 DA 2",
+          "name": "Guest Toilet Leak.Wet",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 9 DA 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 9 DA 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 9 DA 4",
+          "name": "Guest Toilet Leak.HB",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 9 DA 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 9 DA 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 B A 1",
+          "name": "Upstairs Toilet Leak.Dry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57751",
+            "type": "3"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 B A 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 B A 2",
+          "name": "Upstairs Toilet Leak.Wet",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 B A 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 B A 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 B A 4",
+          "name": "Upstairs Toilet Leak.HB",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 B A 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 B A 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "35 53 56 1",
+          "name": "Mexican Tree",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "63777",
+            "type": "3"
+          },
+          "type": "1.14.67.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "35 53 56 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "47 E1 67 1",
+          "name": "Nursery Christmas Tree",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "63777",
+            "type": "3"
+          },
+          "type": "1.14.67.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "47 E1 67 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "49 30 A5 1",
+          "name": "Baby Christmas Tree",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "63777",
+            "type": "3"
+          },
+          "type": "2.55.72.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "49 30 A5 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "HarmonyController",
+          "address": "n009_harmonyctrl",
+          "name": "HarmonyHub Controller",
+          "family": {
+            "_": "10",
+            "instance": "9"
+          },
+          "hint": "0.0.0.0",
+          "type": "0.0.0.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "n009_harmonyctrl",
+          "property": [],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "RelayLampSwitch_ADV",
+          "address": "53 5A 31 1",
+          "name": "Garage Lights East",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "46696",
+            "type": "3"
+          },
+          "type": "2.42.69.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "53 5A 31 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 3 21 1",
+          "name": "East Water Heater Leak.Dry",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57751",
+            "type": "3"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 3 21 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 3 21 2",
+          "name": "East Water Heater Leak.Wet",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 3 21 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 3 21 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "BinaryAlarm_ADV",
+          "address": "55 3 21 4",
+          "name": "East Water Heater Leak.HB",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "55 3 21 1",
+            "type": "1"
+          },
+          "type": "16.8.68.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "55 3 21 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "255",
+              "formatted": "On",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "DimmerLampSwitch_ADV",
+          "address": "2E B8 75 1",
+          "name": "Office Crystal Lamp",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "type": "1.14.67.0",
+          "enabled": "true",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "2E B8 75 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "0",
+              "formatted": "Off",
+              "uom": "100",
+              "name": ""
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "128",
+          "nodeDefId": "RemoteLinc2_ADV",
+          "address": "3E FF 1F 1",
+          "name": "Test Remote - A-B",
+          "hint": "0.0.0.0",
+          "type": "0.26.57.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "3E FF 1F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "RemoteLinc2_ADV",
+          "address": "3E FF 1F 2",
+          "name": "Test Remote - C-D",
+          "hint": "0.0.0.0",
+          "type": "0.26.57.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "3E FF 1F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "RemoteLinc2_ADV",
+          "address": "3E FF 1F 3",
+          "name": "Test Remote - E-F",
+          "hint": "0.0.0.0",
+          "type": "0.26.57.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "3E FF 1F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        },
+        {
+          "flag": "0",
+          "nodeDefId": "RemoteLinc2_ADV",
+          "address": "3E FF 1F 4",
+          "name": "Test Remote - G-H - Test",
+          "hint": "0.0.0.0",
+          "type": "0.26.57.0",
+          "enabled": "false",
+          "deviceClass": "0",
+          "wattage": "0",
+          "dcPeriod": "0",
+          "startDelay": "0",
+          "endDelay": "0",
+          "pnode": "3E FF 1F 1",
+          "property": [
+            {
+              "id": "ST",
+              "value": "",
+              "formatted": " ",
+              "uom": "0"
+            }
+          ],
+          "nodeType": "node"
+        }
+      ],
+      "folder": [
+        {
+          "flag": "0",
+          "address": "42106",
+          "name": "Entry",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "24534",
+          "name": "Family Room",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "43287",
+          "name": "Game Room",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "46696",
+          "name": "Garage",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "52164",
+          "name": "Kitchen",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "57370",
+          "name": "Living Room",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "47298",
+          "name": "Office",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "35180",
+          "name": "Patio",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "6303",
+          "name": "Powder Room",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "507",
+          "name": "Main Bathroom",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "11981",
+          "name": "Main Bedroom",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "5732",
+          "name": "Tim's Office",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "57751",
+          "name": "Leak",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "63777",
+          "name": "Miscellaneous",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "48237",
+          "name": "Laundry",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "53085",
+          "name": "[c]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "22480",
+          "name": "[c]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "37989",
+          "name": "[c][i]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "4342",
+          "name": "[c]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "46696",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "15829",
+          "name": "[c][i]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "16204",
+          "name": "[c][i]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "35553",
+          "name": "[c]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "28721",
+          "name": "[p]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "4307",
+          "name": "Alarm[i]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "12120",
+          "name": "Guest Bedroom",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "36485",
+          "name": "Exterior",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "15904",
+          "name": "[c]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "38227",
+          "name": "Nursery1",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "516",
+          "name": "[c]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        },
+        {
+          "flag": "0",
+          "address": "15377",
+          "name": "[p]",
+          "family": "13",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "46696",
+            "type": "3"
+          },
+          "nodeType": "folder"
+        }
+      ],
+      "group": [
+        {
+          "flag": "12",
+          "nodeDefId": "InsteonDimmer",
+          "address": "00:00:00:00:00:00",
+          "name": "eisy-anon",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "members": {
+            "link": [
+              {
+                "_": "3D 7D 87 1",
+                "type": "0"
+              },
+              {
+                "_": "3D 7D 87 3",
+                "type": "0"
+              },
+              {
+                "_": "3D 7D 87 4",
+                "type": "0"
+              },
+              {
+                "_": "3D 7D 87 5",
+                "type": "0"
+              },
+              {
+                "_": "3D 7D 87 6",
+                "type": "0"
+              },
+              {
+                "_": "40 4E 68 1",
+                "type": "0"
+              },
+              {
+                "_": "40 4E 68 2",
+                "type": "0"
+              },
+              {
+                "_": "40 4E 68 3",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 1",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 2",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 3",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 4",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 5",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 6",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 7",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 8",
+                "type": "0"
+              },
+              {
+                "_": "43 64 E6 1",
+                "type": "0"
+              },
+              {
+                "_": "43 64 E6 3",
+                "type": "0"
+              },
+              {
+                "_": "43 64 E6 4",
+                "type": "0"
+              },
+              {
+                "_": "43 64 E6 5",
+                "type": "0"
+              },
+              {
+                "_": "43 64 E6 6",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 98 1",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 1",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 2",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 3",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 4",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 5",
+                "type": "0"
+              },
+              {
+                "_": "42 B4 1C 1",
+                "type": "0"
+              },
+              {
+                "_": "48 7 1F 1",
+                "type": "0"
+              },
+              {
+                "_": "29 CA 5F 1",
+                "type": "0"
+              },
+              {
+                "_": "22 D8 60 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 68 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B1 37 1",
+                "type": "0"
+              },
+              {
+                "_": "22 E5 E5 1",
+                "type": "0"
+              },
+              {
+                "_": "23 D5 6 1",
+                "type": "0"
+              },
+              {
+                "_": "49 2D 7E 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 B7 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 32 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 B7 3",
+                "type": "0"
+              },
+              {
+                "_": "25 9 B7 4",
+                "type": "0"
+              },
+              {
+                "_": "25 9 B7 5",
+                "type": "0"
+              },
+              {
+                "_": "25 9 B7 6",
+                "type": "0"
+              },
+              {
+                "_": "40 4E 68 4",
+                "type": "0"
+              },
+              {
+                "_": "40 4E 68 5",
+                "type": "0"
+              },
+              {
+                "_": "51 FC 21 1",
+                "type": "0"
+              },
+              {
+                "_": "40 4E 68 6",
+                "type": "0"
+              },
+              {
+                "_": "48 B C9 1",
+                "type": "0"
+              },
+              {
+                "_": "54 8F C0 1",
+                "type": "0"
+              },
+              {
+                "_": "54 8F C0 2",
+                "type": "0"
+              },
+              {
+                "_": "54 8F C0 4",
+                "type": "0"
+              },
+              {
+                "_": "41 8A 6E 1",
+                "type": "0"
+              },
+              {
+                "_": "41 8A 6E 2",
+                "type": "0"
+              },
+              {
+                "_": "40 4E 68 7",
+                "type": "0"
+              },
+              {
+                "_": "23 FF 50 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 3",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 4",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 5",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 6",
+                "type": "0"
+              },
+              {
+                "_": "40 4E 68 8",
+                "type": "0"
+              },
+              {
+                "_": "57 2F F2 1",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 1",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 2",
+                "type": "0"
+              },
+              {
+                "_": "24 72 75 1",
+                "type": "0"
+              },
+              {
+                "_": "23 11 84 1",
+                "type": "0"
+              },
+              {
+                "_": "23 11 84 2",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 3",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 4",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 5",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 6",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 7",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 8",
+                "type": "0"
+              },
+              {
+                "_": "52 B B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 1",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 3",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 4",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 5",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 6",
+                "type": "0"
+              },
+              {
+                "_": "57 3B C5 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 87 1",
+                "type": "0"
+              },
+              {
+                "_": "25 8 20 1",
+                "type": "0"
+              },
+              {
+                "_": "25 8 20 3",
+                "type": "0"
+              },
+              {
+                "_": "25 8 20 4",
+                "type": "0"
+              },
+              {
+                "_": "25 8 20 5",
+                "type": "0"
+              },
+              {
+                "_": "25 8 20 6",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 6A 1",
+                "type": "0"
+              },
+              {
+                "_": "57 2E 2B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B A7 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 50 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 3",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 4",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 5",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 6",
+                "type": "0"
+              },
+              {
+                "_": "25 B8 1F 1",
+                "type": "0"
+              },
+              {
+                "_": "25 B8 1F 2",
+                "type": "0"
+              },
+              {
+                "_": "25 B8 1F 4",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 8F 1",
+                "type": "0"
+              },
+              {
+                "_": "55 9 D2 1",
+                "type": "0"
+              },
+              {
+                "_": "55 9 D2 2",
+                "type": "0"
+              },
+              {
+                "_": "55 9 D2 4",
+                "type": "0"
+              },
+              {
+                "_": "53 5C 95 1",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 1",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 2",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 3",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 4",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 5",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 6",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 7",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 8",
+                "type": "0"
+              },
+              {
+                "_": "57 2F BF 1",
+                "type": "0"
+              },
+              {
+                "_": "50 55 C 1",
+                "type": "0"
+              },
+              {
+                "_": "50 55 C 3",
+                "type": "0"
+              },
+              {
+                "_": "4F CF 54 1",
+                "type": "0"
+              },
+              {
+                "_": "50 55 C 4",
+                "type": "0"
+              },
+              {
+                "_": "50 55 C 5",
+                "type": "0"
+              },
+              {
+                "_": "50 55 C 6",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 3",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 4",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 5",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 6",
+                "type": "0"
+              },
+              {
+                "_": "2D AF 71 1",
+                "type": "0"
+              },
+              {
+                "_": "2D AF 71 2",
+                "type": "0"
+              },
+              {
+                "_": "2D AF 71 3",
+                "type": "0"
+              },
+              {
+                "_": "37 72 2D 1",
+                "type": "0"
+              },
+              {
+                "_": "37 72 2D 2",
+                "type": "0"
+              },
+              {
+                "_": "37 72 2D 4",
+                "type": "0"
+              },
+              {
+                "_": "37 6E 8E 1",
+                "type": "0"
+              },
+              {
+                "_": "37 6E 8E 2",
+                "type": "0"
+              },
+              {
+                "_": "37 6E 8E 4",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 6",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 7",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 8",
+                "type": "0"
+              },
+              {
+                "_": "n010_controller",
+                "type": "0"
+              },
+              {
+                "_": "52 19 CD 0",
+                "type": "0"
+              },
+              {
+                "_": "37 41 FE 1",
+                "type": "0"
+              },
+              {
+                "_": "47 DC 75 1",
+                "type": "0"
+              },
+              {
+                "_": "57 81 2F 1",
+                "type": "0"
+              },
+              {
+                "_": "4B E7 27 1",
+                "type": "0"
+              },
+              {
+                "_": "57 81 2F 3",
+                "type": "0"
+              },
+              {
+                "_": "57 81 2F 4",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 1",
+                "type": "0"
+              },
+              {
+                "_": "57 81 2F 5",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 3",
+                "type": "0"
+              },
+              {
+                "_": "57 81 2F 6",
+                "type": "0"
+              },
+              {
+                "_": "n010_84dd4c2c24c3b7",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 4",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 5",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 6",
+                "type": "0"
+              },
+              {
+                "_": "35 53 B3 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BA CA 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BC E 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BD E4 1",
+                "type": "0"
+              },
+              {
+                "_": "43 60 3F 1",
+                "type": "0"
+              },
+              {
+                "_": "43 60 3F 3",
+                "type": "0"
+              },
+              {
+                "_": "43 60 3F 4",
+                "type": "0"
+              },
+              {
+                "_": "43 60 3F 5",
+                "type": "0"
+              },
+              {
+                "_": "43 60 3F 6",
+                "type": "0"
+              },
+              {
+                "_": "3E 79 2 1",
+                "type": "0"
+              },
+              {
+                "_": "n010_6d69de681ff5a4",
+                "type": "0"
+              },
+              {
+                "_": "n010_3b2f79f31f1178",
+                "type": "0"
+              },
+              {
+                "_": "n010_b626e58fd768ff",
+                "type": "0"
+              },
+              {
+                "_": "55 B 71 1",
+                "type": "0"
+              },
+              {
+                "_": "55 B 71 2",
+                "type": "0"
+              },
+              {
+                "_": "55 B 71 4",
+                "type": "0"
+              },
+              {
+                "_": "55 A EA 1",
+                "type": "0"
+              },
+              {
+                "_": "55 A EA 2",
+                "type": "0"
+              },
+              {
+                "_": "55 A EA 4",
+                "type": "0"
+              },
+              {
+                "_": "55 9 DA 1",
+                "type": "0"
+              },
+              {
+                "_": "55 9 DA 2",
+                "type": "0"
+              },
+              {
+                "_": "55 9 DA 4",
+                "type": "0"
+              },
+              {
+                "_": "55 B A 1",
+                "type": "0"
+              },
+              {
+                "_": "55 B A 2",
+                "type": "0"
+              },
+              {
+                "_": "55 B A 4",
+                "type": "0"
+              },
+              {
+                "_": "35 53 56 1",
+                "type": "0"
+              },
+              {
+                "_": "47 E1 67 1",
+                "type": "0"
+              },
+              {
+                "_": "49 30 A5 1",
+                "type": "0"
+              },
+              {
+                "_": "n009_harmonyctrl",
+                "type": "0"
+              },
+              {
+                "_": "53 5A 31 1",
+                "type": "0"
+              },
+              {
+                "_": "55 3 21 1",
+                "type": "0"
+              },
+              {
+                "_": "55 3 21 2",
+                "type": "0"
+              },
+              {
+                "_": "55 3 21 4",
+                "type": "0"
+              },
+              {
+                "_": "2E B8 75 1",
+                "type": "0"
+              },
+              {
+                "_": "3E FF 1F 1",
+                "type": "0"
+              },
+              {
+                "_": "3E FF 1F 2",
+                "type": "0"
+              },
+              {
+                "_": "3E FF 1F 3",
+                "type": "0"
+              },
+              {
+                "_": "3E FF 1F 4",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "ADR0001",
+          "name": "~zAuto DR[i]1",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "deviceGroup": "16",
+          "pnode": "ADR0001",
+          "members": {
+            "link": []
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "55090",
+          "name": "[s]Driveway",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "deviceGroup": "106",
+          "pnode": "55090",
+          "members": {
+            "link": [
+              {
+                "_": "3D 7D 87 1",
+                "type": "0"
+              },
+              {
+                "_": "48 7 1F 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "15509",
+          "name": "[p]Game Room Lamps",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "43287",
+            "type": "3"
+          },
+          "deviceGroup": "85",
+          "pnode": "15509",
+          "members": {
+            "link": [
+              {
+                "_": "57 81 2F 3",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "36858",
+          "name": "[p]Front Porch Timer",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "deviceGroup": "22",
+          "pnode": "36858",
+          "members": {
+            "link": [
+              {
+                "_": "23 B5 32 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "5963",
+          "name": "[p]Backyard Spotlights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "deviceGroup": "83",
+          "pnode": "5963",
+          "members": {
+            "link": [
+              {
+                "_": "3D 7D 87 3",
+                "type": "0"
+              },
+              {
+                "_": "40 4E 68 7",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 7",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "5116",
+          "name": "[p]Driveway KP.B-Garage Overh",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "84",
+          "pnode": "5116",
+          "members": {
+            "link": [
+              {
+                "_": "41 E1 58 2",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "45311",
+          "name": "[p]Living Room Fan Off",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "28721",
+            "type": "3"
+          },
+          "deviceGroup": "86",
+          "pnode": "45311",
+          "members": {
+            "link": [
+              {
+                "_": "40 FD 8 3",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 4",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 5",
+                "type": "16"
+              },
+              {
+                "_": "40 FD 8 6",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "8499",
+          "name": "[p]Living Room Fan Low",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "28721",
+            "type": "3"
+          },
+          "deviceGroup": "87",
+          "pnode": "8499",
+          "members": {
+            "link": [
+              {
+                "_": "40 FD 8 3",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 4",
+                "type": "16"
+              },
+              {
+                "_": "40 FD 8 5",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 6",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "11937",
+          "name": "Main Bedroom Fan Light",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "42",
+          "pnode": "11937",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 B7 1",
+                "type": "16"
+              },
+              {
+                "_": "23 11 84 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "23284",
+          "name": "Main Bedroom Fan Off",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "43",
+          "pnode": "23284",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 B7 5",
+                "type": "16"
+              },
+              {
+                "_": "23 11 84 2",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "36761",
+          "name": "Main Bedroom Fan Low",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "44",
+          "pnode": "36761",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 B7 4",
+                "type": "16"
+              },
+              {
+                "_": "23 11 84 2",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "16356",
+          "name": "Main Bedroom Fan Med",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "45",
+          "pnode": "16356",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 B7 6",
+                "type": "16"
+              },
+              {
+                "_": "23 11 84 2",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "56824",
+          "name": "Main Bedroom Fan High",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "46",
+          "pnode": "56824",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 B7 3",
+                "type": "16"
+              },
+              {
+                "_": "23 11 84 2",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "13588",
+          "name": "[p]Living Room Fan Med",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "28721",
+            "type": "3"
+          },
+          "deviceGroup": "88",
+          "pnode": "13588",
+          "members": {
+            "link": [
+              {
+                "_": "40 FD 8 3",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 4",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 5",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 6",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "61901",
+          "name": "[p]Living Room Fan High",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "28721",
+            "type": "3"
+          },
+          "deviceGroup": "89",
+          "pnode": "61901",
+          "members": {
+            "link": [
+              {
+                "_": "40 FD 8 3",
+                "type": "16"
+              },
+              {
+                "_": "40 FD 8 4",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 5",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 6",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "5626",
+          "name": "Under Cabinet Lights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "deviceGroup": "17",
+          "pnode": "5626",
+          "members": {
+            "link": [
+              {
+                "_": "52 B B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "40282",
+          "name": "Kitchen Recessed",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "deviceGroup": "18",
+          "pnode": "40282",
+          "members": {
+            "link": [
+              {
+                "_": "23 B5 98 1",
+                "type": "0"
+              },
+              {
+                "_": "23 D5 6 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "21943",
+          "name": "Garbage Disposal",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "deviceGroup": "19",
+          "pnode": "21943",
+          "members": {
+            "link": [
+              {
+                "_": "49 2D 7E 1",
+                "type": "16"
+              },
+              {
+                "_": "57 7F F6 3",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "20070",
+          "name": "[s]Staircase",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "deviceGroup": "20",
+          "pnode": "20070",
+          "members": {
+            "link": [
+              {
+                "_": "22 E5 E5 1",
+                "type": "16"
+              },
+              {
+                "_": "57 2F F2 1",
+                "type": "16"
+              },
+              {
+                "_": "25 8 20 1",
+                "type": "16"
+              },
+              {
+                "_": "56 D3 A5 6",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "36766",
+          "name": "[s]Breezeway",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "deviceGroup": "21",
+          "pnode": "36766",
+          "members": {
+            "link": [
+              {
+                "_": "3D 7D 87 1",
+                "type": "16"
+              },
+              {
+                "_": "41 E1 58 1",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "26013",
+          "name": "Family Room Recessed",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "23",
+          "pnode": "26013",
+          "members": {
+            "link": [
+              {
+                "_": "42 B4 1C 1",
+                "type": "16"
+              },
+              {
+                "_": "23 B5 68 1",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "5958",
+          "name": "[s]Patio Sconces",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "deviceGroup": "24",
+          "pnode": "5958",
+          "members": {
+            "link": [
+              {
+                "_": "40 4E 68 1",
+                "type": "16"
+              },
+              {
+                "_": "25 8 B7 1",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "2089",
+          "name": "[s]Main Bedroom Recessed",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "25",
+          "pnode": "2089",
+          "members": {
+            "link": [
+              {
+                "_": "24 72 75 1",
+                "type": "16"
+              },
+              {
+                "_": "50 55 C 1",
+                "type": "16"
+              },
+              {
+                "_": "43 60 3F 1",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "51848",
+          "name": "[p]Kitchen Recessed Fast",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "53085",
+            "type": "3"
+          },
+          "deviceGroup": "90",
+          "pnode": "51848",
+          "members": {
+            "link": [
+              {
+                "_": "23 B5 98 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "23691",
+          "name": "All Off Stay",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "deviceGroup": "26",
+          "pnode": "23691",
+          "members": {
+            "link": [
+              {
+                "_": "3D 7D 87 1",
+                "type": "0"
+              },
+              {
+                "_": "40 4E 68 1",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 1",
+                "type": "0"
+              },
+              {
+                "_": "43 64 E6 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 98 1",
+                "type": "0"
+              },
+              {
+                "_": "42 B4 1C 1",
+                "type": "0"
+              },
+              {
+                "_": "48 7 1F 1",
+                "type": "0"
+              },
+              {
+                "_": "29 CA 5F 1",
+                "type": "0"
+              },
+              {
+                "_": "22 D8 60 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 68 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B1 37 1",
+                "type": "0"
+              },
+              {
+                "_": "22 E5 E5 1",
+                "type": "0"
+              },
+              {
+                "_": "23 D5 6 1",
+                "type": "0"
+              },
+              {
+                "_": "48 B C9 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 2F F2 1",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 1",
+                "type": "0"
+              },
+              {
+                "_": "52 B B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B C5 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 87 1",
+                "type": "0"
+              },
+              {
+                "_": "25 8 20 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 6A 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 1",
+                "type": "0"
+              },
+              {
+                "_": "4F CF 54 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 5",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 6",
+                "type": "16"
+              },
+              {
+                "_": "37 41 FE 1",
+                "type": "0"
+              },
+              {
+                "_": "47 DC 75 1",
+                "type": "0"
+              },
+              {
+                "_": "4B E7 27 1",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 1",
+                "type": "0"
+              },
+              {
+                "_": "35 53 B3 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BA CA 1",
+                "type": "0"
+              },
+              {
+                "_": "35 53 56 1",
+                "type": "0"
+              },
+              {
+                "_": "47 E1 67 1",
+                "type": "0"
+              },
+              {
+                "_": "49 30 A5 1",
+                "type": "0"
+              },
+              {
+                "_": "53 5A 31 1",
+                "type": "0"
+              },
+              {
+                "_": "2E B8 75 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "7505",
+          "name": "All Off Exit",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "deviceGroup": "27",
+          "pnode": "7505",
+          "members": {
+            "link": [
+              {
+                "_": "40 4E 68 2",
+                "type": "0"
+              },
+              {
+                "_": "40 FD 8 1",
+                "type": "0"
+              },
+              {
+                "_": "43 64 E6 1",
+                "type": "0"
+              },
+              {
+                "_": "43 64 E6 6",
+                "type": "16"
+              },
+              {
+                "_": "23 B5 98 1",
+                "type": "0"
+              },
+              {
+                "_": "42 B4 1C 1",
+                "type": "0"
+              },
+              {
+                "_": "22 D8 60 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 68 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B1 37 1",
+                "type": "0"
+              },
+              {
+                "_": "22 E5 E5 1",
+                "type": "0"
+              },
+              {
+                "_": "23 D5 6 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 2F F2 1",
+                "type": "0"
+              },
+              {
+                "_": "23 11 84 1",
+                "type": "0"
+              },
+              {
+                "_": "23 11 84 2",
+                "type": "0"
+              },
+              {
+                "_": "52 B B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B C5 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 87 1",
+                "type": "0"
+              },
+              {
+                "_": "25 8 20 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 6A 1",
+                "type": "0"
+              },
+              {
+                "_": "57 2E 2B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B A7 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 50 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 8F 1",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 1",
+                "type": "0"
+              },
+              {
+                "_": "57 2F BF 1",
+                "type": "0"
+              },
+              {
+                "_": "50 55 C 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 5",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 8",
+                "type": "16"
+              },
+              {
+                "_": "47 DC 75 1",
+                "type": "0"
+              },
+              {
+                "_": "4B E7 27 1",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 1",
+                "type": "0"
+              },
+              {
+                "_": "35 53 B3 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BA CA 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BC E 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BD E4 1",
+                "type": "0"
+              },
+              {
+                "_": "43 60 3F 1",
+                "type": "0"
+              },
+              {
+                "_": "35 53 56 1",
+                "type": "0"
+              },
+              {
+                "_": "47 E1 67 1",
+                "type": "0"
+              },
+              {
+                "_": "49 30 A5 1",
+                "type": "0"
+              },
+              {
+                "_": "2E B8 75 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "49701",
+          "name": "All Bathroom Lights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "deviceGroup": "28",
+          "pnode": "49701",
+          "members": {
+            "link": [
+              {
+                "_": "57 2E 2B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B A7 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 50 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 8F 1",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 1",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 7",
+                "type": "16"
+              },
+              {
+                "_": "57 24 38 8",
+                "type": "16"
+              },
+              {
+                "_": "57 2F BF 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "57778",
+          "name": "[p]Main Bath KP.B-Hot Water",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "deviceGroup": "30",
+          "pnode": "57778",
+          "members": {
+            "link": [
+              {
+                "_": "57 24 38 2",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "32900",
+          "name": "[s]Patio Recessed",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "deviceGroup": "31",
+          "pnode": "32900",
+          "members": {
+            "link": [
+              {
+                "_": "40 4E 68 2",
+                "type": "16"
+              },
+              {
+                "_": "4F CF 54 1",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "8791",
+          "name": "[p]Fix Patio Recessed",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "deviceGroup": "32",
+          "pnode": "8791",
+          "members": {
+            "link": [
+              {
+                "_": "40 4E 68 2",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "462",
+          "name": "[s]Lindsay's Sink",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "deviceGroup": "33",
+          "pnode": "462",
+          "members": {
+            "link": [
+              {
+                "_": "57 24 38 3",
+                "type": "16"
+              },
+              {
+                "_": "57 2F BF 1",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "13207",
+          "name": "[p]Living Room Fan Light",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "28721",
+            "type": "3"
+          },
+          "deviceGroup": "91",
+          "pnode": "13207",
+          "members": {
+            "link": [
+              {
+                "_": "40 FD 8 2",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "19359",
+          "name": "[p]Living Room Curtains",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "28721",
+            "type": "3"
+          },
+          "deviceGroup": "92",
+          "pnode": "19359",
+          "members": {
+            "link": [
+              {
+                "_": "40 FD 8 7",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "37874",
+          "name": "[p]All Living Room Lights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "28721",
+            "type": "3"
+          },
+          "deviceGroup": "93",
+          "pnode": "37874",
+          "members": {
+            "link": [
+              {
+                "_": "40 FD 8 8",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "38414",
+          "name": "[p]Fix Palm Lamp",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "43287",
+            "type": "3"
+          },
+          "deviceGroup": "94",
+          "pnode": "38414",
+          "members": {
+            "link": [
+              {
+                "_": "57 81 2F 4",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "49457",
+          "name": "[p]Fix Lindsay's Sink",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "deviceGroup": "34",
+          "pnode": "49457",
+          "members": {
+            "link": [
+              {
+                "_": "57 24 38 3",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "59280",
+          "name": "[s]Water Closet Light",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "deviceGroup": "35",
+          "pnode": "59280",
+          "members": {
+            "link": [
+              {
+                "_": "57 3B 50 1",
+                "type": "16"
+              },
+              {
+                "_": "57 24 38 4",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "62419",
+          "name": "[s]Palm Lamp",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "43287",
+            "type": "3"
+          },
+          "deviceGroup": "95",
+          "pnode": "62419",
+          "members": {
+            "link": [
+              {
+                "_": "47 DC 75 1",
+                "type": "16"
+              },
+              {
+                "_": "57 81 2F 4",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "6536",
+          "name": "[p]Living Room Lamps",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "deviceGroup": "96",
+          "pnode": "6536",
+          "members": {
+            "link": [
+              {
+                "_": "40 FD 8 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "48817",
+          "name": "Guest Room Lamps",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "12120",
+            "type": "3"
+          },
+          "deviceGroup": "53",
+          "pnode": "48817",
+          "members": {
+            "link": [
+              {
+                "_": "2E BC E 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BD E4 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "60240",
+          "name": "[p]Fix Water Closet Light",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "deviceGroup": "36",
+          "pnode": "60240",
+          "members": {
+            "link": [
+              {
+                "_": "57 24 38 4",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "39381",
+          "name": "All Kitchen Lights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "deviceGroup": "37",
+          "pnode": "39381",
+          "members": {
+            "link": [
+              {
+                "_": "23 B5 98 1",
+                "type": "0"
+              },
+              {
+                "_": "22 D8 60 1",
+                "type": "0"
+              },
+              {
+                "_": "23 D5 6 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 5",
+                "type": "16"
+              },
+              {
+                "_": "52 B B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 1",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 6",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "60926",
+          "name": "[p]Fix All Kitchen",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "deviceGroup": "38",
+          "pnode": "60926",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 8B 5",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 6",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "10913",
+          "name": "West Wing Recessed All",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "39",
+          "pnode": "10913",
+          "members": {
+            "link": [
+              {
+                "_": "23 B5 98 1",
+                "type": "0"
+              },
+              {
+                "_": "42 B4 1C 1",
+                "type": "0"
+              },
+              {
+                "_": "22 D8 60 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 68 1",
+                "type": "0"
+              },
+              {
+                "_": "23 D5 6 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "30799",
+          "name": "West Wing Recessed Common",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "40",
+          "pnode": "30799",
+          "members": {
+            "link": [
+              {
+                "_": "42 B4 1C 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 68 1",
+                "type": "0"
+              },
+              {
+                "_": "23 D5 6 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "23353",
+          "name": "[p]Pantry Recessed Fast",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "53085",
+            "type": "3"
+          },
+          "deviceGroup": "41",
+          "pnode": "23353",
+          "members": {
+            "link": [
+              {
+                "_": "23 D5 6 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "38940",
+          "name": "[p]Fix West Wing Recessed",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "47",
+          "pnode": "38940",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 8B 3",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "58798",
+          "name": "All Exterior Lights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "deviceGroup": "48",
+          "pnode": "58798",
+          "members": {
+            "link": [
+              {
+                "_": "40 4E 68 1",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 1",
+                "type": "0"
+              },
+              {
+                "_": "48 7 1F 1",
+                "type": "0"
+              },
+              {
+                "_": "29 CA 5F 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 32 1",
+                "type": "0"
+              },
+              {
+                "_": "48 B C9 1",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 1",
+                "type": "0"
+              },
+              {
+                "_": "24 72 75 1",
+                "type": "0"
+              },
+              {
+                "_": "4F CF 54 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "30932",
+          "name": "[p]Patio KP.D-AutoLock",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "29",
+          "pnode": "30932",
+          "members": {
+            "link": [
+              {
+                "_": "25 8 B7 4",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "28110",
+          "name": "Auto Exterior Lights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "deviceGroup": "49",
+          "pnode": "28110",
+          "members": {
+            "link": [
+              {
+                "_": "40 4E 68 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 32 1",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "12705",
+          "name": "[s]Hallway Light",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "deviceGroup": "50",
+          "pnode": "12705",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 8B 4",
+                "type": "16"
+              },
+              {
+                "_": "56 D3 A5 1",
+                "type": "16"
+              },
+              {
+                "_": "56 D5 68 3",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "49295",
+          "name": "[p]Fix MBR Fan Off",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "66",
+          "pnode": "49295",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 B7 5",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "11210",
+          "name": "[p]Fix MBR Fan Low",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "69",
+          "pnode": "11210",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 B7 4",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "55800",
+          "name": "[p]Fix MBR Fan Med",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "74",
+          "pnode": "55800",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 B7 6",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "59368",
+          "name": "[p]Fix MBR Fan High",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "75",
+          "pnode": "59368",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 B7 3",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "18922",
+          "name": "[p]Fix Hallway",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "deviceGroup": "51",
+          "pnode": "18922",
+          "members": {
+            "link": [
+              {
+                "_": "25 9 8B 4",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 3",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "7152",
+          "name": "[p]Patio Fan KPL",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "deviceGroup": "107",
+          "pnode": "7152",
+          "members": {
+            "link": [
+              {
+                "_": "40 4E 68 3",
+                "type": "0"
+              },
+              {
+                "_": "25 8 B7 3",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "65440",
+          "name": "Laundry Room Light",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "48237",
+            "type": "3"
+          },
+          "deviceGroup": "52",
+          "pnode": "65440",
+          "members": {
+            "link": [
+              {
+                "_": "23 FF 50 1",
+                "type": "16"
+              },
+              {
+                "_": "2D AF 71 1",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "41978",
+          "name": "[p]Patio KP.F-Lamp",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "97",
+          "pnode": "41978",
+          "members": {
+            "link": [
+              {
+                "_": "25 8 B7 6",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "45197",
+          "name": "[p]Living Room Curtain",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "deviceGroup": "98",
+          "pnode": "45197",
+          "members": {
+            "link": [
+              {
+                "_": "40 FD 8 7",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "12195",
+          "name": "All IoX Christmas Lights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "63777",
+            "type": "3"
+          },
+          "deviceGroup": "54",
+          "pnode": "12195",
+          "members": {
+            "link": [
+              {
+                "_": "37 41 FE 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BA CA 1",
+                "type": "0"
+              },
+              {
+                "_": "35 53 56 1",
+                "type": "0"
+              },
+              {
+                "_": "47 E1 67 1",
+                "type": "0"
+              },
+              {
+                "_": "49 30 A5 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "49317",
+          "name": "[p]Patio KP.E-Landscape",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "108",
+          "pnode": "49317",
+          "members": {
+            "link": [
+              {
+                "_": "25 8 B7 5",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "50702",
+          "name": "Main Bathroom Fan",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "deviceGroup": "55",
+          "pnode": "50702",
+          "members": {
+            "link": [
+              {
+                "_": "57 24 38 6",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "44968",
+          "name": "Main Bathroom Chandelier",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "deviceGroup": "56",
+          "pnode": "44968",
+          "members": {
+            "link": [
+              {
+                "_": "57 24 38 5",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "4770",
+          "name": "All Off Partial",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "deviceGroup": "57",
+          "pnode": "4770",
+          "members": {
+            "link": [
+              {
+                "_": "3D 7D 87 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B5 98 1",
+                "type": "0"
+              },
+              {
+                "_": "29 CA 5F 1",
+                "type": "0"
+              },
+              {
+                "_": "23 B1 37 1",
+                "type": "0"
+              },
+              {
+                "_": "22 E5 E5 1",
+                "type": "0"
+              },
+              {
+                "_": "23 D5 6 1",
+                "type": "0"
+              },
+              {
+                "_": "48 B C9 1",
+                "type": "0"
+              },
+              {
+                "_": "25 9 8B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 2F F2 1",
+                "type": "0"
+              },
+              {
+                "_": "23 11 84 1",
+                "type": "0"
+              },
+              {
+                "_": "52 B B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 7F F6 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B C5 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 87 1",
+                "type": "0"
+              },
+              {
+                "_": "25 8 20 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 6A 1",
+                "type": "0"
+              },
+              {
+                "_": "57 2E 2B 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B A7 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 50 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B 8F 1",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 1",
+                "type": "0"
+              },
+              {
+                "_": "57 2F BF 1",
+                "type": "0"
+              },
+              {
+                "_": "50 55 C 1",
+                "type": "0"
+              },
+              {
+                "_": "4F CF 54 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D5 68 5",
+                "type": "0"
+              },
+              {
+                "_": "47 DC 75 1",
+                "type": "0"
+              },
+              {
+                "_": "4B E7 27 1",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 1",
+                "type": "0"
+              },
+              {
+                "_": "35 53 B3 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BC E 1",
+                "type": "0"
+              },
+              {
+                "_": "2E BD E4 1",
+                "type": "0"
+              },
+              {
+                "_": "43 60 3F 1",
+                "type": "0"
+              },
+              {
+                "_": "2E B8 75 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "41665",
+          "name": "All Off Guest",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "deviceGroup": "58",
+          "pnode": "41665",
+          "members": {
+            "link": []
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "49133",
+          "name": "All Living Room Recessed",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "deviceGroup": "59",
+          "pnode": "49133",
+          "members": {
+            "link": [
+              {
+                "_": "23 B1 37 1",
+                "type": "0"
+              },
+              {
+                "_": "57 3B C5 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "12295",
+          "name": "All Main Bedroom",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "60",
+          "pnode": "12295",
+          "members": {
+            "link": [
+              {
+                "_": "23 11 84 1",
+                "type": "0"
+              },
+              {
+                "_": "50 55 C 1",
+                "type": "0"
+              },
+              {
+                "_": "3E 79 2 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "25546",
+          "name": "[s]Main Bath Recessed",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "deviceGroup": "61",
+          "pnode": "25546",
+          "members": {
+            "link": [
+              {
+                "_": "57 3B 8F 1",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "38625",
+          "name": "[p]Bedside Lamps",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "62",
+          "pnode": "38625",
+          "members": {
+            "link": [
+              {
+                "_": "50 55 C 3",
+                "type": "16"
+              },
+              {
+                "_": "43 60 3F 3",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "5102",
+          "name": "[s]Backyard Spotlights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "36485",
+            "type": "3"
+          },
+          "deviceGroup": "63",
+          "pnode": "5102",
+          "members": {
+            "link": [
+              {
+                "_": "3D 7D 87 3",
+                "type": "16"
+              },
+              {
+                "_": "29 CA 5F 1",
+                "type": "16"
+              },
+              {
+                "_": "40 4E 68 7",
+                "type": "16"
+              },
+              {
+                "_": "25 8 B7 7",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "9122",
+          "name": "[p]Garage Side Spots",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "46696",
+            "type": "3"
+          },
+          "deviceGroup": "64",
+          "pnode": "9122",
+          "members": {
+            "link": [
+              {
+                "_": "3D 7D 87 4",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "16836",
+          "name": "[p]Mercury Lamp",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "65",
+          "pnode": "16836",
+          "members": {
+            "link": [
+              {
+                "_": "25 8 B7 8",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "50184",
+          "name": "Garage Lights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "46696",
+            "type": "3"
+          },
+          "deviceGroup": "67",
+          "pnode": "50184",
+          "members": {
+            "link": [
+              {
+                "_": "41 E1 58 5",
+                "type": "16"
+              },
+              {
+                "_": "53 5A 31 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "59403",
+          "name": "All Office Lights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "deviceGroup": "68",
+          "pnode": "59403",
+          "members": {
+            "link": [
+              {
+                "_": "57 3B 87 1",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 5",
+                "type": "16"
+              },
+              {
+                "_": "56 CD 91 1",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 3",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 4",
+                "type": "0"
+              },
+              {
+                "_": "56 CD 91 6",
+                "type": "16"
+              },
+              {
+                "_": "2E B8 75 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "47541",
+          "name": "[p]Office Small Lamp",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "deviceGroup": "70",
+          "pnode": "47541",
+          "members": {
+            "link": [
+              {
+                "_": "56 CD 91 4",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "12529",
+          "name": "[p]Office Crystal Lamp",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "deviceGroup": "71",
+          "pnode": "12529",
+          "members": {
+            "link": [
+              {
+                "_": "56 CD 91 3",
+                "type": "16"
+              },
+              {
+                "_": "2E B8 75 1",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "23933",
+          "name": "[p]Fix Office Crystal Lamp",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "47298",
+            "type": "3"
+          },
+          "deviceGroup": "72",
+          "pnode": "23933",
+          "members": {
+            "link": [
+              {
+                "_": "56 CD 91 3",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "55996",
+          "name": "[p]Sink KP.B-Hot Water",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "52164",
+            "type": "3"
+          },
+          "deviceGroup": "100",
+          "pnode": "55996",
+          "members": {
+            "link": [
+              {
+                "_": "57 7F F6 4",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "53246",
+          "name": "[s]Garage Side Spotlights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "46696",
+            "type": "3"
+          },
+          "deviceGroup": "101",
+          "pnode": "53246",
+          "members": {
+            "link": [
+              {
+                "_": "41 E1 58 4",
+                "type": "16"
+              },
+              {
+                "_": "48 B C9 1",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "31831",
+          "name": "[p]Driveway KP.D-Side Spots",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "102",
+          "pnode": "31831",
+          "members": {
+            "link": [
+              {
+                "_": "41 E1 58 4",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "28276",
+          "name": "[p]Bedroom Hall KP.C",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "11981",
+            "type": "3"
+          },
+          "deviceGroup": "103",
+          "pnode": "28276",
+          "members": {
+            "link": [
+              {
+                "_": "56 D5 68 5",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "15144",
+          "name": "[p]Driveway KP.E",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "73",
+          "pnode": "15144",
+          "members": {
+            "link": [
+              {
+                "_": "41 E1 58 5",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "61311",
+          "name": "All Patio Lights",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "deviceGroup": "76",
+          "pnode": "61311",
+          "members": {
+            "link": [
+              {
+                "_": "40 4E 68 1",
+                "type": "0"
+              },
+              {
+                "_": "4F CF 54 1",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "2613",
+          "name": "[p]Fix Staircase",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "deviceGroup": "77",
+          "pnode": "2613",
+          "members": {
+            "link": [
+              {
+                "_": "56 D3 A5 6",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "4125",
+          "name": "[s]Entry",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "deviceGroup": "78",
+          "pnode": "4125",
+          "members": {
+            "link": [
+              {
+                "_": "43 64 E6 1",
+                "type": "16"
+              },
+              {
+                "_": "25 8 20 3",
+                "type": "16"
+              },
+              {
+                "_": "56 D3 A5 3",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "18545",
+          "name": "[p]Fix Entry",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "42106",
+            "type": "3"
+          },
+          "deviceGroup": "79",
+          "pnode": "18545",
+          "members": {
+            "link": [
+              {
+                "_": "25 8 20 3",
+                "type": "0"
+              },
+              {
+                "_": "56 D3 A5 3",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "25294",
+          "name": "[s]Living Room Recessed",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "57370",
+            "type": "3"
+          },
+          "deviceGroup": "80",
+          "pnode": "25294",
+          "members": {
+            "link": [
+              {
+                "_": "23 B1 37 1",
+                "type": "16"
+              },
+              {
+                "_": "56 D3 A5 4",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "61085",
+          "name": "[s]Garage Overhang",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "46696",
+            "type": "3"
+          },
+          "deviceGroup": "81",
+          "pnode": "61085",
+          "members": {
+            "link": [
+              {
+                "_": "41 E1 58 2",
+                "type": "16"
+              },
+              {
+                "_": "48 7 1F 1",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "25696",
+          "name": "[p]Garage Door Buttons",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "46696",
+            "type": "3"
+          },
+          "deviceGroup": "82",
+          "pnode": "25696",
+          "members": {
+            "link": [
+              {
+                "_": "40 4E 68 8",
+                "type": "0"
+              },
+              {
+                "_": "41 E1 58 7",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "47678",
+          "name": "[p]Driveway KP.C-AutoLock",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "24534",
+            "type": "3"
+          },
+          "deviceGroup": "104",
+          "pnode": "47678",
+          "members": {
+            "link": [
+              {
+                "_": "41 E1 58 3",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "63097",
+          "name": "[p]Fix Main Bathroom Keypad",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "507",
+            "type": "3"
+          },
+          "deviceGroup": "99",
+          "pnode": "63097",
+          "members": {
+            "link": [
+              {
+                "_": "57 24 38 7",
+                "type": "0"
+              },
+              {
+                "_": "57 24 38 8",
+                "type": "0"
+              }
+            ]
+          },
+          "nodeType": "group"
+        },
+        {
+          "flag": "132",
+          "nodeDefId": "InsteonDimmer",
+          "address": "41321",
+          "name": "[p]Main BR Patio KP.D-AutoLoc",
+          "family": "6",
+          "hint": "0.0.0.0",
+          "parent": {
+            "_": "35180",
+            "type": "3"
+          },
+          "deviceGroup": "105",
+          "pnode": "41321",
+          "members": {
+            "link": [
+              {
+                "_": "40 4E 68 4",
+                "type": "16"
+              }
+            ]
+          },
+          "nodeType": "group"
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_client/test_client.py
+++ b/tests/test_client/test_client.py
@@ -191,7 +191,6 @@ async def test_connect_runs_full_load_with_real_profile_fixture(session: FakeSes
     session.set_route("GET", "/rest/profiles?include=nodedefs,editors,linkdefs", 200, profile_json)
     session.set_route("GET", "/api/nodes", 200, nodes_payload)
     session.set_route("GET", "/rest/status", 200, status_xml)
-    session.set_route("GET", "/rest/nodes", 200, '<?xml version="1.0"?><nodes><root/></nodes>')
     session.set_route("GET", "/api/programs", 200, {"successful": True, "data": []})
     session.set_route("GET", "/api/triggers", 200, {"successful": True, "data": []})
     session.set_route(
@@ -229,23 +228,22 @@ async def test_connect_runs_full_load_with_real_profile_fixture(session: FakeSes
     assert list(result.network_resources) == ["1"]
     assert result.network_resources["1"].name == "Reboot Router"
 
-    # Total HTTP cost: 1 (config setup) + 1 (login setup) + 9 (parallel
-    # fan-out) = 11 calls. The fan-out covers: profiles, /api/nodes,
-    # /rest/nodes (groups + folders), /rest/status, /api/programs,
-    # /api/triggers, /api/variables/1, /api/variables/2,
+    # Total HTTP cost: 1 (config setup) + 1 (login setup) + 8 (parallel
+    # fan-out) = 10 calls. The fan-out covers: profiles, /api/nodes
+    # (which now carries groups + folders too, see #127), /rest/status,
+    # /api/programs, /api/triggers, /api/variables/1, /api/variables/2,
     # /rest/networking/resources. Still constant w.r.t. node-server count.
     fanout = [c for c in session.calls if c[0] == "GET" and c[1] not in ("/api/config",)]
-    assert len(fanout) == 9
+    assert len(fanout) == 8
 
 
 def _empty_fanout_routes(session: FakeSession) -> None:
-    """Script the eight non-/api/nodes fan-out endpoints with empty
+    """Script the seven non-/api/nodes fan-out endpoints with empty
     payloads — enough for ``load()`` to complete; tests override the
     pieces they care about afterwards."""
     profile_json = json.loads((FIXTURE_DIR / "profiles_with_flume.json").read_text())
     session.set_route("GET", "/rest/profiles?include=nodedefs,editors,linkdefs", 200, profile_json)
     session.set_route("GET", "/rest/status", 200, "<nodes/>")
-    session.set_route("GET", "/rest/nodes", 200, "<nodes/>")
     session.set_route("GET", "/api/programs", 200, {"successful": True, "data": []})
     session.set_route("GET", "/api/triggers", 200, {"successful": True, "data": []})
     session.set_route("GET", "/api/variables/1", 200, {"successful": True, "data": []})

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -113,12 +113,6 @@ def _stub_responses(session: FakeSession) -> None:
         200,
         '<?xml version="1.0"?><nodes></nodes>',
     )
-    session.set_route(
-        "GET",
-        "/rest/nodes",
-        200,
-        '<?xml version="1.0"?><nodes><root/></nodes>',
-    )
     session.set_route("GET", "/api/programs", 200, {"successful": True, "data": []})
     session.set_route("GET", "/api/triggers", 200, {"successful": True, "data": []})
     session.set_route("GET", "/api/variables/1", 200, {"successful": True, "data": []})

--- a/tests/test_runtime/test_groups.py
+++ b/tests/test_runtime/test_groups.py
@@ -1,4 +1,6 @@
-"""Tests for Group + Folder runtime wrappers + the /rest/nodes XML parser."""
+"""Tests for Group + Folder runtime wrappers + the /api/nodes and
+/rest/nodes parsers (both shapes — JSON is the default load path; XML
+stays available for LocalAuth)."""
 
 from __future__ import annotations
 
@@ -14,6 +16,7 @@ from pyisyox.client import (
     IoXClient,
     NodePropertyValue,
     NodeRecord,
+    parse_api_nodes_groups_folders,
     parse_rest_nodes_groups_folders,
 )
 from pyisyox.constants import INSTEON_STATELESS_NODEDEFID
@@ -22,6 +25,7 @@ from pyisyox.schema import Profile
 from tests.test_client.conftest import FakeSession
 
 FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "eisy6"
+JSON_FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "eisy6_json"
 BASE = "https://eisy.local"
 
 
@@ -127,6 +131,59 @@ def test_parse_rest_nodes_handles_empty_or_missing_xml() -> None:
         {},
         "",
     )
+
+
+# --- /api/nodes JSON parser (the default load path post-#127) ----------
+
+
+def _load_json_fixture() -> dict:
+    return json.loads((JSON_FIXTURE_DIR / "api_nodes_full.json").read_text())
+
+
+def test_parse_api_nodes_extracts_groups_and_folders() -> None:
+    """Captured controller has 94 groups + 30 folders in the JSON payload
+    (the same shape the legacy ``/rest/nodes`` XML used to carry).
+    One group is the root pseudo-group (``flag="12"``) — filtered out
+    of the returned dict, surfaced via the third tuple element."""
+    raw = _load_json_fixture()
+    groups, folders, root_name = parse_api_nodes_groups_folders(raw)
+    # 94 group entries in the fixture; the root pseudo-group is excluded.
+    assert len(groups) == 93
+    assert len(folders) == 30
+    assert root_name == "eisy-anon"
+
+
+def test_parse_api_nodes_captures_member_controller_marker() -> None:
+    """``link.type == "16"`` marks a scene controller in the JSON, same
+    as the legacy XML. Verified against captures with mixed member
+    types (``Main Bedroom Fan*`` scenes are controller+responder)."""
+    raw = _load_json_fixture()
+    groups, _, _ = parse_api_nodes_groups_folders(raw)
+    # ``Main Bedroom Fan Light`` (address 11937) has a mix of types.
+    fan = groups["11937"]
+    assert fan.name == "Main Bedroom Fan Light"
+    # Each ``type="16"`` member appears in both lists; responders only
+    # in member_addresses.
+    assert set(fan.controller_addresses).issubset(set(fan.member_addresses))
+    assert fan.controller_addresses, "expected at least one controller"
+
+
+def test_parse_api_nodes_filters_root_pseudo_group() -> None:
+    """The controller-self pseudo-group (``flag="12"``,
+    ``IS_A_GROUP | ROOT``) is removed from the groups dict — its
+    address is the controller MAC, not a user-facing scene."""
+    raw = _load_json_fixture()
+    groups, _, root_name = parse_api_nodes_groups_folders(raw)
+    assert root_name  # non-empty
+    for group_addr in groups:
+        # MAC-style addresses (colons) wouldn't be there post-filter.
+        assert ":" not in group_addr or len(group_addr) != 17
+
+
+def test_parse_api_nodes_handles_empty_or_missing_payload() -> None:
+    assert parse_api_nodes_groups_folders({}) == ({}, {}, "")
+    assert parse_api_nodes_groups_folders({"data": {}}) == ({}, {}, "")
+    assert parse_api_nodes_groups_folders({"data": {"nodes": {}}}) == ({}, {}, "")
 
 
 def test_parse_rest_nodes_captures_root_group_name() -> None:


### PR DESCRIPTION
Closes #127.

## Summary

``/api/nodes`` JSON exposes ``data.nodes.{node, group, folder}`` with a ``nodeType`` discriminator on each entry — verified against two live captures (188-node controller with 94 groups, mixed Insteon / Z-Wave / scene-controller members) attached to #127. The controller-self pseudo-group carries the same ``flag="12"`` bit and ``<name>`` payload as the legacy XML; member entries use the same ``type="16"`` controller marker. Both controller and responder members appear in the captures (``Main Bedroom Fan*`` scenes, etc.), so the encoding is confirmed identical to the XML.

## Net wins

- **One fewer HTTP round-trip** per ``connect()`` (load fan-out drops from 9 to 8 parallel calls).
- **One fewer XML parse** per ``connect()``.
- **Single source of truth** for the node/group/folder tree — no reconciliation between ``/api/nodes`` JSON and ``/rest/nodes`` XML.

## Changes

- New ``parse_api_nodes_groups_folders(raw)`` returning the same ``(groups, folders, root_name)`` 3-tuple as the XML parser. Walks ``data.nodes.{group, folder}`` and routes by ``nodeType``.
- ``IoXClient.load`` drops ``self._get_text(REST_NODES_PATH)`` from the gather and calls the new parser against the existing ``nodes_raw`` payload.
- ``parse_rest_nodes_groups_folders`` **stays exported** — LocalAuth on ``:8443`` (which doesn't serve ``/api/*``) still needs the XML surface, tracked in #106.
- Module docstring + ``paths.py`` comment on ``REST_NODES_PATH`` refreshed (the constant stays exported for the same reason).

## Tests (+7)

- New JSON fixture under ``tests/fixtures/eisy6_json/api_nodes_full.json`` (anonymised live capture: 188 nodes, 94 groups, 30 folders).
- ``test_parse_api_nodes_extracts_groups_and_folders`` — round-trips the fixture.
- ``test_parse_api_nodes_captures_member_controller_marker`` — pins the ``type="16"`` controller-vs-responder discrimination against the mixed-type ``Main Bedroom Fan*`` scenes.
- ``test_parse_api_nodes_filters_root_pseudo_group`` — same ``NodeFlag.ROOT`` filtering as the XML.
- ``test_parse_api_nodes_handles_empty_or_missing_payload`` — empty/partial JSON returns the same ``({}, {}, "")`` shape.
- Existing fixtures + stubs updated: ``/rest/nodes`` removed from ``_empty_fanout_routes`` and the ``test_controller.py`` stub setup; fan-out count assertion adjusted (9 → 8).

**626 pass (was 619; +7 new).**

## Test plan

- [x] CI green.
- [x] User: reload the integration in the devcontainer; verify in the trace that ``/rest/nodes`` is no longer fetched but groups/folders/controller-name still populate correctly.
- [x] User: confirm scene entities still get their controller-vs-responder member discrimination right (the legacy XML field that was hardest to replicate).

## Follow-up

- ``parse_rest_nodes_groups_folders`` stays exported as the LocalAuth fallback path. When the LocalAuth-revival work in #106 lands, this gives a clean choice: PortalAuth → JSON; LocalAuth → XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)