### PR TITLE
fix: parse program <s> byte as hex; add Program.run_state/eval_state

### DIFF
--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -1500,15 +1500,19 @@ class EventDispatcher:
         running_text = (info.findtext("s") or "").strip()
         running_int: int | None
         try:
-            running_int = int(running_text) if running_text else None
+            # Cookbook §8.5.3: the byte is two ASCII hex digits
+            # (high nibble = eval state, low nibble = run state).
+            running_int = int(running_text, 16) if running_text else None
         except ValueError:
             running_int = None
 
         record.status = new_status
         if running_int is not None:
-            # Stored as the wire string so consumers can compare or
-            # parse; the typed ProgramStatusEvent carries the int form.
-            record.running = str(running_int)
+            # Stored as the wire string verbatim so the typed Program
+            # accessors and consumers reading the raw byte agree on the
+            # source of truth; the typed ProgramStatusEvent carries the
+            # decoded int form.
+            record.running = running_text
 
         _LOGGER.debug(
             "Program %s status -> %s%s",

--- a/pyisyox/runtime/program.py
+++ b/pyisyox/runtime/program.py
@@ -39,12 +39,6 @@ _REST_RUN_LABEL_TO_STATE: dict[str, ProgramRunState] = {
     "running then": ProgramRunState.THEN,
     "running else": ProgramRunState.ELSE,
 }
-_REST_EVAL_LABEL_TO_STATE: dict[str, ProgramEvalState] = {
-    "true": ProgramEvalState.TRUE,
-    "false": ProgramEvalState.FALSE,
-    "unknown": ProgramEvalState.UNKNOWN,
-    "not loaded": ProgramEvalState.NOT_LOADED,
-}
 
 
 def _split_running_field(

--- a/pyisyox/runtime/program.py
+++ b/pyisyox/runtime/program.py
@@ -21,8 +21,58 @@ from dataclasses import asdict
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+from pyisyox.runtime.events import (
+    ProgramEvalState,
+    ProgramRunState,
+    _decode_program_status_byte,
+)
+
 if TYPE_CHECKING:
     from pyisyox.client import IoXClient, ProgramRecord
+
+
+# REST `/api/programs` returns the running state as a human label
+# rather than the cookbook ``<s>`` byte. Older firmware also varies
+# the spacing/casing. Lower-case + collapse whitespace before lookup.
+_REST_RUN_LABEL_TO_STATE: dict[str, ProgramRunState] = {
+    "idle": ProgramRunState.IDLE,
+    "running then": ProgramRunState.THEN,
+    "running else": ProgramRunState.ELSE,
+}
+_REST_EVAL_LABEL_TO_STATE: dict[str, ProgramEvalState] = {
+    "true": ProgramEvalState.TRUE,
+    "false": ProgramEvalState.FALSE,
+    "unknown": ProgramEvalState.UNKNOWN,
+    "not loaded": ProgramEvalState.NOT_LOADED,
+}
+
+
+def _split_running_field(
+    raw: str | None,
+) -> tuple[ProgramRunState | None, ProgramEvalState | None]:
+    """Decode :attr:`Program.running` to typed (run, eval) states.
+
+    Handles both wire shapes the controller emits:
+
+    * REST ``/api/programs`` returns a human label
+      (``"idle"`` / ``"running then"`` / ...). Eval state isn't
+      separately reported on the REST load — the dispatcher derives it
+      from ``ProgramRecord.status`` instead, so this branch returns
+      ``None`` for eval.
+    * The WebSocket ``<s>`` byte (cookbook §8.5.3) — two ASCII hex
+      digits ORing a low-nibble :class:`ProgramRunState` with a
+      high-nibble :class:`ProgramEvalState`.
+    """
+    if raw is None:
+        return (None, None)
+    label = " ".join(raw.split()).lower()
+    if (run := _REST_RUN_LABEL_TO_STATE.get(label)) is not None:
+        return (run, None)
+    try:
+        byte = int(raw, 16)
+    except ValueError:
+        return (None, None)
+    return _decode_program_status_byte(byte)
 
 
 class ProgramCommand(StrEnum):
@@ -147,10 +197,35 @@ class Program(_ProgramBase):
 
     @property
     def running(self) -> str | None:
-        """Free-form runtime state: ``"idle"`` for idle programs;
-        running programs report ``"running then"`` / ``"running else"``
-        / ``"running if"`` etc."""
+        """Raw runtime-state field as the controller reported it.
+
+        Two wire shapes: REST ``/api/programs`` emits a human label
+        (``"idle"`` / ``"running then"`` / ``"running else"``); the WS
+        event stream emits the cookbook ``<s>`` byte (two ASCII hex
+        digits). Use :attr:`run_state` / :attr:`eval_state` for a
+        firmware-agnostic typed view.
+        """
         return self._record.running
+
+    @property
+    def run_state(self) -> ProgramRunState | None:
+        """Typed run-clause state — one of ``IDLE`` / ``THEN`` / ``ELSE``.
+
+        ``None`` when the program errored
+        (:attr:`ProgramEvalState.NOT_LOADED`) or the controller hasn't
+        reported a running field yet.
+        """
+        run, _eval = _split_running_field(self._record.running)
+        return run
+
+    @property
+    def eval_state(self) -> ProgramEvalState | None:
+        """Typed if-clause evaluation state — disambiguates the three
+        "not really True/False" cases that :attr:`status` collapses.
+        ``None`` from REST loads (which only carry the run label) and
+        when the controller hasn't reported a running field yet."""
+        _run, eval_state = _split_running_field(self._record.running)
+        return eval_state
 
     @property
     def last_run_time(self) -> str | None:

--- a/pyisyox/runtime/program.py
+++ b/pyisyox/runtime/program.py
@@ -34,6 +34,11 @@ if TYPE_CHECKING:
 # REST `/api/programs` returns the running state as a human label
 # rather than the cookbook ``<s>`` byte. Older firmware also varies
 # the spacing/casing. Lower-case + collapse whitespace before lookup.
+# Cookbook §8.5.3 defines exactly three run states (and v1 mirrored
+# them). "running if" — sometimes mentioned in older docs — describes
+# a transient mid-evaluation moment that resolves to THEN/ELSE before
+# the controller can render a stable status, so it's intentionally
+# absent here; an unknown label falls through to ``None``.
 _REST_RUN_LABEL_TO_STATE: dict[str, ProgramRunState] = {
     "idle": ProgramRunState.IDLE,
     "running then": ProgramRunState.THEN,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1347,7 +1347,8 @@ async def test_program_status_event_updates_record_in_place() -> None:
 
     assert received and received[0].address == "008D"
     assert received[0].status is True
-    assert received[0].running == 31
+    # `<s>31</s>` is two ASCII hex digits per cookbook §8.5.3 → 0x31.
+    assert received[0].running == 0x31
     # Record mutated in place — Program wrapper sees the new status.
     assert controller.programs["008D"].status is True
 

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -982,11 +982,11 @@ def test_program_status_event_carries_decoded_run_and_eval_state() -> None:
     received: list[ProgramStatusEvent] = []
     dispatcher.add_program_status_listener(received.append)
 
-    # ELSE | FALSE → 0x33 = 51 decimal
-    dispatcher.feed(_program_frame("<id>8D</id><off /><s>51</s>"))
+    # ELSE | FALSE → 0x33 (cookbook §8.5.3: wire byte is two hex digits)
+    dispatcher.feed(_program_frame("<id>8D</id><off /><s>33</s>"))
     assert len(received) == 1
     event = received[0]
-    assert event.running == 51
+    assert event.running == 0x33
     assert event.run_state is ProgramRunState.ELSE
     assert event.eval_state is ProgramEvalState.FALSE
 
@@ -999,8 +999,8 @@ def test_program_status_event_run_state_is_none_when_not_loaded() -> None:
     received: list[ProgramStatusEvent] = []
     dispatcher.add_program_status_listener(received.append)
 
-    # NOT_LOADED = 0xF0 = 240 decimal
-    dispatcher.feed(_program_frame("<id>8D</id><on /><s>240</s>"))
+    # NOT_LOADED = 0xF0 (cookbook §8.5.3: wire byte is two hex digits)
+    dispatcher.feed(_program_frame("<id>8D</id><on /><s>F0</s>"))
     assert len(received) == 1
     event = received[0]
     assert event.run_state is None

--- a/tests/test_runtime/test_program.py
+++ b/tests/test_runtime/test_program.py
@@ -1,0 +1,72 @@
+"""Tests for the :class:`pyisyox.runtime.Program` typed-state accessors."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyisyox.client import IoXClient, ProgramRecord
+from pyisyox.runtime.events import ProgramEvalState, ProgramRunState
+from pyisyox.runtime.program import Program
+
+
+def _client() -> IoXClient:
+    return IoXClient.__new__(IoXClient)
+
+
+def _program(running: str | None) -> Program:
+    record = ProgramRecord(
+        address="0030",
+        name="Sunset",
+        path="/Programs/Sunset",
+        parent_address=None,
+        is_folder=False,
+        status=True,
+        running=running,
+    )
+    return Program(record, _client())
+
+
+@pytest.mark.parametrize(
+    ("running", "run_state", "eval_state"),
+    [
+        ("21", ProgramRunState.IDLE, ProgramEvalState.TRUE),
+        ("22", ProgramRunState.THEN, ProgramEvalState.TRUE),
+        ("33", ProgramRunState.ELSE, ProgramEvalState.FALSE),
+        ("11", ProgramRunState.IDLE, ProgramEvalState.UNKNOWN),
+        ("F0", None, ProgramEvalState.NOT_LOADED),
+        ("f0", None, ProgramEvalState.NOT_LOADED),
+    ],
+)
+def test_run_state_decodes_ws_byte(
+    running: str, run_state: ProgramRunState | None, eval_state: ProgramEvalState
+) -> None:
+    """WS frames carry ``<s>`` as two ASCII hex digits per cookbook §8.5.3."""
+    program = _program(running)
+    assert program.run_state is run_state
+    assert program.eval_state is eval_state
+
+
+@pytest.mark.parametrize(
+    ("running", "run_state"),
+    [
+        ("idle", ProgramRunState.IDLE),
+        ("Idle", ProgramRunState.IDLE),
+        ("running then", ProgramRunState.THEN),
+        ("Running Then", ProgramRunState.THEN),
+        ("running  else", ProgramRunState.ELSE),
+    ],
+)
+def test_run_state_decodes_rest_label(
+    running: str, run_state: ProgramRunState
+) -> None:
+    """REST ``/api/programs`` returns human labels; eval is None there."""
+    program = _program(running)
+    assert program.run_state is run_state
+    assert program.eval_state is None
+
+
+@pytest.mark.parametrize("running", [None, "", "garbage", "ZZ"])
+def test_run_state_returns_none_for_unparseable(running: str | None) -> None:
+    program = _program(running)
+    assert program.run_state is None
+    assert program.eval_state is None


### PR DESCRIPTION
## Summary
Cookbook §8.5.3: the WS `<s>` byte on program-status frames is two ASCII hex digits — high nibble = eval state, low nibble = run state. The dispatcher was parsing it as decimal, so a wire `21` became 21 (`0x15`) instead of `0x21`, and the typed enums #145 added on `ProgramStatusEvent` decoded to garbage.

- Fix the dispatcher to parse hex; store the wire string verbatim in `record.running` so the typed accessors and consumers reading the raw byte agree.
- Add `Program.run_state` / `Program.eval_state` typed properties that decode both wire shapes:
  - WS hex byte (`"21"`, `"F0"`, ...).
  - REST `/api/programs` human label (`"idle"`, `"running then"`, ...).
- v1 reference: <https://github.com/shbatm/pyisyox/blob/1.0.0b0/pyisyox/programs/__init__.py#L121-L124>

Removes the consumer-side workaround in hacs-udi-iox#53 (which had to import `_decode_program_status_byte` privately and try-hex-then-decimal to compensate).

## Test plan
- [x] `pytest` — 781 passed
- [x] New `tests/test_runtime/test_program.py` covers hex bytes, REST labels, and unparseable input
- [x] Existing `_decode_program_status_byte` and dispatcher tests updated to use the correct hex wire format