### PR TITLE
fix: is_dimmable also requires DON in nodedef accepts

### DIFF
--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -21,6 +21,7 @@ from pyisyox.constants import (
     CMD_CLIMATE_MODE,
     CMD_MANUAL_DIM_BEGIN,
     CMD_MANUAL_DIM_STOP,
+    CMD_ON,
     CMD_SECURE,
     PROP_BATTERY_LEVEL,
     PROP_ON_LEVEL,
@@ -281,14 +282,28 @@ class Node:
 
     @property
     def is_dimmable(self) -> bool:
-        """True if the node reports a multilevel ``ST`` state.
+        """True if the node has a multilevel ``ST`` state **and** accepts ``DON``.
 
-        Derived from the ``ST`` property editor: a binary subset
-        (``{0, 100}``) → not dimmable; a multilevel range → dimmable.
-        Relay nodedefs accept ``DON`` with an ignored level param, so
-        ``DON``'s editor is unreliable — ``ST`` is the source of truth.
+        Two conditions must both hold for a real dimmer:
+
+        1. ``ST`` editor reports a multilevel range (not a binary
+           ``{0, 100}`` subset). Relay nodedefs accept ``DON`` with an
+           ignored level param, so ``DON``'s editor alone is
+           unreliable — ``ST`` is the source of truth for "can the
+           node hold a non-binary level".
+        2. The nodedef accepts ``DON``. Some Insteon nodedefs
+           (RemoteLinc2_ADV scene buttons, IMETER_SOLO meters) carry a
+           multilevel ``ST`` editor — meaningful for the device's own
+           bookkeeping — but only accept ``WDU`` / ``QUERY``, so they
+           can't actually be commanded on. Without this check
+           ``is_dimmable`` returns True for them and consumers route
+           them onto the LIGHT platform where DON-based turn_on
+           silently fails.
         """
         if self._nodedef is None:
+            return False
+        accepts = {cmd.id for cmd in self._nodedef.cmds.accepts}
+        if CMD_ON not in accepts:
             return False
         st_prop = self._nodedef.properties.get(PROP_STATUS)
         if st_prop is None or st_prop.editor_id is None:

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -302,8 +302,7 @@ class Node:
         """
         if self._nodedef is None:
             return False
-        accepts = {cmd.id for cmd in self._nodedef.cmds.accepts}
-        if CMD_ON not in accepts:
+        if not self._has_command(CMD_ON):
             return False
         st_prop = self._nodedef.properties.get(PROP_STATUS)
         if st_prop is None or st_prop.editor_id is None:

--- a/tests/test_runtime/test_node_introspection.py
+++ b/tests/test_runtime/test_node_introspection.py
@@ -372,6 +372,18 @@ def test_is_dimmable_false_when_st_property_missing_from_nodedef(real_profile: P
     assert node.is_dimmable is False
 
 
+def test_is_dimmable_false_when_nodedef_does_not_accept_don(
+    real_profile: Profile,
+) -> None:
+    """``RemoteLinc2_ADV`` reports a multilevel ``ST`` editor (the LED
+    bookkeeping range) but its accepts list is just ``WDU`` — sending
+    ``DON`` would fail. ``is_dimmable`` must return False so the consumer
+    doesn't route it onto the LIGHT platform where ``turn_on`` would
+    silently break."""
+    node = _make_node(_make_record(nodedef_id="RemoteLinc2_ADV"), real_profile)
+    assert node.is_dimmable is False
+
+
 # --- ergonomic wrappers: end-to-end via real fixture nodedefs ------------
 
 

--- a/tests/test_runtime/test_node_introspection.py
+++ b/tests/test_runtime/test_node_introspection.py
@@ -372,15 +372,26 @@ def test_is_dimmable_false_when_st_property_missing_from_nodedef(real_profile: P
     assert node.is_dimmable is False
 
 
+@pytest.mark.parametrize(
+    "nodedef_id",
+    [
+        # Battery-powered scene remote — ST is a multilevel LED bookkeeping
+        # range, accepts is just ``WDU``.
+        "RemoteLinc2_ADV",
+        # Energy meter — multilevel ST (the meter reading), accepts is
+        # ``QUERY`` / ``RESET`` / ``WDU``. No DON.
+        "IMETER_SOLO",
+    ],
+)
 def test_is_dimmable_false_when_nodedef_does_not_accept_don(
-    real_profile: Profile,
+    real_profile: Profile, nodedef_id: str
 ) -> None:
-    """``RemoteLinc2_ADV`` reports a multilevel ``ST`` editor (the LED
-    bookkeeping range) but its accepts list is just ``WDU`` — sending
-    ``DON`` would fail. ``is_dimmable`` must return False so the consumer
-    doesn't route it onto the LIGHT platform where ``turn_on`` would
-    silently break."""
-    node = _make_node(_make_record(nodedef_id="RemoteLinc2_ADV"), real_profile)
+    """Nodes with a multilevel ``ST`` editor but no ``DON`` in
+    ``cmds.accepts`` aren't actually dimmable — sending ``DON`` would
+    fail. ``is_dimmable`` must return False so the consumer doesn't
+    route them onto the LIGHT platform where ``turn_on`` would silently
+    break (this is the user-reported RemoteLinc2 / IMETER bug)."""
+    node = _make_node(_make_record(nodedef_id=nodedef_id), real_profile)
     assert node.is_dimmable is False
 
 


### PR DESCRIPTION
## Summary
\`is_dimmable\` previously returned True for any nodedef with a multilevel \`ST\` editor — but some Insteon nodedefs (RemoteLinc2_ADV scene buttons, IMETER_SOLO energy meters) carry a multilevel \`ST\` range for their own bookkeeping while only accepting \`WDU\` / \`QUERY\` on the wire. Consumers reading \`is_dimmable\` then route those nodes onto the LIGHT platform where \`turn_on\` silently fails.

This PR adds a \`DON\` accept-set check before the multilevel \`ST\` check. The two halves now mean "the node has a non-binary level state **and** can actually be commanded on" — a much more useful contract for primary-platform routing.

## User impact
The hacs-udi-iox user hit this when pairing a RemoteLinc2 to the test eisy:

\`\`\`
Unable to turn on light 3E FF 1F 7: command 'DON' not accepted by
nodedef 'RemoteLinc2_ADV' on node '3E FF 1F 7' (accepts: ['WDU'])
\`\`\`

Pairs with a hacs-udi-iox change that switches primary-platform routing to use \`classify().controllable\` for the non-thermostat / non-lock / non-fan classes — together they prevent broken switch / light entities from being created for any node with no real control surface.

## Behaviour matrix

| nodedef | accepts DON? | multilevel ST? | is_dimmable before | after |
|---|---|---|---|---|
| DimmerLampSwitch | yes | yes | True | True |
| KeypadDimmer | yes | yes | True | True |
| RelayLampOnly | yes | no (binary subset) | False | False |
| **RemoteLinc2_ADV** | **no** | yes | True (broken) | **False** |
| **IMETER_SOLO** | **no** | yes | True (broken) | **False** |
| FanLincMotor | yes | no (4-value subset) | False | False |

## Test plan
- [x] New test \`test_is_dimmable_false_when_nodedef_does_not_accept_don\` pinning RemoteLinc2_ADV
- [x] Existing tests still pass (DimmerLampSwitch True, RelayLampOnly False, FanLincMotor False, no-ST defensive False)
- [x] Full suite green: 765 passing
- [x] Pre-commit clean