### PR TITLE
chore: trim verbose docstrings + fix duplicated GET log

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -1,42 +1,17 @@
 """JSON-first HTTP client for IoX 6+ controllers.
 
-Sits between the auth layer (:mod:`pyisyox.auth`) and the schema layer
-(:mod:`pyisyox.schema`) and orchestrates the initial connect:
-
-* ``GET /api/config`` — uuid, version, portalHost (small, prerequisite
-  for anything else).
-* ``GET /rest/profiles?include=nodedefs,editors,linkdefs`` — single
-  ~117 KB JSON blob; the source for every nodedef + editor.
-* Parallel fan-out:
-    * ``GET /api/nodes`` — JSON structure with three parallel arrays
-      under ``data.nodes``: ``node`` (family/instance, addresses,
-      parent/pnode; plugin nodes have **no** ``property[]`` field),
-      ``group`` (scenes with members + ``flag`` bit for the
-      controller-self root group whose ``<name>`` is the friendly
-      controller label), and ``folder`` (organisational tree).
-      Each entry tagged with ``nodeType``.
-    * ``GET /rest/status`` — XML, the canonical full-property table for
-      both native and plugin nodes. PyISY 3.x already merges this into
-      ``/rest/nodes`` to fill in Insteon thermostat properties; the
-      same merge step handles plugin nodes uniformly here.
-    * ``GET /api/programs``, ``/api/triggers`` — JSON.
-    * ``GET /api/variables/1`` and ``/api/variables/2`` — JSON.
+Orchestrates the initial load (``/api/config`` → ``/rest/profiles`` →
+parallel fan-out of nodes/status/programs/triggers/variables) and
+exposes mutation methods. Auth-mode-agnostic — accepts any
+:class:`pyisyox.auth.Auth` and retries once on 401 if recovery succeeds.
 
 Total: ≤ 6 HTTP + 1 WebSocket regardless of node-server count
-(``/rest/nodes`` was dropped from the fan-out in #127 — its
-group/folder data is fully covered by ``/api/nodes`` JSON, saving one
-round-trip per connect).
+(``/rest/nodes`` was dropped from the fan-out in #127 — its group /
+folder data is fully covered by ``/api/nodes`` JSON).
 
-The client is auth-mode-agnostic — it accepts any :class:`pyisyox.auth.Auth`
-implementation (``PortalAuth`` or ``LocalAuth``). On a 401 it asks the
-auth strategy to recover, retrying the original request once if recovery
-succeeds.
-
-XML decoders here are deliberately narrow — the only legacy XML surfaces
-left after the JSON-first cut are ``/rest/status`` (used here),
-``/rest/nodes/{addr}/cmd/...`` responses (touched at command-send time),
-and ``/rest/subscribe`` event frames (handled by the WebSocket pipeline).
-``xml.etree.ElementTree`` from the stdlib covers all three.
+The remaining legacy XML surfaces are ``/rest/status``,
+``/rest/nodes/{addr}/cmd/...`` responses, and ``/rest/subscribe`` event
+frames; stdlib ``xml.etree.ElementTree`` covers all three.
 """
 
 from __future__ import annotations
@@ -115,16 +90,9 @@ class HTTPError(ClientError):
 
 
 class NodeType(StrEnum):
-    """String discriminator the eisy requires in ``POST /api/nodes/{address}``
-    bodies — even though the address already disambiguates which kind
-    of object is being mutated. The same ``"node"`` / ``"group"`` /
-    ``"folder"`` vocabulary appears on lifecycle events, so this enum
-    doubles as the typed name for that wire vocabulary.
-
-    The legacy XML surface uses the numeric hierarchy codes instead
-    (``0`` notset / ``1`` node / ``2`` group / ``3`` folder) — see
-    :class:`pyisyox.constants.UDHierarchyNodeType`.
-    """
+    """Required ``nodeType`` body field on ``POST /api/nodes/{address}``;
+    also the lifecycle-event vocabulary. Legacy XML surface uses numeric
+    codes — see :class:`pyisyox.constants.UDHierarchyNodeType`."""
 
     NODE = "node"
     GROUP = "group"
@@ -132,13 +100,8 @@ class NodeType(StrEnum):
 
 
 class VariableField(StrEnum):
-    """Body keys accepted by ``POST /api/variables/{type}/{id}``.
-
-    The eisy only honours one key per request — :class:`VALUE`,
-    :class:`INIT`, or :class:`NAME`. The runtime
-    :class:`pyisyox.Variable` wrapper enforces that contract by
-    exposing one coroutine per key.
-    """
+    """Body keys accepted by ``POST /api/variables/{type}/{id}``;
+    one key per request."""
 
     VALUE = "value"
     INIT = "init"
@@ -156,21 +119,10 @@ class ControllerConfig:
 
 @dataclass(slots=True)
 class NodePropertyValue:
-    """One live property value, normalised to a single shape regardless of
-    whether it arrived from ``/api/nodes`` JSON or ``/rest/status`` XML.
+    """One live property value (JSON ``/api/nodes`` or XML ``/rest/status``).
 
-    The shape mirrors :class:`pyisyox.schema.nodedef.Property` but is kept
-    here as a private data carrier so the client can produce values
-    without importing the runtime Node classes.
-
-    ``precision`` is the decimal precision the controller declares for
-    this value (``raw / 10**precision`` is the displayed number). The
-    wire keyed it as ``"prec"`` across all three ingest paths —
-    ``/api/nodes`` JSON has ``"prec": <int>``, ``/rest/status`` XML uses
-    ``prec="<int>"``, and WS frames put it on the ``<action prec="...">``
-    element — but the Python attribute spells it out for readability
-    (matches PyISY 3.x's ``precision`` naming). Defaults to ``0`` (= no
-    scaling) when the controller omits it.
+    ``precision``: decimal precision (``raw / 10**precision``). Wire
+    field is ``prec``; defaults to ``0`` when omitted.
     """
 
     id: str
@@ -209,16 +161,10 @@ class NodeRecord:
 
 @dataclass(slots=True)
 class GroupRecord:
-    """One scene/group from ``/rest/nodes``.
+    """One scene/group. Commands to ``address`` broadcast to every member.
 
-    A group represents a controller-managed collection of nodes.
-    Sending a command to ``address`` causes the controller to
-    broadcast it to every entry in ``member_addresses``.
-
-    Sourced from ``<group flag="132">`` elements in the legacy
-    ``/rest/nodes`` XML. ``flag="12"`` (the special "ISY" group
-    representing the controller itself) is filtered out at parse
-    time and does not appear in the registry.
+    Sourced from ``<group flag="132">`` elements; the special ``flag="12"``
+    controller-self group is filtered out at parse time.
     """
 
     address: str
@@ -238,11 +184,7 @@ class GroupRecord:
 
 @dataclass(slots=True)
 class FolderRecord:
-    """One folder from ``/rest/nodes`` (organisational, no command surface).
-
-    Folders use family ``"13"`` (folder family) on IoX. Sourced from
-    ``<folder>`` elements.
-    """
+    """One folder (organisational, no command surface). Family ``"13"``."""
 
     address: str
     name: str
@@ -252,47 +194,15 @@ class FolderRecord:
 
 @dataclass(slots=True)
 class ProgramRecord:
-    """One program from ``/api/programs``.
+    """One program or program-folder from ``/api/programs``.
 
-    Programs and program-folders live in the same flat list on the
-    wire, discriminated by ``is_folder``. Folders carry only
-    identity + status; programs additionally carry timing /
-    enabled / running fields.
-
-    The eisy returns ``status`` as the strings ``"true"`` or
-    ``"false"`` (matching the legacy XML convention). They're
-    decoded into a Python bool here. Empty time strings become
-    ``None``.
-
-    ``path`` is reconstructed from the ``parent_address`` chain at
-    parse time so consumers can use the legacy ``HA.<platform>/...``
-    folder convention without walking the tree themselves.
-
-    Attributes:
-        address: Program / folder id (4-character hex string).
-        name: User-assigned label.
-        path: Slash-joined ancestry, e.g. ``"My Programs/HA.switch/Foo/status"``.
-            Excludes the root folder name ``"My Programs"`` to match
-            the convention pyisy 3.x consumers used.
-        parent_address: Parent folder id, or ``None`` for the root.
-        is_folder: ``True`` for folders, ``False`` for programs.
-        status: True when the program's last evaluation was True.
-            Folder status reflects the AND of children. Empty string
-            on the wire is treated as ``False``.
-        enabled: ``False`` when the program is disabled. Always
-            ``True`` for folders (which have no enabled flag on
-            the wire). ``None`` if absent.
-        run_at_startup: ``True`` if the program is set to run on
-            controller boot. ``None`` for folders.
-        running: Free-form runtime state — ``"idle"`` on idle
-            programs; running programs report variants like
-            ``"running then"`` / ``"running else"`` /
-            ``"running if"``. ``None`` for folders.
-        last_run_time / last_finish_time / next_scheduled_run_time:
-            ISO 8601 timestamps as strings (``"2026-05-10T14:49:53.000Z"``)
-            or ``None`` when absent. Kept as strings to avoid pulling
-            in a datetime parser at this layer; consumers that need
-            datetime objects can parse on read.
+    Programs and folders share the flat list, discriminated by ``is_folder``.
+    Status strings ``"true"``/``"false"`` are decoded to bool; empty time
+    strings become ``None``. ``path`` is the slash-joined ancestry (excluding
+    the ``"My Programs"`` root) to match the pyisy 3.x convention.
+    Timestamps stay as ISO 8601 strings so this layer doesn't pull in a
+    datetime parser; ``running`` is free-form (``"idle"``,
+    ``"running then"``, …).
     """
 
     address: str
@@ -311,27 +221,9 @@ class ProgramRecord:
 
 @dataclass(slots=True)
 class VariableRecord:
-    """One entry from ``/api/variables/{type}``.
-
-    The IoX controller exposes two variable types — integer (``"1"``)
-    and state (``"2"``) — and each carries an int value (``val``),
-    init/restore-on-startup value, decimal precision, a user-assigned
-    name, and a last-change timestamp. The wire JSON uses ``val`` for
-    the current value; we expose it here as ``value`` so consumers
-    don't have to track the wire spelling.
-
-    Attributes:
-        type_id: ``"1"`` (integer) or ``"2"`` (state).
-        id: Variable id within the type.
-        name: User-assigned label.
-        value: Current value (wire field ``val``).
-        init: Restore-on-startup value.
-        precision: Decimal precision (``displayed = raw / 10**precision``).
-            The wire keyed it as ``"prec"`` — Python attribute spells
-            it out (matches PyISY 3.x).
-        ts: Last-change timestamp as the controller emits it (ISO 8601
-            UTC). Empty string when the controller omits it.
-    """
+    """One entry from ``/api/variables/{type}``. ``type_id`` is ``"1"``
+    (integer) or ``"2"`` (state). Wire field ``val`` is exposed as
+    ``value``; ``prec`` is exposed as ``precision``."""
 
     type_id: str
     id: str
@@ -343,27 +235,15 @@ class VariableRecord:
 
     @property
     def address(self) -> str:
-        """``"{type_id}.{id}"`` — composite identifier that joins into
-        controller endpoints and is useful for unique-id derivation in
-        downstream consumers (HA entity unique ids, log lines, etc.)."""
+        """Composite ``{type_id}.{id}`` identifier."""
         return f"{self.type_id}.{self.id}"
 
 
 @dataclass(slots=True)
 class NetworkResourceRecord:
-    """One entry from ``/rest/networking/resources``.
-
-    Network resources are user-defined HTTP / TCP / UDP fire-triggers
-    on the controller (e.g. "ping the router", "post to a webhook").
-    The runtime wrapper :class:`pyisyox.runtime.NetworkResource`
-    surfaces ``run()`` which fires the resource by id.
-
-    Attributes:
-        address: Resource id, kept as a string for symmetry with
-            node / group records (the wire is ``<id>5</id>``, an
-            integer, but consumers want it joinable into URL paths).
-        name: User-assigned label.
-    """
+    """One user-defined HTTP/TCP/UDP fire-trigger from
+    ``/rest/networking/resources``. ``address`` is the integer id as a
+    string for URL-path symmetry."""
 
     address: str
     name: str
@@ -371,33 +251,7 @@ class NetworkResourceRecord:
 
 @dataclass(slots=True)
 class LoadResult:
-    """Output of :meth:`IoXClient.connect`.
-
-    Attributes:
-        config: Parsed ``/api/config`` slice.
-        profile: Decoded ``/rest/profiles`` blob, ready for nodedef
-            lookups via ``profile.find_nodedef(...)``.
-        nodes: Map of address → :class:`NodeRecord` with merged properties.
-        groups: Map of address → :class:`GroupRecord` for IoX scenes.
-        folders: Map of address → :class:`FolderRecord` for the
-            organisational tree shown in the controller UI.
-        programs: Map of id → :class:`ProgramRecord` for both
-            programs and program-folders (discriminated by
-            ``is_folder``). Empty when the controller has no
-            programs configured.
-        triggers: Raw ``/api/triggers`` payload — the program AST as JSON.
-        variables: Map of variable type id (``"1"`` or ``"2"``) to the
-            raw ``/api/variables/{type}`` ``data`` list.
-        network_resources: Map of id → :class:`NetworkResourceRecord`,
-            empty when the controller has no networking module
-            enabled (the endpoint returns an empty ``<NetConfig/>``).
-        root_name: User-assigned name of the controller (the
-            ``<name>`` of the root group in ``/rest/nodes``, e.g.
-            ``"Main eisy"``). Empty string when the controller hasn't
-            been named or the legacy endpoint isn't available.
-            :attr:`Controller.name` exposes this with hostname / uuid
-            fallbacks for consumer ergonomics.
-    """
+    """Output of :meth:`IoXClient.connect`. See attributes for shape."""
 
     config: ControllerConfig
     profile: Profile
@@ -625,15 +479,7 @@ class IoXClient:
                         prop.name = resolved
 
     async def _fetch_config(self) -> ControllerConfig:
-        """``GET /api/config`` — minimal, used to confirm IoX 6+ + uuid.
-
-        Authenticated like every other endpoint: ``/api/config`` is
-        gated on both auth modes (``LocalAuth`` HTTP-basic on
-        ``:8443``, ``PortalAuth`` JWT on ``:443``), so an earlier
-        ``authenticated=False`` here 401'd the local-credentials flow.
-        ``_authenticate_once`` is a no-op for ``LocalAuth`` (basic auth
-        attaches per request) and runs the login POST for ``PortalAuth``.
-        """
+        """``GET /api/config`` — confirms IoX 6+ and returns uuid/version."""
         raw = await self._get_json(CONFIG_PATH)
         data = raw.get("data", raw)
         return ControllerConfig(
@@ -643,21 +489,13 @@ class IoXClient:
         )
 
     async def _authenticate_once(self) -> None:
-        """Run ``auth.authenticate`` exactly once across concurrent callers.
-
-        The lock-then-recheck pattern collapses concurrent first-use
-        callers onto a single ``auth.authenticate`` round-trip. Without
-        it, two parallel requests during ``connect()`` setup could both
-        observe ``_authenticated is False`` and each call ``authenticate``.
-        """
+        """Run ``auth.authenticate`` exactly once across concurrent callers."""
         if self._authenticated:
             return
         if self._auth_lock is None:
             self._auth_lock = asyncio.Lock()
         async with self._auth_lock:
-            # Double-checked: another coroutine may have authenticated
-            # while we were queued for the lock. We deliberately re-read
-            # via a local so mypy doesn't narrow it away as unreachable.
+            # Re-read via a local so mypy doesn't narrow it away as unreachable.
             already_authenticated: bool = self._authenticated
             if already_authenticated:
                 return
@@ -665,17 +503,14 @@ class IoXClient:
             self._authenticated = True
 
     async def _get_json(self, path: str, *, authenticated: bool = True) -> Any:
-        """GET a JSON endpoint. Applies auth (if requested) and retries
-        once on 401 if the auth strategy can recover."""
+        """GET a JSON endpoint. Applies auth and retries once on 401."""
         text = await self._get_text(path, authenticated=authenticated)
         try:
             payload = _loads_json(text)
         except ValueError as exc:
             raise ClientError(f"invalid JSON from {path}: {exc}") from exc
-        # Full payloads are high-volume on initial load (the profiles
-        # blob alone is ~117 KB); keep them at VERBOSE so DEBUG stays
-        # readable. A one-line summary at DEBUG keeps the load trail.
-        _LOGGER.debug("GET %s -> %d bytes", path, len(text))
+        # _get_text already logged the GET summary at DEBUG. JSON bodies
+        # stay at VERBOSE because the profiles blob is ~117 KB.
         if _LOGGER.isEnabledFor(LOG_VERBOSE):
             _LOGGER.log(LOG_VERBOSE, "GET %s body: %s", path, redact_sensitive(payload))
         return payload
@@ -699,25 +534,15 @@ class IoXClient:
                 if resp.status >= 400:
                     raise HTTPError(resp.status, url)
                 text = await resp.text()
-            # Match the ``_get_json`` summary line so wire-trace
-            # debugging works regardless of payload format. Reads
-            # through ``_get_text`` (the legacy XML surfaces:
-            # ``/rest/nodes``, ``/rest/status``,
-            # ``/rest/networking/resources``) were previously silent,
-            # so a consumer comparing tcpdump output to a DEBUG log
-            # saw different request sets. VERBOSE-level body dumps
-            # are intentionally not added here — XML payloads can be
-            # multi-MB on a populated controller and would dominate
-            # the log; ``_get_json``'s VERBOSE body dump exists
-            # because the redactor is JSON-specific.
+            # Wire-trace summary for every GET (JSON + XML). No VERBOSE
+            # body dump: XML payloads can be multi-MB and the redactor is
+            # JSON-specific.
             _LOGGER.debug("GET %s -> %d bytes", path, len(text))
             return text
 
     async def _get_text_or_empty(self, path: str) -> str:
-        """``_get_text`` that swallows HTTPError and returns an empty
-        string. Used for optional-module endpoints (networking) where a
-        missing module surfaces as a 404 / 503 rather than an empty
-        document — we don't want those to abort initial load."""
+        """``_get_text`` that swallows HTTPError → ``""``. For optional
+        endpoints (networking) where a missing module 404s."""
         try:
             return await self._get_text(path)
         except HTTPError as exc:
@@ -727,26 +552,8 @@ class IoXClient:
     async def send_node_command(self, address: str, command_id: str, *params: int | str) -> str:
         """Issue ``GET /rest/nodes/{addr}/cmd/{cmd}[/{p1}[/{p2}...]]``.
 
-        The legacy XML command surface is still the only command path
-        on IoX 6 — no ``/api/*`` equivalent has surfaced in captures.
-        Both auth modes (PortalAuth JWT, LocalAuth basic) accept this
-        path. ``address`` is URL-quoted because Insteon addresses
-        contain spaces (``"3D 7D 87 1"``).
-
-        Args:
-            address: Wire address of the target node.
-            command_id: IoX command id (e.g. ``"DON"``).
-            *params: Already-encoded path segments (the runtime
-                :meth:`Node.send_command` runs the editor codec and
-                interleaves each value with its UOM — ``75, "51"`` →
-                ``.../DON/75/51``; this client method just stringifies
-                and joins what it's given).
-
-        Returns:
-            The text body of the response — typically a small
-            ``<RestResponse status="200">...</RestResponse>`` envelope.
-            Caller doesn't usually need to parse it; HTTPError covers
-            non-2xx.
+        Params are stringified and joined as-is — the editor codec runs
+        in :meth:`Node.send_command`. ``address`` is URL-quoted.
         """
         encoded_addr = quote(address, safe="")
         path_parts = [NODE_COMMAND_PATH.format(address=encoded_addr, command=command_id)]
@@ -757,21 +564,10 @@ class IoXClient:
     async def get_zwave_parameter(self, address: str, number: int, *, zmatter: bool = False) -> str:
         """Issue ``GET /rest/(zmatter/)?zwave/node/{addr}/config/query/{n}``.
 
-        Triggers the controller to query parameter ``n`` from the device.
-        On success the response body is a ``<config paramNum="N"
-        size="SZ" value="V"/>`` element (PyISY 3.x verified shape); on a
-        controller-side failure (404, device unreachable, …) the body
-        is a ``<RestResponse succeeded="false"><status>404</status>...``
-        envelope which the caller must inspect — ``HTTPError`` only
-        covers transport-level non-2xx.
-
-        Args:
-            address: Wire address of the Z-Wave node (URL-quoted here).
-            number: Z-Wave parameter number (1-based; device-defined).
-            zmatter: ``True`` for Z-Matter (family ``12``) nodes, which
-                use the ``/rest/zmatter/zwave/...`` path prefix. The
-                runtime :meth:`Node.get_zwave_parameter` flips this from
-                the node's ``family_id`` automatically.
+        Body on success: ``<config paramNum="N" size="SZ" value="V"/>``.
+        Controller failure surfaces as a ``<RestResponse succeeded="false">``
+        envelope (caller must inspect — HTTPError covers transport only).
+        ``zmatter=True`` switches to the family-12 path prefix.
         """
         encoded_addr = quote(address, safe="")
         path_tmpl = ZMATTER_ZWAVE_PARAMETER_GET_PATH if zmatter else ZWAVE_PARAMETER_GET_PATH
@@ -799,19 +595,9 @@ class IoXClient:
     ) -> str:
         """Issue ``GET /rest/(zmatter/)?zwave/node/{addr}/config/set/{n}/{v}/{sz}``.
 
-        Args:
-            address: Wire address of the Z-Wave node (URL-quoted here).
-            number: Z-Wave parameter number (device-defined).
-            value: Parameter value to write (signed int; the controller
-                interprets the sign per the device's parameter spec).
-            size: Parameter byte size — ``1``, ``2``, or ``4``. The
-                controller forwards this to the device so multi-byte
-                parameters land correctly. The Insteon-style ``CONFIG``
-                ``cmd`` editor in ``/rest/profiles`` doesn't model
-                ``size`` (it's a NUM/VAL pair only), which is why this
-                path takes precedence over a ``send_command("CONFIG",
-                ...)`` for Z-Wave parameter writes.
-            zmatter: ``True`` for Z-Matter (family ``12``) nodes.
+        ``size`` (1/2/4 bytes) is carried explicitly; the Insteon-style
+        ``CONFIG`` command editor doesn't model byte size, so this path
+        takes precedence over ``send_command("CONFIG", ...)`` for Z-Wave.
         """
         encoded_addr = quote(address, safe="")
         path_tmpl = ZMATTER_ZWAVE_PARAMETER_SET_PATH if zmatter else ZWAVE_PARAMETER_SET_PATH
@@ -840,17 +626,9 @@ class IoXClient:
     ) -> str:
         """Issue ``GET /rest/(zmatter/)?zwave/node/{addr}/security/user/{n}/set/code/{c}``.
 
-        Program one user-code slot on a Z-Wave lock. The HTTP body is a
-        ``<RestResponse>`` envelope — callers should pass it through
-        :meth:`Node.set_zwave_lock_code`'s parser, which raises on
-        ``succeeded="false"``.
-
-        Args:
-            address: Wire address of the Z-Wave lock node (URL-quoted here).
-            user_num: User-code slot number (device-defined, 1-based).
-            code: Numeric PIN to program into the slot. Stored on the
-                device; pyisyox doesn't read it back.
-            zmatter: ``True`` for Z-Matter (family ``12``) locks.
+        Programs one user-code slot. Returns a ``<RestResponse>`` envelope
+        — callers should pass it through :meth:`Node.set_zwave_lock_code`'s
+        parser, which raises on ``succeeded="false"``.
         """
         encoded_addr = quote(address, safe="")
         path_tmpl = ZMATTER_ZWAVE_LOCK_CODE_SET_PATH if zmatter else ZWAVE_LOCK_CODE_SET_PATH
@@ -876,12 +654,7 @@ class IoXClient:
     ) -> str:
         """Issue ``GET /rest/(zmatter/)?zwave/node/{addr}/security/user/{n}/delete``.
 
-        Clear one user-code slot on a Z-Wave lock.
-
-        Args:
-            address: Wire address of the Z-Wave lock node (URL-quoted here).
-            user_num: User-code slot number to clear.
-            zmatter: ``True`` for Z-Matter (family ``12``) locks.
+        Clears one user-code slot.
         """
         encoded_addr = quote(address, safe="")
         path_tmpl = ZMATTER_ZWAVE_LOCK_CODE_DELETE_PATH if zmatter else ZWAVE_LOCK_CODE_DELETE_PATH
@@ -901,11 +674,8 @@ class IoXClient:
     async def set_node_enabled(self, address: str, enabled: bool) -> str:
         """Issue ``GET /rest/nodes/{addr}/{enable|disable}``.
 
-        Re-enables or disables a node on the controller (a disabled node
-        stays in the table but the controller stops polling / commanding
-        it). ``address`` is URL-quoted. Returns the response text body
-        (a small ``<RestResponse>`` envelope — callers don't usually
-        parse it; ``HTTPError`` covers non-2xx).
+        A disabled node stays in the table; the controller stops polling
+        and commanding it.
         """
         encoded_addr = quote(address, safe="")
         path = (NODE_ENABLE_PATH if enabled else NODE_DISABLE_PATH).format(address=encoded_addr)
@@ -916,22 +686,12 @@ class IoXClient:
     ) -> dict[str, Any]:
         """Issue ``POST /api/variables/{type}/{id}`` with the supplied body.
 
-        Three documented body shapes (verified against eisy-ui captures):
+        Three documented body shapes (one key per call; eisy-ui doesn't
+        mix them):
 
         * ``{"value": <int>}`` — set the current value
-        * ``{"init": <int>}`` — set the initial / restore value
-        * ``{"name": "<str>"}`` — rename the variable
-
-        Mixing keys in one call wasn't observed; eisy-ui issues separate
-        calls for each. Higher-level helpers in
-        :class:`pyisyox.controller.Controller` enforce one-key-per-call
-        for clarity.
-
-        Returns the parsed response body (a ``{successful, data}``
-        envelope).
-
-        Raises:
-            HTTPError on non-2xx; ClientError on malformed response.
+        * ``{"init": <int>}`` — set the initial/restore value
+        * ``{"name": "<str>"}`` — rename
         """
         path = VARIABLE_ITEM_PATH.format(type_id=var_type, var_id=var_id)
         _LOGGER.debug(
@@ -1646,6 +1406,5 @@ def _unwrap_data(raw: Any, *, source: str = "endpoint") -> list[dict[str, Any]]:
 
 
 def _loads_json(text: str) -> Any:
-    """Local alias for json.loads — kept as a thin wrapper so tests can
-    monkey-patch one symbol if they need to inject decode failures."""
+    """Local alias for ``json.loads`` — monkey-patchable from tests."""
     return json.loads(text)

--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -1,33 +1,13 @@
 """WebSocket event parsing and dispatch.
 
-The eisy event stream sends ``<Event>`` XML frames over WebSocket. Two
-transports exist:
+Two transports — legacy ``/rest/subscribe`` (raw XML) and modern
+``/api/events/subscribe`` (JSON-wrapped, adds PG3 ``spolisy`` channel)
+— wrap the same ``<Event>`` payload, so :func:`parse_event_frame`
+accepts either. System events use underscore-prefixed control ids
+(``_5``, ``_28``, …) — see :class:`SystemEventControl`.
 
-* ``/rest/subscribe`` — legacy, raw XML frames. **Default** for both
-  PortalAuth and LocalAuth modes.
-* ``/api/events/subscribe`` — modern, JSON-wrapped:
-  ``{"type": "event", "data": "<xml>"}``. Adds a ``"spolisy"`` side
-  channel for PG3 service status. Opt-in for portal mode only.
-
-Both wrap the same ``<Event seqnum=... sid=... timestamp=...>`` XML
-payload, so :func:`parse_event_frame` accepts either shape and
-returns a single :class:`Event` (or ``None`` for unparsable / non-
-event frames like keep-alive nulls).
-
-Event control ids:
-
-* Property updates use the property id (e.g. ``"ST"``, ``"GV1"``) and
-  populate ``node_address``.
-* System events use a leading underscore (``"_5"`` system status,
-  ``"_28"`` Matter status, etc.) with empty ``node_address``. The
-  documented codes are enumerated in :class:`SystemEventControl`;
-  consumers can either branch on the enum or render labels via
-  :meth:`SystemEventControl.label` (which passes unknown codes
-  through verbatim).
-
-This module is decoupled from the actual WebSocket reader so the
-dispatcher can be tested with synthetic frames; the WS loop lives in
-:mod:`pyisyox.runtime.ws`.
+Decoupled from the WS reader (:mod:`pyisyox.runtime.ws`) so the
+dispatcher can be tested with synthetic frames.
 """
 
 from __future__ import annotations
@@ -1029,28 +1009,10 @@ class EventDispatcher:
     ) -> None:
         """Bind to a node + program + variable registry.
 
-        Args:
-            nodes: The same ``dict[str, NodeRecord]`` that
-                :class:`IoXClient.LoadResult` produces. The dispatcher
-                mutates ``record.properties`` in place when an event
-                targets a known node; events for unknown addresses
-                are dropped silently (typically nodes that joined
-                after the initial load — listen for node-add via
-                :meth:`add_lifecycle_listener` and trigger a reload).
-            programs: Optional program registry. When provided, the
-                dispatcher mutates ``record.status`` / ``record.running``
-                in place on program-status frames. ``None`` (the
-                default for tests that only care about node events)
-                makes program-status dispatch a no-op.
-            variables: Optional variable registry, shape
-                ``{type_id: {var_id: VariableRecord}}``. When provided,
-                the dispatcher mutates ``record.value`` (action ``"6"``
-                frames) or ``record.init`` (action ``"7"`` frames) in
-                place; symmetric with the node-property and
-                program-status handling. ``None`` (the default) makes
-                variable-change dispatch a no-op — consumers that need
-                variable updates without registering a registry can
-                still parse :attr:`Event.event_info` themselves.
+        The dispatcher mutates records in place. Events for unknown
+        addresses are dropped silently (subscribe to lifecycle for
+        joins). Passing ``None`` for ``programs``/``variables`` makes
+        those dispatch paths a no-op.
         """
         self._nodes = nodes
         self._programs = programs if programs is not None else {}

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -1,28 +1,10 @@
-"""Runtime ``Node`` — wraps a :class:`NodeRecord` + :class:`NodeDef` + client.
+"""Runtime ``Node`` — :class:`NodeRecord` + :class:`NodeDef` + client.
 
-The :class:`Node` is the primary user-facing handle for a single device.
-It exposes the structural fields and current property values
-(populated by :class:`pyisyox.client.IoXClient`'s initial load and
-later updated by the WebSocket dispatcher) plus a
-:meth:`Node.send_command` that:
-
-1. Looks the command up in the node's :class:`NodeDef` (under
-   ``cmds.accepts``).
-2. Validates each parameter against the editor that command parameter
-   references — using the bidirectional codec from
-   :mod:`pyisyox.schema.editor`. Enum names get translated to their
-   raw integers; subset constraints are enforced; out-of-range numeric
-   values raise before any HTTP traffic.
-3. Issues the legacy XML command endpoint
-   ``GET /rest/nodes/{addr}/cmd/{cmd_id}[/{p1}[/{p2}...]]`` via the
-   client. The response is a small ``<RestResponse/>`` envelope which
-   we don't need to decode beyond confirming the HTTP status.
-
-Only the legacy ``/rest/nodes/{addr}/cmd/...`` surface exists for
-sending node commands — there is no ``/api/*`` equivalent observed in
-captures, so we go through the legacy XML path. Auth still works:
-both :class:`PortalAuth` JWT and :class:`LocalAuth` HTTP basic accept
-``/rest/*`` requests.
+The primary user-facing device handle. Exposes structural fields,
+current properties (updated in place by the WS dispatcher), and
+:meth:`Node.send_command` for editor-validated command dispatch.
+Commands go through the legacy ``/rest/nodes/{addr}/cmd/...`` XML
+surface — no ``/api/*`` equivalent has been observed.
 """
 
 from __future__ import annotations
@@ -95,20 +77,7 @@ class Node:
         profile: Profile,
         client: IoXClient,
     ) -> None:
-        """Store the components needed for state reads and command sends.
-
-        Args:
-            record: The structural + merged-property data for this node.
-            nodedef: The resolved nodedef, or ``None`` if the
-                ``(nodedef_id, family, instance)`` triple didn't match
-                anything in the profile (e.g. a brand-new plugin
-                whose profile hasn't been loaded yet).
-            profile: The parsed :class:`Profile`. Used to resolve
-                editors scoped to this node's family/instance for
-                command-parameter validation.
-            client: The :class:`IoXClient` that owns the HTTP session.
-                Calls go through ``client.send_node_command``.
-        """
+        """Store the components needed for state reads and command sends."""
         self._record = record
         self._nodedef = nodedef
         self._profile = profile
@@ -159,37 +128,21 @@ class Node:
 
     @property
     def parent_address(self) -> str | None:
-        """Address of the tree-hierarchy parent (folder containing this node).
+        """Tree-hierarchy parent (containing folder). ``None`` at root.
 
-        Sourced from the IoX ``<parent>`` element. ``None`` for nodes at the
-        root of the node tree. Matches the ``parent_address`` semantic on
-        :class:`pyisyox.Folder`, :class:`pyisyox.Group`, and
-        :class:`pyisyox.Program` — i.e., "what folder is this in?"
-
-        Note: this is NOT the device primary for multi-button physical
-        devices (KeypadLinc, RemoteLinc, FanLinc). For that, use
-        :attr:`primary_address` — which derives from the IoX ``<pnode>``
-        element. The two concepts are independent: a sub-button can be
-        under a folder while also being a sub-node of a device primary.
+        Distinct from :attr:`primary_address`: ``<parent>`` is the folder,
+        ``<pnode>`` is the device primary for multi-button hardware.
         """
         return self._record.parent_address
 
     @property
     def primary_address(self) -> str | None:
-        """Address of the device primary for sub-button nodes.
+        """Device primary for sub-button nodes (from ``<pnode>``).
 
-        Sourced from the IoX ``<pnode>`` element. For multi-button physical
-        devices (KeypadLinc, RemoteLinc, FanLinc) the sub-button nodes carry
-        the primary load node's address in ``<pnode>``; primaries carry
-        their own address. We return ``None`` for primaries so the consumer
-        can treat ``primary_address is not None`` as a "this is a sub-node"
-        indicator and ``primary_address or address`` as "the canonical
-        device-grouping address."
-
-        PyISY 3.x exposed the same concept as ``Node.primary_node`` (which
-        returned a string). The ``_address`` suffix here matches the
-        convention used elsewhere in the package (``parent_address``,
-        ``member_addresses``, ``controller_addresses``).
+        Sub-buttons of multi-button devices (KeypadLinc, RemoteLinc,
+        FanLinc) carry the primary's address. ``None`` for primaries —
+        so ``primary_address is not None`` reads as "sub-node" and
+        ``primary_address or address`` as the device-grouping address.
         """
         pnode = self._record.pnode
         if pnode is None or pnode == self._record.address:
@@ -218,20 +171,11 @@ class Node:
     def properties(self) -> dict[str, NodePropertyValue]:
         """Live property values, keyed by property id (e.g. ``"ST"``).
 
-        For native nodes these are merged from ``/api/nodes`` + the
-        ``/rest/status`` overlay during initial load. Plugin nodes get
-        all values from ``/rest/status``. WebSocket events update the
-        underlying record in place at runtime via
-        :class:`pyisyox.runtime.EventDispatcher`.
-
-        Each value is normalised to its nodedef editor's canonical UOM
-        before being returned — e.g. an Insteon dimmer that reports
-        ``OL``/``ST`` as a UOM-100 0-255 byte is surfaced here as the
-        UOM-51 0-100% value its ``I_OL`` editor (and the ``/cmd`` write
-        surface) uses. Values whose reported UOM already matches the
-        editor pass through unchanged. The returned dict is freshly
-        built on each access; mutate the controller's state via commands,
-        not by writing here.
+        Each value is UOM-normalised to its nodedef editor's canonical
+        unit — e.g. an Insteon dimmer reporting ``OL`` as a UOM-100
+        0-255 byte is surfaced as the UOM-51 0-100% the ``I_OL`` editor
+        (and the ``/cmd`` write surface) uses. Values already matching
+        the editor pass through unchanged.
         """
         record_props = self._record.properties
         return {
@@ -278,17 +222,7 @@ class Node:
     def has_flag(self, flag: NodeFlag) -> bool:
         """Return ``True`` if every bit in ``flag`` is set on this node.
 
-        ``flag`` may be a single :class:`NodeFlag` member or an OR'd
-        combination (e.g. ``NodeFlag.NEW | NodeFlag.IN_ERR``); the check
-        is bitwise-AND against all requested bits, so a combined value
-        only matches when every bit is present.
-
-        Example::
-
-            from pyisyox.constants import NodeFlag
-
-            if node.has_flag(NodeFlag.DEVICE_ROOT):
-                ...
+        ``flag`` may be OR'd; combined values must have every bit set.
         """
         return (self._record.flag & int(flag)) == int(flag)
 
@@ -296,28 +230,12 @@ class Node:
 
     @property
     def protocol(self) -> Protocol:
-        """Best-effort device-protocol classification, derived from ``family_id``.
+        """Transport-protocol classification from ``family_id``.
 
-        Returns a :class:`pyisyox.constants.Protocol` member (a
-        ``StrEnum``, so it compares equal to its string value):
-
-        * :attr:`Protocol.INSTEON` — family ``"1"``.
-        * :attr:`Protocol.UPB` — family ``"2"``.
-        * :attr:`Protocol.ZWAVE` — family ``"4"`` (legacy attached
-          Z-Wave radio) or ``"12"`` (Z-Matter radio as a Z-Wave
-          controller).
-        * :attr:`Protocol.MATTER` — family ``"15"`` (Z-Matter radio
-          as a Matter/Thread controller).
-        * :attr:`Protocol.NODE_SERVER` — family ``"10"`` or any id
-          outside the IoX core family set; PG3 plugin nodes report a
-          slot id here, so we treat the whole space as node-server.
-        * :attr:`Protocol.UNKNOWN` — recognised core family with no
-          dedicated protocol mapping (RCS, Brultech, NCD, UDI, the
-          group/auto families, folders) or no family id at all.
-
-        This classifies the *transport*, not the device class — a
-        plugin thermostat reads as ``NODE_SERVER`` here; use
-        :attr:`is_thermostat` etc. for capability.
+        Returns ``NODE_SERVER`` for any non-core family id (PG3 plugin
+        nodes report a slot id here), ``UNKNOWN`` for recognised but
+        unmapped core families. Classifies transport, not device class
+        — use :attr:`is_thermostat` etc. for capability.
         """
         fid = self.family_id
         if fid == NodeFamily.INSTEON:
@@ -336,63 +254,37 @@ class Node:
 
     @property
     def is_thermostat(self) -> bool:
-        """True if the node accepts climate-mode or setpoint commands.
-
-        Derived from ``nodedef.cmds.accepts`` (protocol-agnostic), so a
-        PG3 plugin thermostat reads as a thermostat the same way a
-        native Insteon 2441ZTH does.
-        """
+        """True if the node accepts climate-mode or setpoint commands."""
         return self._has_command(CMD_CLIMATE_MODE) or self._has_command(PROP_SETPOINT_HEAT)
 
     @property
     def is_lock(self) -> bool:
-        """True if the node is a door / deadbolt lock.
+        """True for door/deadbolt locks.
 
-        Two tells, either is sufficient:
-
-        * The nodedef accepts the secure-lock (``SECMD``) verb — Z-Wave
-          and Insteon I2CS locks both expose this.
-        * The nodedef id contains the substring ``"Lock"`` — covers
-          IoX 6+ ``DoorLock`` / ``DoorLock_ADV`` / equivalents that
-          drive the lock via ``DON`` / ``DOF`` rather than ``SECMD``.
+        Two tells: nodedef accepts ``SECMD`` (Z-Wave / Insteon I2CS), or
+        nodedef id contains ``"Lock"`` (IoX 6+ ``DoorLock`` variants that
+        drive via ``DON``/``DOF``).
         """
         return self._has_command(CMD_SECURE) or "Lock" in self.nodedef_id
 
     @property
     def is_fan(self) -> bool:
-        """True if the node is a multi-speed fan controller.
+        """True for multi-speed fan controllers (nodedef id contains ``"Fan"``).
 
-        Derived from the nodedef id substring ``"Fan"`` — matches
-        the Insteon ``FanLincMotor`` sub-node (the FanLinc light
-        side reports as ``DimmerLampOnly``, so light/fan separate
-        cleanly per sub-address) and PG3 plugin fan nodedefs that
-        follow the same naming convention.
-
-        Fan nodes are a subset of dimmable nodes (``FanLincMotor``
-        accepts ``DON`` with a level parameter restricted to the
-        ``{0, 25, 75, 100}`` Off/Low/Medium/High subset), so
-        callers classifying onto a HA-style ``Platform.FAN`` should
-        check ``is_fan`` **before** ``is_dimmable``.
+        Fan nodes are a subset of dimmable (``FanLincMotor`` accepts
+        ``DON`` with a ``{0, 25, 75, 100}`` subset), so platform
+        classification should check ``is_fan`` **before** ``is_dimmable``.
         """
         return "Fan" in self.nodedef_id
 
     @property
     def is_dimmable(self) -> bool:
-        """True if the node reports a multilevel ``ST`` (status) state.
+        """True if the node reports a multilevel ``ST`` state.
 
-        Derived from the ``ST`` property's editor on the resolved
-        nodedef:
-
-        * ``I_OL_RELAY`` / similar editors with a binary subset
-          (``{0, 100}``) → on/off only → **not** dimmable.
-        * ``I_OL`` / similar editors with a multilevel range (e.g.
-          ``[0, 100]`` or ``[0, 255]``) and no binary subset →
-          dimmable.
-
-        Relay nodedefs accept ``DON`` with an optional level parameter
-        too (the controller ignores the level), so checking ``DON``'s
-        parameters isn't reliable. The ST editor is the source of
-        truth — it's what the device reports its own state through.
+        Derived from the ``ST`` property editor: a binary subset
+        (``{0, 100}``) → not dimmable; a multilevel range → dimmable.
+        Relay nodedefs accept ``DON`` with an ignored level param, so
+        ``DON``'s editor is unreliable — ``ST`` is the source of truth.
         """
         if self._nodedef is None:
             return False
@@ -409,12 +301,10 @@ class Node:
 
     @property
     def is_battery_node(self) -> bool:
-        """True for nodes that report battery level but no on/off status.
+        """True if the node reports ``BATLVL`` but no ``ST``.
 
-        Battery-powered Insteon sensors (motion, leak, open/close) follow
-        this pattern — they advertise ``BATLVL`` and protocol-specific
-        sub-properties but no ``ST`` because they don't have an on/off
-        primary state.
+        Battery-powered Insteon sensors (motion, leak, open/close) match
+        this — they have no on/off primary state.
         """
         props = self._record.properties
         return PROP_BATTERY_LEVEL in props and PROP_STATUS not in props
@@ -428,43 +318,17 @@ class Node:
     # --- commanding ---------------------------------------------------
 
     async def send_command(self, command_id: str, *params: float | str) -> None:
-        """Send a command to this node, with editor-codec parameter validation.
+        """Send a command, with editor-codec parameter validation.
 
-        Each positional arg is matched against the corresponding
-        parameter slot on the command's nodedef definition. Enum names
-        ("Heat", "Authorized") are accepted in addition to integers and
-        translated through the editor's ``names`` map. Out-of-subset or
-        out-of-range values raise :class:`NodeCommandError` before any
-        HTTP traffic.
+        Each parameter is sent as ``/{value}/{uom}`` using the UOM its
+        editor declares (the eisy web-UI convention — ``/cmd/DON/75/51``).
+        Parameters whose editor carries no real unit (UOM ``"0"`` or
+        unset) are sent bare.
 
-        Each parameter is sent in the form ``/{value}/{uom}`` — the UOM
-        is the one the parameter's editor declares — so the controller
-        does any device-side scaling itself (this is the convention the
-        eisy web UI uses, e.g. ``/cmd/DON/75/51`` to set 75% on a
-        dimmer; ``/cmd/OL/75/51``; ``/cmd/BL/10/25``). Parameters whose
-        editor carries no real unit (UOM ``"0"`` / unset) are sent as a
-        bare ``/{value}`` with no UOM segment.
-
-        Args:
-            command_id: The IoX command id (e.g. ``"DON"``, ``"DOF"``,
-                ``"CLISPC"``, ``"DISCOVER"``).
-            *params: Positional command arguments. Number must match
-                the command's parameter count (or be zero for
-                parameterless commands like ``DOF``).
-
-        When the node has **no resolved nodedef** (e.g. dynamically
-        provisioned Z-Wave / Z-Matter nodes, whose ``UZW*`` nodedefs
-        aren't published in ``/rest/profiles``), there is nothing to
-        validate against — the command and any params are passed
-        through verbatim (numeric params coerced to ``int``, no UOM
-        segment). This keeps such nodes controllable; the cost is no
-        client-side validation.
-
-        Raises:
-            NodeCommandError: When the command id isn't on this node's
-                accept list, the parameter count is wrong, or any
-                parameter fails editor validation. (Not raised for
-                nodedef-less nodes — see above.)
+        When the node has no resolved nodedef (dynamically provisioned
+        Z-Wave/Z-Matter nodes whose ``UZW*`` defs aren't in
+        ``/rest/profiles``), params pass through verbatim (numeric →
+        int, no UOM) so the node stays controllable without validation.
         """
         if self._nodedef is None:
             passthrough: list[int | str] = [int(p) if isinstance(p, (int, float)) else p for p in params]
@@ -524,21 +388,7 @@ class Node:
         await self.send_command(CMD_SECURE, 0)
 
     async def set_on_level(self, val: int) -> None:
-        """Set the device's remembered on-level via the ``OL`` command.
-
-        ``val`` is the **percentage** ``0-100`` — the unit the ``I_OL``
-        editor (and therefore the ``/cmd/OL`` write surface) uses. The
-        command is sent as ``/cmd/OL/{val}/51`` and the controller does
-        any device-side scaling (Insteon dimmers internally store a
-        0-255 byte; ``75`` → byte ``191`` → reported back as
-        ``OL uom="100" 191``, which :attr:`properties` normalises back
-        to ``75`` for you).
-
-        Raises:
-            NodeCommandError: when this node's nodedef doesn't accept
-                ``OL``, or ``val`` falls outside the ``I_OL`` editor's
-                range (``0-100``).
-        """
+        """Set the remembered on-level via ``OL`` (0-100 percent)."""
         await self.send_command(PROP_ON_LEVEL, val)
 
     async def set_ramp_rate(self, val: int) -> None:
@@ -550,20 +400,10 @@ class Node:
         await self.send_command(PROP_RAMP_RATE, val)
 
     async def set_backlight(self, val: int | str) -> None:
-        """Set keypad / switch backlight intensity.
+        """Set keypad/switch backlight intensity.
 
-        Two encoding modes selected by the BL editor's UOM:
-
-        * **UOM 100 (percentage)** — DimmerSwitch / RelaySwitch / etc.
-          Pass 0-100.
-        * **UOM 25 (index)** — KeypadDimmer / KeypadRelay / KeypadButton.
-          Pass an integer index into the IoX backlight table, or — if
-          the profile's BL editor carries the enum names — the
-          human-readable label string (the codec resolves it).
-
-        The display-label list is *not* mirrored in pyisyox; consumers
-        wanting the labels can iterate
-        ``editor.range_for("25").names`` against the node's BL editor.
+        Two encodings driven by the BL editor's UOM: UOM 100 → 0-100%,
+        UOM 25 → integer index (or enum-name string the codec resolves).
         """
         await self.send_command(CMD_BACKLIGHT, val)
 
@@ -579,27 +419,12 @@ class Node:
         await self.send_command(CMD_MANUAL_DIM_STOP)
 
     async def rename(self, name: str) -> None:
-        """Rename this node.
-
-        Wire shape: ``POST /api/nodes/{address}`` with
-        ``{"name": "<str>", "nodeType": "node"}``. The IoX server
-        emits a ``<control>_3</control>`` lifecycle event with
-        ``action="NN"`` after a successful rename, so consumers
-        listening through
-        :meth:`Controller.add_node_lifecycle_listener` will see the
-        change without polling.
-        """
+        """Rename this node. The controller emits a ``_3`` lifecycle frame
+        with ``action="NN"`` on success."""
         await self._client.post_node_update(self.address, {"name": name, "nodeType": NodeType.NODE})
 
     def to_dict(self) -> dict[str, Any]:
-        """Flatten this node to a JSON-compatible dict.
-
-        Includes the underlying record's structural fields (address,
-        nodedef triple, properties map, flag bitfield) plus the
-        derived :attr:`protocol`. Property values are already
-        :class:`NodePropertyValue` dataclasses so ``asdict`` walks them
-        recursively.
-        """
+        """Flatten this node to a JSON-compatible dict (record + protocol)."""
         payload = asdict(self._record)
         payload["protocol"] = self.protocol
         return payload
@@ -607,36 +432,17 @@ class Node:
     # --- Z-Wave parameter surface ------------------------------------
     #
     # Z-Wave configuration parameters live on a dedicated wire path
-    # (``/rest/(zmatter/)?zwave/node/{addr}/parameters/...``) rather than
-    # the legacy ``/cmd/CONFIG/...`` surface. The ``CONFIG`` accept
-    # command in the dynamic Z-Wave nodedefs models only the (NUM, VAL)
-    # pair — it has no slot for the parameter's byte size, which the
-    # device needs for multi-byte writes — so these helpers are the
-    # supported way to read / write parameters from consumers (HA
-    # service calls, scripts, …).
+    # (``/rest/(zmatter/)?zwave/node/{addr}/parameters/...``). The legacy
+    # ``CONFIG`` accept command models only (NUM, VAL) — no slot for byte
+    # size — so these helpers are the supported read/write surface.
 
     async def get_zwave_parameter(self, number: int) -> dict[str, int]:
-        """Request parameter ``number`` from this Z-Wave node.
+        """Request parameter ``number``; return ``{parameter, size, value}``.
 
-        On success the controller responds with
-        ``<config paramNum="N" size="SZ" value="V"/>`` synchronously
-        (matches PyISY 3.x's verified shape); this method parses that
-        and returns ``{"parameter": N, "size": SZ, "value": V}`` so
-        consumers get structured data instead of raw XML. The device's
-        post-poll parameter report also arrives on the WS event stream.
-
-        Picks the right wire prefix from this node's family id:
-        ``"4"`` → legacy ``/rest/zwave/...``, ``"12"`` → Z-Matter
-        ``/rest/zmatter/zwave/...``.
-
-        Raises:
-            NodeCommandError: When this node isn't a Z-Wave node
-                (family ``4`` or ``12``), or when the controller
-                returns a ``<RestResponse succeeded="false">`` envelope
-                (unknown parameter number, device unreachable, …).
-            ISYResponseParseError: When the response body is neither
-                a ``<config>`` element nor a ``<RestResponse>``
-                envelope — i.e. malformed.
+        Family id picks the wire prefix (``"4"`` → ``/rest/zwave/...``,
+        ``"12"`` → ``/rest/zmatter/zwave/...``). Raises
+        :class:`NodeCommandError` on non-Z-Wave nodes or controller
+        failure; ``ISYResponseParseError`` on malformed bodies.
         """
         if self.family_id not in _ZWAVE_FAMILY_IDS:
             raise NodeCommandError(
@@ -651,24 +457,11 @@ class Node:
         return parsed
 
     async def set_zwave_parameter(self, number: int, value: int, size: int) -> None:
-        """Write parameter ``number`` on this Z-Wave node.
+        """Write parameter ``number`` (size 1/2/4 bytes) on this Z-Wave node.
 
-        Args:
-            number: Z-Wave parameter number (device-defined).
-            value: Signed integer value; the controller / device
-                interpret the sign per the device's parameter spec.
-            size: Parameter byte size — ``1``, ``2``, or ``4``.
-
-        On controller acceptance the device's post-write parameter
-        report arrives asynchronously on the WS stream. The HTTP body
-        is a ``<RestResponse>`` envelope which this method inspects —
-        ``succeeded="false"`` raises :class:`NodeCommandError` so a
-        failed write is never silent.
-
-        Raises:
-            NodeCommandError: When this node isn't Z-Wave, ``size``
-                isn't ``1`` / ``2`` / ``4``, or the controller rejects
-                the write.
+        The post-write report arrives asynchronously on the WS stream.
+        Raises :class:`NodeCommandError` on rejection so failures aren't
+        silent.
         """
         if self.family_id not in _ZWAVE_FAMILY_IDS:
             raise NodeCommandError(
@@ -695,30 +488,13 @@ class Node:
 
     # --- Z-Wave lock-code surface ------------------------------------
     #
-    # Same Z-Wave-only family guard as the parameter surface above. The
-    # wire paths come from PyISY 3.x — assumed valid on IoX 6+ without
+    # Wire paths come from PyISY 3.x — assumed valid on IoX 6+ without
     # captured proof; needs a tester with an enrolled Z-Wave lock for
-    # confirmation. Lock codes are stored on the device; pyisyox doesn't
-    # read them back (the controller doesn't expose a "get code" surface
-    # either — slots are write-only by design for security).
+    # confirmation. Lock codes are write-only (no "get code" surface).
 
     async def set_zwave_lock_code(self, user_num: int, code: int) -> None:
-        """Program a Z-Wave lock's user-code slot.
-
-        Args:
-            user_num: Slot number (device-defined, 1-based).
-            code: Numeric PIN. Locks vary in min/max digits; the
-                controller forwards the value verbatim.
-
-        Path: ``GET /rest/(zmatter/)?zwave/node/<addr>/security/user/<n>/set/code/<c>``.
-        Raises :class:`NodeCommandError` on a ``<RestResponse
-        succeeded="false">`` envelope so failed programmings aren't
-        silent.
-
-        Raises:
-            NodeCommandError: When this node isn't a Z-Wave node, or
-                the controller rejects the write.
-        """
+        """Program a Z-Wave lock's user-code slot. Raises
+        :class:`NodeCommandError` on a failed envelope."""
         if self.family_id not in _ZWAVE_FAMILY_IDS:
             raise NodeCommandError(
                 f"node {self.address!r} is not a Z-Wave node "
@@ -739,14 +515,7 @@ class Node:
         )
 
     async def delete_zwave_lock_code(self, user_num: int) -> None:
-        """Clear a Z-Wave lock's user-code slot.
-
-        Path: ``GET /rest/(zmatter/)?zwave/node/<addr>/security/user/<n>/delete``.
-
-        Raises:
-            NodeCommandError: When this node isn't a Z-Wave node, or
-                the controller rejects the delete.
-        """
+        """Clear a Z-Wave lock's user-code slot."""
         if self.family_id not in _ZWAVE_FAMILY_IDS:
             raise NodeCommandError(
                 f"node {self.address!r} is not a Z-Wave node "
@@ -769,13 +538,8 @@ class Node:
     async def set_enabled(self, enabled: bool) -> None:
         """Enable or disable this node on the controller.
 
-        Wire shape: ``GET /rest/nodes/{address}/{enable|disable}``. A
-        disabled node stays in the table but the controller stops
-        polling / commanding it. On success the local record's
-        :attr:`enabled` flag is updated optimistically (the controller
-        also emits a ``<control>_3</control>`` ``action="EN"`` lifecycle
-        event); on failure the underlying ``HTTPError`` propagates and
-        the flag is left untouched.
+        On success the local ``enabled`` flag is updated optimistically;
+        the controller also emits a ``_3`` ``action="EN"`` lifecycle.
         """
         await self._client.set_node_enabled(self.address, enabled)
         self._record.enabled = enabled
@@ -826,9 +590,8 @@ def _parse_zwave_parameter_response(address: str, number: int, body: str) -> dic
                 f"Z-Wave get parameter {number} on {address!r} rejected by "
                 f"controller (status={status or 'unknown'})"
             )
-        # A "succeeded" RestResponse with no <config> sibling is unexpected
-        # on the get path — surface as parse error so the caller can log
-        # the body and we can adapt if a new firmware ever returns this.
+        # A succeeded RestResponse without <config> is unexpected — parse
+        # error so the body surfaces for triage.
         raise ISYResponseParseError(
             f"Z-Wave get parameter {number} on {address!r} returned a "
             f"RestResponse envelope without a <config> payload: {body!r}"

--- a/pyisyox/schema/editor.py
+++ b/pyisyox/schema/editor.py
@@ -1,41 +1,20 @@
 """Editor dataclasses and bidirectional codec for IoX profile editors.
 
-In IoX 6's profile schema an *editor* is referenced by id (e.g. ``"I_OL"``,
-``"I_TSTAT_MODE"``, ``"GALLONS"``) from both nodedef properties and
-command parameters. The editor is **not just display metadata** — it
-defines a bidirectional contract:
-
-- Read-side: how a raw integer value reported by the controller decodes
-  to a display string and unit.
-- Write-side: which integer values are *valid* to send as a command
-  parameter, and how a user-provided enum name maps back to the integer
-  the controller expects.
-
-Three write-side fields beyond UOM/min/max/prec:
-
-* ``min``/``max`` plus ``prec`` (decimal precision) — slider bounds and
-  outbound validation.
-* ``subset`` — narrower than min/max. ``"0-3,5-7"`` excludes 4. Outbound
-  commands MUST respect this.
-* ``names`` — enum option list AND int↔string mapping both directions.
-
-The same editor commonly applies to both a property and a related command
-parameter (``I_TSTAT_MODE`` covers reading ``CLIMD`` state and writing
-``CLIMD`` setpoints), so editor-handling code is one shared codec.
-
-Source schema: ``/rest/profiles`` ``editors[]``.
+An *editor* (e.g. ``"I_OL"``, ``"I_TSTAT_MODE"``) is referenced by both
+nodedef properties and command parameters and defines a bidirectional
+contract — read-side decode and write-side validation/encode. Write-side
+constraints beyond ``min``/``max``/``prec`` are the ``subset`` mask
+(``"0-3,5-7"`` excludes 4) and the ``names`` enum option list.
 
 UOM-101 quirk
 -------------
 
-Insteon thermostats encode 0.5°-precision temps as ``raw = 2 * displayed``,
-not as a normal ``prec=1`` decimal. The IoX legacy alias ``"degrees"``
-behaves the same way. When an editor's range carries one of those UOMs and
-declares ``prec=0`` (i.e. it's not already using the modern decimal-prec
-convention) we double on encode / halve on decode to keep the codec
-symmetric. UOM 101 *can* appear with ``prec=1`` on modern profiles too —
-in that case the regular prec scaling already handles it and the doubling
-is skipped.
+Insteon thermostats encode 0.5°-precision temps as ``raw = 2 * displayed``
+(not a normal ``prec=1`` decimal); the legacy alias ``"degrees"`` behaves
+the same way. When a range carries one of those UOMs and declares
+``prec=0`` we double on encode / halve on decode for codec symmetry. Skip
+when ``prec=1`` (modern profiles), since the regular prec scaling
+already handles it.
 """
 
 from __future__ import annotations

--- a/pyisyox/schema/profile.py
+++ b/pyisyox/schema/profile.py
@@ -1,21 +1,15 @@
-"""Profile loader for IoX ``/rest/profiles`` JSON responses.
+"""Profile loader for ``/rest/profiles`` JSON.
 
-Parses one profile blob (families → instances → editors/linkdefs/nodedefs)
-into resolved Python objects, then builds the
-``(nodedef_id, family_id, instance_id) → NodeDef`` lookup that lets a node
-from ``/api/nodes`` find its definition.
+Parses families → instances → editors/linkdefs/nodedefs and builds the
+``(nodedef_id, family_id, instance_id) → NodeDef`` lookup. Knows the
+wire shape but does no HTTP — callers pass dicts to
+:meth:`Profile.load_from_json`.
 
-This module knows the JSON wire shape but does no HTTP. Callers pass
-already-fetched dicts to :meth:`Profile.load_from_json`.
-
-Source schema: ``/rest/profiles?include=nodedefs,editors,linkdefs`` JSON.
-For its families the controller inline-resolves every visible string into
-the ``name`` fields, so the NLS string table isn't needed there. The
-*dynamically* generated Z-Wave nodedefs (fetched from ``def/get`` XML, not
-``/rest/profiles``) are the exception: their commands/properties arrive
-label-less, so :mod:`pyisyox.client` fetches the relevant per-family NLS
-tables and stashes the merged result on :attr:`Profile.nls` — used to
-resolve those labels and to fill encoded editors' enum option names.
+The controller inline-resolves visible strings into the ``name`` fields,
+so the NLS string table isn't needed for ``/rest/profiles`` families.
+Dynamically generated Z-Wave nodedefs (from ``def/get`` XML) are the
+exception: they arrive label-less, so :mod:`pyisyox.client` overlays
+the per-family NLS tables onto :attr:`Profile.nls` after loading them.
 """
 
 from __future__ import annotations
@@ -117,37 +111,12 @@ class Profile:
     def merge(self, other: Profile) -> ProfileMergeResult:
         """Merge ``other`` into ``self`` in place; return a diff summary.
 
-        Designed for PG3 dynamic profile reload: when a plugin updates
-        its nodedefs at runtime (per
-        https://developer.isy.io/docs/API/pg/DynamicProfiles), the
-        consumer refetches ``/rest/profiles`` and constructs a fresh
-        :class:`Profile` from the new payload, then calls this method
-        to fold the updates into the live one. Existing
-        :class:`pyisyox.runtime.Node` instances hold a reference to
-        the resolved :class:`NodeDef`; if we replaced the Profile
-        wholesale they'd cling to stale lookups, so the merge mutates
-        the existing dicts and replaces individual NodeDef / Editor /
-        LinkDef objects rather than rebuilding the structure.
-
-        Semantics:
-
-        * Editors / LinkDefs / NodeDefs in ``other`` overwrite same-id
-          entries in ``self`` at the same family/instance scope.
-        * Editors / LinkDefs / NodeDefs only in ``self`` are kept —
-          ``other`` is treated as additive, never as a delete list.
-          (To remove items, the caller passes a profile with the
-          removed entries explicitly absent and tracks the
-          :attr:`ProfileMergeResult` to act on the diff themselves.)
-        * Families / Instances new to ``other`` are added to ``self``.
-        * The ``nodedef_lookup`` table is updated so the
-          ``(nodedef_id, family_id, instance_id)`` join key resolves
-          to the new instance.
-
-        Returns:
-            A :class:`ProfileMergeResult` listing the nodedef ids that
-            were added vs replaced, plus the equivalent for editors
-            and linkdefs. Consumers can use this to invalidate caches
-            or re-classify nodes whose nodedef changed.
+        Designed for PG3 dynamic profile reload. Existing runtime
+        :class:`Node` instances hold references to the resolved
+        :class:`NodeDef`, so a wholesale replace would leave them
+        clinging to stale lookups — instead the merge mutates the
+        existing dicts and replaces individual NodeDef/Editor/LinkDef
+        objects. Additive only: items absent from ``other`` are kept.
         """
         result = ProfileMergeResult()
         for fam_id, other_family in other.families.items():
@@ -178,15 +147,9 @@ class Profile:
     def register_nodedefs(self, family_id: str, instance_id: str, nodedefs: dict[str, NodeDef]) -> None:
         """Add a batch of nodedefs to ``family_id``/``instance_id`` in place.
 
-        Used for the dynamically-generated Z-Wave nodedefs, which aren't
-        carried by ``/rest/profiles`` and are fetched separately from
-        ``/rest/zwave/node/{addr}/def/get``. The target family / instance
-        is created if it doesn't exist yet (the Z-Wave families *do*
-        already exist in ``/rest/profiles`` — with their ``ZW_*`` editors
-        but no nodedefs — so usually only the nodedef dicts are filled
-        in). Existing same-id nodedefs at that scope are overwritten and
-        the ``nodedef_lookup`` table updated so the
-        ``(nodedef_id, family_id, instance_id)`` join key resolves.
+        Used for dynamic Z-Wave nodedefs (fetched from ``def/get`` XML —
+        the Z-Wave families already exist in ``/rest/profiles`` with
+        their ``ZW_*`` editors but no nodedefs). Overwrites by id.
         """
         family = self.families.setdefault(family_id, Family(id=family_id, name=""))
         instance = family.instances.setdefault(instance_id, Instance(id=instance_id, name=""))


### PR DESCRIPTION
## Summary

Two cleanups bundled into one PR (user request):

1. **Fix doubled GET log lines** — PR #129 added DEBUG to `_get_text` for wire-trace symmetry, but `_get_json` wraps `_get_text` and still had its own `_LOGGER.debug("GET %s -> %d bytes", ...)` summary. So every JSON-load line was logged twice in HA's user-side wire traces (caught in live testing: every `_get_json` call doubled, `_get_text`-only paths logged once). Drop the duplicate from `_get_json`; let `_get_text` own the line.

2. **Slim multi-paragraph docstrings** across `client.py`, `runtime/node.py`, `runtime/events.py`, `schema/profile.py`, and `schema/editor.py`. Module docstrings collapsed to short paragraphs; per-method docstrings tightened to one or two sentences. Net **-570 lines**.

## Load-bearing facts preserved

Trims preserved every wire fact and judgement call the audit flagged as essential:

- UOM-101 encode quirk (`schema/editor.py`)
- `is_fan` ordering rule (must be checked before `is_dimmable`)
- ST-editor as source of truth for `is_dimmable` (DON's level param isn't reliable)
- Z-Wave parameter `size` not modelled by the legacy `CONFIG` cmd editor (`runtime/node.py`)
- Lock-code "needs a tester" caveat (`runtime/node.py`)
- Dynamic-nodedef merge invariant (live runtime Node instances hold NodeDef refs — wholesale replace would leave stale lookups)
- ``_authenticate_once`` double-checked-locking comment (mypy narrowing pitfall)

## Test plan

- [x] 619/619 unit tests pass
- [x] pre-commit (ruff, codespell, mypy, pylint, prettier) clean
- [x] User live-confirmed the doubled log lines were a logging bug, not duplicated HTTP requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)