### PR TITLE
fix(schema): ensure correct family_id in Profile merge diff results

### DIFF
--- a/pyisyox/schema/profile.py
+++ b/pyisyox/schema/profile.py
@@ -138,7 +138,7 @@ class Profile:
                         result.nodedefs_added.append(nd.lookup_key)
                     continue
 
-                _merge_instance(self_inst, other_inst, self.nodedef_lookup, result)
+                _merge_instance(fam_id, self_inst, other_inst, self.nodedef_lookup, result)
 
         if other.timestamp:
             self.timestamp = other.timestamp
@@ -289,6 +289,7 @@ class ProfileMergeResult:
 
 
 def _merge_instance(
+    fam_id: str,
     self_inst: Instance,
     other_inst: Instance,
     nodedef_lookup: dict[tuple[str, str, str], NodeDef],
@@ -302,7 +303,7 @@ def _merge_instance(
     ``changed is False``.
     """
     for ed_id, ed in other_inst.editors.items():
-        key = (ed_id, self_inst.id, self_inst.id)
+        key = (ed_id, fam_id, self_inst.id)
         existing = self_inst.editors.get(ed_id)
         if existing is None:
             result.editors_added.append(key)
@@ -312,7 +313,7 @@ def _merge_instance(
             self_inst.editors[ed_id] = ed
 
     for ld_id, ld in other_inst.linkdefs.items():
-        key = (ld_id, self_inst.id, self_inst.id)
+        key = (ld_id, fam_id, self_inst.id)
         existing_ld = self_inst.linkdefs.get(ld_id)
         if existing_ld is None:
             result.linkdefs_added.append(key)


### PR DESCRIPTION
## Summary

Fixes a bug in `Profile.merge` where `family_id` was shadowed by `instance_id` in the diff result keys for editors and linkdefs.

## Changes

- `_merge_instance` now takes `fam_id` as a parameter
- `editors_added`, `editors_replaced`, `linkdefs_added`, `linkdefs_replaced` keys now use the actual family_id instead of being overwritten by the instance_id

## Impact

Critical for Polyglot (PG3) node-server integrations. Without it, dynamic profile reloads report incorrect metadata paths to consumers (like Home Assistant), potentially preventing correct identification of updated editors or link definitions across different node-server slots.

## Verification

- Repro script that previously returned `('ED1', '11', '11')` (instance_id used twice) now correctly returns `('ED1', '10', '11')`
- Full schema and runtime suite passes (626 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)