### PR TITLE
chore: add Zigbee NodeFamily; drop empty pyisyox.util package

### DIFF
--- a/docs/api/pyisyox.rst
+++ b/docs/api/pyisyox.rst
@@ -15,7 +15,6 @@ Subpackages
    pyisyox.helpers
    pyisyox.runtime
    pyisyox.schema
-   pyisyox.util
 
 Submodules
 ----------

--- a/docs/api/pyisyox.util.rst
+++ b/docs/api/pyisyox.util.rst
@@ -1,7 +1,0 @@
-pyisyox.util package
-====================
-
-.. automodule:: pyisyox.util
-   :members:
-   :show-inheritance:
-   :undoc-members:

--- a/pyisyox/constants.py
+++ b/pyisyox/constants.py
@@ -73,7 +73,7 @@ class NodeFamily(StrEnum):
     latest published WSDL). 10 (Node Server / PG3) and 12-15 are IoX 6
     additions confirmed against eisy hardware: 12 is the Z-Matter
     radio acting as a Z-Wave controller, 15 the same radio acting as
-    a Matter/Thread controller, 13 the folder family.
+    a Matter/Thread controller, 13 the folder family, 14 Zigbee.
     """
 
     CORE = "0"
@@ -89,6 +89,7 @@ class NodeFamily(StrEnum):
     NODESERVER = "10"
     ZMATTER_ZWAVE = "12"
     FOLDER = "13"
+    ZIGBEE = "14"
     MATTER = "15"
 
 

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -246,6 +246,8 @@ class Node:
             return Protocol.ZWAVE
         if fid == NodeFamily.MATTER:
             return Protocol.MATTER
+        if fid == NodeFamily.ZIGBEE:
+            return Protocol.ZIGBEE
         # NODESERVER family, or any id we don't recognise — PG3
         # plugin nodes report their slot id in this field.
         if fid and fid not in _CORE_FAMILY_IDS:

--- a/pyisyox/util/__init__.py
+++ b/pyisyox/util/__init__.py
@@ -1,4 +1,0 @@
-"""Utility functions for PyISYoX.
-
-Functions in this directory do not rely on imports from the rest of pyisyox.
-"""

--- a/tests/test_runtime/test_node_introspection.py
+++ b/tests/test_runtime/test_node_introspection.py
@@ -75,6 +75,7 @@ def _make_node(record: NodeRecord, profile: Profile, session: FakeSession | None
         ("4", Protocol.ZWAVE),  # legacy attached Z-Wave radio
         ("12", Protocol.ZWAVE),  # Z-Matter radio as a Z-Wave controller
         ("15", Protocol.MATTER),  # Z-Matter radio as a Matter controller
+        ("14", Protocol.ZIGBEE),  # Zigbee radio
         ("10", Protocol.NODE_SERVER),  # NODESERVER family / PG3 slot
         ("99", Protocol.NODE_SERVER),  # any id outside the core family set
         ("13", Protocol.UNKNOWN),  # folder family — recognised but no protocol


### PR DESCRIPTION
## Summary
Two small pyisyox housekeeping items folded together.

- **Zigbee added to `NodeFamily`** — new `ZIGBEE = \"14\"` between `FOLDER` (13) and `MATTER` (15). Confirmed against eisy hardware as the family id for Zigbee in the IoX 6 additions block. Docstring updated to mention 14.
- **Drop empty `pyisyox.util` package** — the package has been a namespace-only `__init__.py` with a docstring since the v6 rewrite trimmed its last consumer. Nothing inside or outside pyisyox imports from it. Also removes the auto-generated Sphinx stub (`docs/api/pyisyox.util.rst`) and its toctree entry.

## Test plan
- [x] Full suite green (752 passing)
- [x] Pre-commit clean