### PR TITLE
fix(events): PROGRAM_STATUS semantics + parse <r>/<f>/<nr> timestamps

### DIFF
--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -917,14 +917,21 @@ def _parse_ws_program_timestamp(raw: str | None) -> str | None:
     """Convert a ``<r>`` / ``<f>`` / ``<nr>`` WS timestamp to ISO 8601.
 
     The eisy emits these as ``"YYMMDD HH:MM:SS "`` (note the trailing
-    space) in the controller's local time. Returns an ISO 8601 naive
-    string (``"YYYY-MM-DDTHH:MM:SS"``) — the typed
+    space) in the controller's local time. Returns the ISO 8601 naive
+    string (e.g. ``"2026-05-14T16:44:11"``) — the typed
     :class:`pyisyox.runtime.Program` accessors normalise naive parses
     to UTC, matching the existing REST-side ``Z``-suffix path.
 
     Returns ``None`` for missing / blank input (``<nr/>`` self-closes
     when the schedule has been cleared) or unparsable junk so the
-    dispatcher can treat "absent" and "unparsable" the same way.
+    dispatcher can treat "absent" and "unparsable" the same way; the
+    unparsable case is logged at DEBUG to aid firmware-quirk triage.
+
+    Note on the ``%y`` window: Python maps two-digit years 00-68 to
+    2000-2068 and 69-99 to 1969-1999. The eisy is a home controller
+    so timestamps past 2068 are not a realistic concern in this
+    decade, but worth flagging if the cookbook ever upgrades to
+    four-digit years.
     """
     if raw is None:
         return None
@@ -934,6 +941,7 @@ def _parse_ws_program_timestamp(raw: str | None) -> str | None:
     try:
         parsed = datetime.strptime(text, "%y%m%d %H:%M:%S")
     except ValueError:
+        _LOGGER.debug("unparsable program WS timestamp %r — skipping", raw)
         return None
     return parsed.isoformat()
 
@@ -1520,11 +1528,11 @@ class EventDispatcher:
         ``<r>`` / ``<f>`` / ``<nr>`` are timestamps in the controller's
         local time as ``YYMMDD HH:MM:SS`` (with trailing space). Empty
         elements (``<nr/>``) mean "cleared" — surface as ``None``. The
-        record stores them as ISO 8601 naive strings (``"YYYY-MM-DDT
-        HH:MM:SS"``) so the typed
+        record stores them as ISO 8601 naive strings — e.g.
+        ``"2026-05-14T16:44:11"`` — so the typed
         :class:`pyisyox.runtime.Program.last_run_time` accessor can
-        decode either wire shape — REST `Z`-suffix UTC and WS naive
-        local — symmetrically.
+        decode either wire shape (REST ``Z``-suffix UTC and WS naive
+        local) symmetrically.
         """
         if not event.event_info:
             return
@@ -1549,6 +1557,13 @@ class EventDispatcher:
         # <on/> / <off/> are the enabled flag (cookbook §8.5.3 +
         # pyisy v3 ref). Absent on some frames; the dispatcher only
         # touches record.enabled when the frame actually carries one.
+        # ``<onAdj/>`` / ``<offAdj/>`` are status-adjust markers that
+        # appear on *node* frames — pyisy v3 doesn't look for them on
+        # program-status frames, and no captured program-status frame
+        # carries one either. Intentionally not handled here; if a
+        # firmware ever emits them, the unknown-marker fall-through
+        # (``new_enabled = None``) keeps record.enabled unchanged
+        # rather than guessing.
         new_enabled: bool | None
         if info.find("on") is not None:
             new_enabled = True

--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -17,6 +17,7 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from enum import IntEnum, StrEnum
 from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
@@ -912,6 +913,31 @@ class ProgramEvalState(IntEnum):
     NOT_LOADED = 0xF0
 
 
+def _parse_ws_program_timestamp(raw: str | None) -> str | None:
+    """Convert a ``<r>`` / ``<f>`` / ``<nr>`` WS timestamp to ISO 8601.
+
+    The eisy emits these as ``"YYMMDD HH:MM:SS "`` (note the trailing
+    space) in the controller's local time. Returns an ISO 8601 naive
+    string (``"YYYY-MM-DDTHH:MM:SS"``) — the typed
+    :class:`pyisyox.runtime.Program` accessors normalise naive parses
+    to UTC, matching the existing REST-side ``Z``-suffix path.
+
+    Returns ``None`` for missing / blank input (``<nr/>`` self-closes
+    when the schedule has been cleared) or unparsable junk so the
+    dispatcher can treat "absent" and "unparsable" the same way.
+    """
+    if raw is None:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.strptime(text, "%y%m%d %H:%M:%S")
+    except ValueError:
+        return None
+    return parsed.isoformat()
+
+
 def _decode_program_status_byte(
     raw: int | None,
 ) -> tuple[ProgramRunState | None, ProgramEvalState | None]:
@@ -949,10 +975,17 @@ class ProgramStatusEvent:
     Attributes:
         address: Program id (4-character hex, zero-padded to match
             ``/api/programs``).
-        status: ``True`` if the frame contained ``<on/>``; ``False``
-            for ``<off/>``. Other markers (``<onAdj/>`` etc.) are
-            normalised to ``True`` since they all imply
-            "the if-clause matched".
+        status: ``True`` when the cookbook ``<s>`` byte's eval state
+            is :attr:`ProgramEvalState.TRUE` (the if-clause matched on
+            the most recent evaluation); ``False`` for
+            :attr:`ProgramEvalState.FALSE`. For
+            :attr:`ProgramEvalState.UNKNOWN` /
+            :attr:`ProgramEvalState.NOT_LOADED` (and frames with no
+            ``<s>`` byte) the dispatcher carries forward the prior
+            ``record.status`` so a transient unknown doesn't flip the
+            entity. Wire-shape note: the ``<on/>`` / ``<off/>``
+            elements that ride along on the same frame are the
+            **enabled flag**, not the status — see :attr:`enabled`.
         running: Raw ``<s>`` byte the eisy sent, or ``None`` if
             absent. Cookbook §8.5.3: the byte is a bitwise OR of a
             :class:`ProgramRunState` (low nibble) and a
@@ -969,6 +1002,13 @@ class ProgramStatusEvent:
             collapses. ``NOT_LOADED`` is the cookbook label for what
             is in practice the **program-errored** sentinel — see
             :class:`ProgramEvalState`.
+        enabled: New ``enabled`` state when the frame carried an
+            ``<on/>`` / ``<off/>`` element — ``True`` for ``<on/>``,
+            ``False`` for ``<off/>``. ``None`` when the frame omitted
+            both (some "ran"-only frames carry only ``<r>`` / ``<f>``
+            / ``<s>`` — see cookbook §8.5.3). The matching record's
+            :attr:`pyisyox.client.ProgramRecord.enabled` is updated
+            in-place before listeners fire when this is non-``None``.
         seqnum: Sequence number of the underlying :class:`Event`.
     """
 
@@ -978,6 +1018,7 @@ class ProgramStatusEvent:
     seqnum: int
     run_state: ProgramRunState | None = None
     eval_state: ProgramEvalState | None = None
+    enabled: bool | None = None
 
 
 ProgramStatusListener = Callable[[ProgramStatusEvent], None]
@@ -1446,27 +1487,44 @@ class EventDispatcher:
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Variable table change listener raised")
 
-    def _apply_program_status(self, event: Event) -> None:
+    def _apply_program_status(self, event: Event) -> None:  # pylint: disable=too-many-locals
         """Decode a program-status frame and update the matching record.
 
-        Wire shape::
+        Wire shape (cookbook §8.5.3)::
 
             <control>_1</control><action>0</action>
-            <eventInfo><id>HEX</id><on/><r>YYMMDD HH:MM:SS </r>
-            <f>YYMMDD HH:MM:SS </f><s>NN</s></eventInfo>
+            <eventInfo>
+              <id>HEX</id>
+              <on/>                              <!-- enabled flag -->
+              <nr>YYMMDD HH:MM:SS </nr>          <!-- next scheduled run -->
+              <r>YYMMDD HH:MM:SS </r>            <!-- last run start -->
+              <f>YYMMDD HH:MM:SS </f>            <!-- last run finish -->
+              <s>NN</s>                          <!-- status byte -->
+            </eventInfo>
 
         ``<id>`` is hex without zero-padding (``8D``); the
         ``ProgramRecord`` registry is keyed on the zero-padded
         4-character form (``008D``) from ``/api/programs``, so we
-        normalise. ``<on/>`` flips status True; ``<off/>`` flips it
-        False; other markers (``<onAdj/>`` etc.) imply
-        "if-clause matched" and also flip True.
+        normalise.
 
-        ``<s>`` is decoded as int into ``record.running`` so
-        consumers can compare against firmware-version-specific
-        running-state codes; the typed :class:`ProgramRunState` /
-        :class:`ProgramEvalState` decode of the same byte rides on
-        the emitted :class:`ProgramStatusEvent`.
+        Per the cookbook (and the pyisy 3.x reference): ``<on/>`` /
+        ``<off/>`` are the **enabled** flag, *not* the status — they
+        mean "this program is enabled / disabled on the controller"
+        and ride on every program-status frame as the current state.
+        Status ("did the if-clause match") comes from the high nibble
+        of the ``<s>`` byte (:class:`ProgramEvalState`):
+        ``TRUE`` → ``True``, ``FALSE`` → ``False``;
+        ``UNKNOWN`` / ``NOT_LOADED`` carry forward the prior
+        ``record.status`` rather than flipping based on a transient.
+
+        ``<r>`` / ``<f>`` / ``<nr>`` are timestamps in the controller's
+        local time as ``YYMMDD HH:MM:SS`` (with trailing space). Empty
+        elements (``<nr/>``) mean "cleared" — surface as ``None``. The
+        record stores them as ISO 8601 naive strings (``"YYYY-MM-DDT
+        HH:MM:SS"``) so the typed
+        :class:`pyisyox.runtime.Program.last_run_time` accessor can
+        decode either wire shape — REST `Z`-suffix UTC and WS naive
+        local — symmetrically.
         """
         if not event.event_info:
             return
@@ -1488,25 +1546,39 @@ class EventDispatcher:
             _LOGGER.debug("WS program-status event for unknown id %r — dropping", raw_id)
             return
 
-        # <on/> / <onAdj/> / etc. all mean "if-clause matched" → True.
-        # <off/> / <offAdj/> mean "else-clause matched" → False.
-        if info.find("off") is not None or info.find("offAdj") is not None:
-            new_status = False
-        elif info.find("on") is not None or info.find("onAdj") is not None:
-            new_status = True
+        # <on/> / <off/> are the enabled flag (cookbook §8.5.3 +
+        # pyisy v3 ref). Absent on some frames; the dispatcher only
+        # touches record.enabled when the frame actually carries one.
+        new_enabled: bool | None
+        if info.find("on") is not None:
+            new_enabled = True
+        elif info.find("off") is not None:
+            new_enabled = False
         else:
-            new_status = record.status  # Defensive — unrecognised tag
+            new_enabled = None
 
         running_text = (info.findtext("s") or "").strip()
         running_int: int | None
         try:
-            # Cookbook §8.5.3: the byte is two ASCII hex digits
-            # (high nibble = eval state, low nibble = run state).
+            # Cookbook §8.5.3: two ASCII hex digits.
             running_int = int(running_text, 16) if running_text else None
         except ValueError:
             running_int = None
 
+        run_state, eval_state = _decode_program_status_byte(running_int)
+        # Status is the eval-state high nibble. UNKNOWN / NOT_LOADED /
+        # absent → carry forward the prior record.status (don't flip
+        # the entity on a transient mid-evaluation or a load error).
+        if eval_state is ProgramEvalState.TRUE:
+            new_status = True
+        elif eval_state is ProgramEvalState.FALSE:
+            new_status = False
+        else:
+            new_status = record.status
+
         record.status = new_status
+        if new_enabled is not None:
+            record.enabled = new_enabled
         if running_int is not None:
             # Stored as the wire string verbatim so the typed Program
             # accessors and consumers reading the raw byte agree on the
@@ -1514,14 +1586,26 @@ class EventDispatcher:
             # decoded int form.
             record.running = running_text
 
+        last_run = _parse_ws_program_timestamp(info.findtext("r"))
+        last_finish = _parse_ws_program_timestamp(info.findtext("f"))
+        # `<nr/>` (empty) clears the schedule; only mutate when the
+        # frame actually carried the element (some frames omit it).
+        nr_el = info.find("nr")
+        if last_run is not None:
+            record.last_run_time = last_run
+        if last_finish is not None:
+            record.last_finish_time = last_finish
+        if nr_el is not None:
+            record.next_scheduled_run_time = _parse_ws_program_timestamp(nr_el.text)
+
         _LOGGER.debug(
-            "Program %s status -> %s%s",
+            "Program %s status -> %s%s%s",
             record.address,
             new_status,
+            f" enabled={new_enabled}" if new_enabled is not None else "",
             f" (running={running_int})" if running_int is not None else "",
         )
 
-        run_state, eval_state = _decode_program_status_byte(running_int)
         if not self._program_status_listeners:
             return
         status_event = ProgramStatusEvent(
@@ -1531,6 +1615,7 @@ class EventDispatcher:
             seqnum=event.seqnum,
             run_state=run_state,
             eval_state=eval_state,
+            enabled=new_enabled,
         )
         for listener in tuple(self._program_status_listeners):
             try:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1310,10 +1310,11 @@ async def test_send_program_command_before_connect_raises() -> None:
 
 @pytest.mark.asyncio
 async def test_program_status_event_updates_record_in_place() -> None:
-    """Feeding a ``<control>_1</control>`` action ``"0"`` frame with
-    a known program id flips ``program.status`` and fires any
-    registered ``add_program_status_listener`` callbacks. The
-    matching record updates before the listener fires."""
+    """Feeding a ``<control>_1</control>`` action ``"0"`` frame with a
+    known program id mutates the matching record (status from the
+    ``<s>`` eval-state nibble; enabled from ``<on/>`` / ``<off/>``;
+    timestamps from ``<r>`` / ``<f>`` / ``<nr>``) and fires any
+    registered ``add_program_status_listener`` callbacks."""
     session = FakeSession(BASE)
     _stub_responses(session)
     session.set_route(
@@ -1325,8 +1326,8 @@ async def test_program_status_event_updates_record_in_place() -> None:
                 "id": "008D",
                 "name": "Foo",
                 "folder": False,
-                "status": "false",
-                "enabled": True,
+                "status": "true",
+                "enabled": False,
                 "running": "idle",
             },
         ),
@@ -1337,28 +1338,38 @@ async def test_program_status_event_updates_record_in_place() -> None:
     received: list = []
     controller.add_program_status_listener(received.append)
 
-    # Wire frame: <id>8D</id> (unpadded), <on/>, running state 31.
+    # Wire frame: <id>8D</id> (unpadded), <on/> = enabled True,
+    # <s>31</s> = eval FALSE (status flips False), <r>/<f> = last run
+    # timestamps in YYMMDD HH:MM:SS controller-local, <nr/> empty
+    # clears the schedule.
     frame = (
         '<?xml version="1.0"?><Event seqnum="9" sid="x" timestamp="t">'
         "<control>_1</control><action>0</action><node></node>"
         "<eventInfo><id>8D</id><on /><nr /><r>260506 14:30:36 </r>"
-        "<f>260506 14:30:36 </f><s>31</s></eventInfo></Event>"
+        "<f>260506 14:31:42 </f><s>31</s></eventInfo></Event>"
     )
     controller.feed_event_frame(frame)
 
     assert received and received[0].address == "008D"
-    assert received[0].status is True
-    # `<s>31</s>` is two ASCII hex digits per cookbook §8.5.3 → 0x31.
+    # `<s>31</s>` → eval FALSE → status flips False (was True).
+    assert received[0].status is False
     assert received[0].running == 0x31
-    # Record mutated in place — Program wrapper sees the new status.
-    assert controller.programs["008D"].status is True
+    assert received[0].enabled is True
+    # Record mutated in place — Program wrapper sees the new state.
+    program = controller.programs["008D"]
+    assert program.status is False
+    assert program.enabled is True
+    assert program.last_run_time == datetime(2026, 5, 6, 14, 30, 36, tzinfo=UTC)
+    assert program.last_finish_time == datetime(2026, 5, 6, 14, 31, 42, tzinfo=UTC)
+    assert program.next_scheduled_run_time is None  # <nr/> cleared the schedule.
 
     await controller.stop()
 
 
 @pytest.mark.asyncio
-async def test_program_status_event_off_marker_flips_false() -> None:
-    """An ``<off/>`` marker in the eventInfo flips status False."""
+async def test_program_status_event_off_marker_flips_enabled_false() -> None:
+    """``<off/>`` is the enabled-flag, not status. ``<s>21</s>`` carries
+    eval-state TRUE so status flips True regardless of the on/off marker."""
     session = FakeSession(BASE)
     _stub_responses(session)
     session.set_route(
@@ -1370,7 +1381,7 @@ async def test_program_status_event_off_marker_flips_false() -> None:
                 "id": "0011",
                 "name": "Bar",
                 "folder": False,
-                "status": "true",
+                "status": "false",
                 "enabled": True,
             },
         ),
@@ -1385,7 +1396,9 @@ async def test_program_status_event_off_marker_flips_false() -> None:
     )
     controller.feed_event_frame(frame)
 
-    assert controller.programs["0011"].status is False
+    program = controller.programs["0011"]
+    assert program.enabled is False, "<off/> sets enabled = False"
+    assert program.status is True, "<s>21 → eval TRUE → status flips True"
     await controller.stop()
 
 

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -918,27 +918,34 @@ def test_program_status_with_missing_id_is_dropped() -> None:
     assert program.status is False, "no <id> means we can't match a record"
 
 
-def test_program_status_without_on_off_marker_preserves_status() -> None:
-    """Unrecognised marker tags fall through to ``record.status`` —
-    defensive against future firmware adding new flavours."""
+def test_program_status_without_on_off_marker_preserves_enabled() -> None:
+    """A frame without ``<on/>`` / ``<off/>`` (the enabled-flag elements)
+    leaves ``record.enabled`` unchanged — the dispatcher only mutates
+    when the wire actually carries a new value. ``<s>21</s>`` still
+    drives status from its eval-state nibble (TRUE → True)."""
     program = _make_program()
-    program.status = True
+    program.enabled = True
+    program.status = False
     dispatcher = EventDispatcher({}, programs={"008D": program})
 
     dispatcher.feed(_program_frame("<id>8D</id><weird /><s>21</s>"))
-    assert program.status is True, "unrecognised marker preserves prior status"
+    assert program.enabled is True, "no on/off marker preserves prior enabled"
+    assert program.status is True, "<s>21 has eval-state TRUE → status flips True"
 
 
 def test_program_status_with_non_integer_running_is_dropped() -> None:
     """The ``<s>`` running-state value is best-effort-int; garbage there
-    must not crash the apply step (the record's ``running`` simply
-    stays unchanged)."""
+    must not crash the apply step. With no decoded eval state, status
+    carries forward; ``<on/>`` still updates the enabled flag."""
     program = _make_program()
+    program.status = False
+    program.enabled = False
     program.running = None
     dispatcher = EventDispatcher({}, programs={"008D": program})
 
     dispatcher.feed(_program_frame("<id>8D</id><on /><s>not-a-number</s>"))
-    assert program.status is True
+    assert program.status is False, "garbage <s> leaves status unchanged"
+    assert program.enabled is True, "<on/> still flips enabled True"
     assert program.running is None, "non-int <s> leaves running unchanged"
 
 
@@ -1005,6 +1012,52 @@ def test_program_status_event_run_state_is_none_when_not_loaded() -> None:
     event = received[0]
     assert event.run_state is None
     assert event.eval_state is ProgramEvalState.NOT_LOADED
+
+
+def test_program_status_writes_timestamps_to_record() -> None:
+    """``<r>`` / ``<f>`` are parsed from ``YYMMDD HH:MM:SS`` controller-
+    local into ISO 8601 naive strings on the record so the typed
+    :class:`Program` accessors can decode them. ``<nr/>`` self-closed
+    means the schedule was cleared — surface as ``None``."""
+    program = _make_program()
+    program.last_run_time = "2026-05-01T00:00:00"
+    program.last_finish_time = "2026-05-01T00:00:00"
+    program.next_scheduled_run_time = "2026-05-15T18:00:00"
+    dispatcher = EventDispatcher({}, programs={"008D": program})
+
+    dispatcher.feed(
+        _program_frame(
+            "<id>8D</id><on /><nr /><r>260514 16:44:11 </r>"
+            "<f>260514 16:44:21 </f><s>21</s>"
+        )
+    )
+
+    assert program.last_run_time == "2026-05-14T16:44:11"
+    assert program.last_finish_time == "2026-05-14T16:44:21"
+    assert program.next_scheduled_run_time is None
+
+
+def test_program_status_garbage_timestamp_leaves_record_unchanged() -> None:
+    """Unparsable ``<r>`` text doesn't crash and leaves the prior value."""
+    program = _make_program()
+    program.last_run_time = "2026-05-01T00:00:00"
+    dispatcher = EventDispatcher({}, programs={"008D": program})
+
+    dispatcher.feed(_program_frame("<id>8D</id><on /><r>not-a-timestamp</r>"))
+
+    assert program.last_run_time == "2026-05-01T00:00:00"
+
+
+def test_program_status_omitted_nr_preserves_schedule() -> None:
+    """A frame *without* an ``<nr>`` element (vs ``<nr/>`` self-closed)
+    means "no info" — the prior schedule is preserved."""
+    program = _make_program()
+    program.next_scheduled_run_time = "2026-05-15T18:00:00"
+    dispatcher = EventDispatcher({}, programs={"008D": program})
+
+    dispatcher.feed(_program_frame("<id>8D</id><on /><s>21</s>"))
+
+    assert program.next_scheduled_run_time == "2026-05-15T18:00:00"
 
 
 def test_program_status_event_run_state_is_none_when_running_absent() -> None:


### PR DESCRIPTION
## Summary

Stacked on #149. Fixes a long-standing dispatcher-side misinterpretation of program-status frames that surfaced in hacs-udi-iox as switches that bounced back and timestamp sensors that never refreshed.

The dispatcher was treating ``<on/>`` / ``<off/>`` as the program **status** flag and ignoring ``<r>`` / ``<f>`` / ``<nr>`` entirely. Per cookbook §8.5.3 and the pyisy 3.x reference implementation, ``<on/>`` / ``<off/>`` are the **enabled** flag, and status comes from the high-nibble eval state of the ``<s>`` byte.

### Symptoms (in hacs-udi-iox PR #53)

* "Enable" switch bounced back to ON after toggling off — the ``<off/>`` ack flipped record.status, never record.enabled, so ``program.enabled`` stayed True on re-render.
* Last-run / last-finish timestamp sensors never updated after a program ran — the dispatcher dropped the ``<r>`` / ``<f>`` payload entirely.

### Fixes

* ``<on/>`` / ``<off/>`` now write to ``record.enabled`` (only when the frame actually carries one).
* Status is derived from the ``<s>`` byte's :class:`ProgramEvalState`: ``TRUE`` → True, ``FALSE`` → False; ``UNKNOWN`` / ``NOT_LOADED`` carry forward the prior value (don't flip the entity on a transient).
* New ``_parse_ws_program_timestamp`` helper converts ``YYMMDD HH:MM:SS`` controller-local strings to ISO 8601 naive (``"YYYY-MM-DDTHH:MM:SS"``). The typed :class:`Program` accessors from #149 decode both wire shapes symmetrically (REST ``Z``-suffix UTC + WS naive local).
* ``<nr/>`` self-closed clears the schedule (→ ``None``); a frame without ``<nr>`` preserves the prior value.
* :class:`ProgramStatusEvent` gains an ``enabled: bool | None`` field carrying the new enabled state when the frame supplied one.

## Test plan

- [x] Updated existing controller-level tests to assert corrected semantics (3 tests).
- [x] New dispatcher-level tests cover ``<r>`` / ``<f>`` / ``<nr>`` parse, garbage timestamps, and the omitted-vs-cleared distinction (3 tests).
- [x] Full suite: 796 passing.
- [x] pre-commit: all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)