### PR TITLE
chore(coverage): exclude TYPE_CHECKING / __main__ from coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,19 @@ log_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
+[tool.coverage.report]
+# Lines that aren't executable at runtime — typing-only imports, the
+# CLI bootstrap line that pytest can't reach, and abstract / not-yet-
+# implemented stubs. ``exclude_also`` extends coverage.py's defaults
+# (``pragma: no cover``) rather than replacing them.
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "if typing\\.TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+    "@(abc\\.)?abstractmethod",
+]
+
 [tool.ruff]
 required-version = ">=0.15.12"
 target-version = "py311"


### PR DESCRIPTION
## Summary

Add a `[tool.coverage.report]` section to `pyproject.toml` so coverage percentages reflect *executable* code rather than typing-only and bootstrap lines that pytest can't reach without contortions.

## Excluded patterns

Cumulative with coverage.py's `pragma: no cover` default:

| Pattern | Why |
|---|---|
| `if TYPE_CHECKING:` / `if typing\.TYPE_CHECKING:` | Typing imports — exist only for static analysis; never executed at runtime. |
| `if __name__ == .__main__.:` | CLI bootstrap line. Reaching it needs subprocess/runpy gymnastics that add no real assurance over a direct call to the function the block invokes. |
| `raise NotImplementedError` | Abstract / not-yet-implemented stubs. |
| `@(abc\.)?abstractmethod` | Abstract method decorators on bases. |

## Effect on `pytest --cov=pyisyox`

| Module | Before | After |
|---|---|---|
| `pyisyox/__main__.py` | 79% | **100%** |
| `pyisyox/controller.py` | 97% | **100%** |
| `pyisyox/runtime/variable.py` | 99% | **100%** |
| `pyisyox/runtime/events.py` | 99% (4 missing) | 99% (3 missing — drops the TYPE_CHECKING import) |
| **Total** | 96% | **97%** |

(Numbers above are vs current `main`. Once #139 also lands, the same exclusions apply to its added TYPE_CHECKING / `if __name__` lines for free.)

No code changes; pure reporting accuracy.

## Test plan

- [x] `pytest --cov=pyisyox` — 728 passed, 97% total
- [x] `pre-commit run --files pyproject.toml` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)