### PR TITLE
ci(claude-review): fix silent no-comment runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -36,8 +36,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
+          track_progress: true
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

Applies the fixes from [anthropics/claude-code-action#944](https://github.com/anthropics/claude-code-action/issues/944) to our auto-generated `claude-code-review.yml`. As-shipped by `/install-github-app`, the workflow runs to completion but never posts a review comment.

## Changes

- `pull-requests: read` → `write` and `issues: read` → `write` — comment posting needs write
- Pass `github_token: \${{ github.token }}` so the workflow's declared permissions reach the action (related to #891 upstream)
- `track_progress: true` — when `prompt` is set on a `pull_request` event the action enters agent mode, where `claudeCommentId` is `undefined` and the cleanup block that posts results is skipped; this forces tag mode so a comment scaffold is created
- Append `--comment` to the `/code-review:code-review` slash command — recently added plugin flag that tells the plugin to actually emit the review

## Test plan

- [ ] Open a no-op PR after merge and confirm a review comment is posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)