### PR TITLE
chore(devcontainer): fix postCreate comment + add TOML extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,8 @@
         "redhat.vscode-yaml",
         "esbenp.prettier-vscode",
         "github.vscode-pull-request-github",
-        "streetsidesoftware.code-spell-checker"
+        "streetsidesoftware.code-spell-checker",
+        "tamasfe.even-better-toml"
       ],
       "settings": {
         "files.eol": "\n",

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -10,9 +10,10 @@ cd /workspaces/pyisyox
 pip3 install -e .
 
 # Pre-commit hooks call script/run-in-env.sh, which prefers a project
-# .venv. Symlink the system Python in so worktrees don't have to
-# bootstrap one before commit (matches the "Worktree gotcha" note in
-# CLAUDE.md).
+# .venv. Create one that inherits the system site-packages (the
+# Dockerfile already installed the runtime + dev deps there) so
+# worktrees don't have to bootstrap a fresh venv before commit
+# (matches the "Worktree gotcha" note in CLAUDE.md).
 if [ ! -e .venv ]; then
   python3 -m venv --system-site-packages .venv
 fi


### PR DESCRIPTION
## Summary

Stacked on top of `chore/refresh-devcontainer` to address two bits of post-review feedback on that branch.

- **postCreate.sh comment was wrong.** It said "Symlink the system Python in", but the next line is `python3 -m venv --system-site-packages .venv` — that's a full venv that inherits the system site-packages, not a symlink. Reworded to describe what's actually happening.
- **Add `tamasfe.even-better-toml` to the recommended VS Code extensions.** `pyproject.toml` is a first-class file in this repo (`[tool.ruff]`, `[tool.mypy]`, `[tool.pytest.ini_options]`, …), so hover docs + schema validation come along for free for contributors. Not a blocker — just a nice-to-have.

## Test plan

- [ ] Rebuild the devcontainer and confirm `postCreate.sh` still runs clean (the code didn't change, only the comment).
- [ ] Confirm the TOML extension shows up in the recommended-extensions prompt on first open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BPiv3tNB5ckLyAnUDpSkAu)_