### PR TITLE
fix(events): use event frame's tz offset for WS body timestamps

### DIFF
--- a/pyisyox/runtime/events.py
+++ b/pyisyox/runtime/events.py
@@ -17,7 +17,7 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, tzinfo
 from enum import IntEnum, StrEnum
 from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
@@ -913,29 +913,51 @@ class ProgramEvalState(IntEnum):
     NOT_LOADED = 0xF0
 
 
-def _parse_ws_program_timestamp(raw: str | None) -> str | None:
+def _extract_event_tz(timestamp: str) -> tzinfo | None:
+    """Pull the controller's tz from a frame's ``<Event timestamp="...">``.
+
+    The eisy stamps every WS frame with its own local time + offset
+    (e.g. ``"2026-05-14T20:47:26.828098-05:00"``). That offset is the
+    most reliable signal pyisyox has for the controller's tz; the
+    naive ``YYMMDD HH:MM:SS`` body timestamps share it.
+
+    Returns ``None`` if the attribute is empty, unparsable, or carries
+    no offset — the caller falls back to system-local in that case.
+    """
+    if not timestamp:
+        return None
+    try:
+        parsed = datetime.fromisoformat(timestamp)
+    except ValueError:
+        return None
+    return parsed.tzinfo
+
+
+def _parse_ws_program_timestamp(raw: str | None, *, tz: tzinfo | None = None) -> str | None:
     """Convert a ``<r>`` / ``<f>`` / ``<nsr>`` WS timestamp to ISO 8601 UTC.
 
     The eisy emits these as ``"YYMMDD HH:MM:SS "`` (note the trailing
     space) in the **controller's local time**, with no timezone
-    indicator on the wire. Returns an ISO 8601 string with an explicit
-    UTC offset (e.g. ``"2026-05-14T21:44:11+00:00"``) so the stored
-    representation matches the REST ``Z``-suffix shape — the typed
-    :class:`pyisyox.runtime.Program` accessors then parse it back to
-    a tz-aware :class:`datetime` that consumers can hand straight to
-    HA's TIMESTAMP sensor class without a second tz coercion.
+    indicator on the body element. Returns an ISO 8601 string with an
+    explicit UTC offset (e.g. ``"2026-05-14T21:44:11+00:00"``) so the
+    stored representation matches the REST ``Z``-suffix shape — the
+    typed :class:`pyisyox.runtime.Program` accessors then parse it
+    back to a tz-aware :class:`datetime` that consumers can hand
+    straight to HA's TIMESTAMP sensor class without a second tz
+    coercion.
 
-    The naive wire string is interpreted as **system-local time** —
-    the deployment assumption is that the eisy and the host running
-    pyisyox share a timezone (the common LAN setup). If the eisy and
-    host are in different zones, last-run / last-finish timestamps
-    will be off by the delta until ``pyisyox`` learns to fetch the
-    controller's tz from ``/rest/time``.
-
-    Returns ``None`` for missing / blank input (``<nsr/>`` self-closes
-    when no next run is scheduled) or unparsable junk so the
-    dispatcher can treat "absent" and "unparsable" the same way; the
-    unparsable case is logged at DEBUG to aid firmware-quirk triage.
+    Args:
+        raw: The wire string. ``None`` / blank / unparsable returns
+            ``None`` so the dispatcher can treat "absent" and
+            "unparsable" the same way; the unparsable case is logged
+            at DEBUG to aid firmware-quirk triage.
+        tz: The controller's tz, normally extracted from the parent
+            frame's ``<Event timestamp="...">`` offset (see
+            :func:`_extract_event_tz`). When ``None`` the caller
+            doesn't know — fall back to system-local. The fall-back
+            is only correct when host tz == eisy tz; the fallback
+            path matters in test contexts where there's no ambient
+            event frame.
 
     Note on the ``%y`` window: Python maps two-digit years 00-68 to
     2000-2068 and 69-99 to 1969-1999. The eisy is a home controller
@@ -949,14 +971,18 @@ def _parse_ws_program_timestamp(raw: str | None) -> str | None:
     if not text:
         return None
     try:
-        # ``astimezone()`` on a naive datetime treats it as system-local
-        # and returns a tz-aware datetime in the system local zone.
-        # Then convert to UTC so the stored ISO 8601 string carries an
-        # explicit ``+00:00`` offset and matches the REST shape.
-        parsed = datetime.strptime(text, "%y%m%d %H:%M:%S").astimezone()
+        parsed = datetime.strptime(text, "%y%m%d %H:%M:%S")
     except ValueError:
         _LOGGER.debug("unparsable program WS timestamp %r — skipping", raw)
         return None
+    # ``astimezone()`` on a naive datetime assumes system-local — the
+    # fall-back when no event frame supplies the eisy's tz (e.g. direct
+    # helper calls). The explicit-tz branch keeps the wall-clock when
+    # the frame did supply one.
+    if tz is not None:  # noqa: SIM108
+        parsed = parsed.replace(tzinfo=tz)
+    else:
+        parsed = parsed.astimezone()
     return parsed.astimezone(UTC).isoformat()
 
 
@@ -1651,13 +1677,19 @@ class EventDispatcher:
             # decoded int form.
             record.running = running_text
 
-        last_run = _parse_ws_program_timestamp(info.findtext("r"))
-        last_finish = _parse_ws_program_timestamp(info.findtext("f"))
+        # The controller stamps every WS frame with its own local
+        # time + offset (e.g. ``-05:00``). Use that as the tz for the
+        # naive ``YYMMDD HH:MM:SS`` body timestamps — more reliable
+        # than guessing the host's tz, which is wrong inside a
+        # ``TZ=UTC`` container with the eisy in a different zone.
+        event_tz = _extract_event_tz(event.timestamp)
+        last_run = _parse_ws_program_timestamp(info.findtext("r"), tz=event_tz)
+        last_finish = _parse_ws_program_timestamp(info.findtext("f"), tz=event_tz)
         # ``<nsr>`` is the next-scheduled-run timestamp — fires as a
         # standalone partial frame when the controller's scheduler
         # plans the next run (e.g. immediately after ``runAtNextTime``
         # is set or after each fire). Same wire shape as ``<r>``/``<f>``.
-        next_scheduled = _parse_ws_program_timestamp(info.findtext("nsr"))
+        next_scheduled = _parse_ws_program_timestamp(info.findtext("nsr"), tz=event_tz)
         if last_run is not None:
             record.last_run_time = last_run
         if last_finish is not None:

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -894,9 +894,10 @@ def _make_program(address: str = "008D") -> ProgramRecord:
     )
 
 
-def _program_frame(event_info: str, *, seqnum: int = 1) -> str:
+def _program_frame(event_info: str, *, seqnum: int = 1, timestamp: str = "") -> str:
+    ts_attr = f' timestamp="{timestamp}"' if timestamp else ""
     return (
-        f'<Event seqnum="{seqnum}"><control>_1</control><action>0</action><node></node>'
+        f'<Event seqnum="{seqnum}"{ts_attr}><control>_1</control><action>0</action><node></node>'
         f"<eventInfo>{event_info}</eventInfo></Event>"
     )
 
@@ -1040,6 +1041,43 @@ def test_program_status_writes_timestamps_to_record() -> None:
     assert program.last_run_time == "2026-05-14T16:44:11+00:00"
     assert program.last_finish_time == "2026-05-14T16:44:21+00:00"
     assert program.next_scheduled_run_time == "2026-05-15T18:00:00"
+
+
+def test_program_status_uses_event_frame_tz_for_body_timestamps() -> None:
+    """The eisy stamps every WS frame with its own local time + offset
+    (e.g. ``-05:00``). The dispatcher uses that offset — not the host's
+    system tz — when interpreting the naive ``YYMMDD HH:MM:SS`` body
+    timestamps. This is the only correct path inside a ``TZ=UTC``
+    container talking to an eisy in a different zone (the common
+    devcontainer setup)."""
+    program = _make_program()
+    dispatcher = EventDispatcher({}, programs={"008D": program})
+
+    # Eisy in CDT: frame timestamp carries -05:00 offset; <r>/<f>
+    # body strings are 20:42:42 *local CDT* → 01:42:42 *UTC* of the
+    # next day.
+    frame = _program_frame(
+        "<id>8D</id><on /><r>260514 20:42:42 </r>"
+        "<f>260514 20:42:42 </f><s>21</s>",
+        timestamp="2026-05-14T20:47:26.828098-05:00",
+    )
+    dispatcher.feed(frame)
+
+    assert program.last_run_time == "2026-05-15T01:42:42+00:00"
+    assert program.last_finish_time == "2026-05-15T01:42:42+00:00"
+
+
+def test_program_status_falls_back_to_system_tz_when_event_timestamp_missing() -> None:
+    """When the event frame has no timestamp attribute, the parser
+    falls back to system-local tz (``TZ=UTC`` in the test suite, so the
+    fall-back path is a no-op and the wall-clock survives)."""
+    program = _make_program()
+    dispatcher = EventDispatcher({}, programs={"008D": program})
+
+    # No ``timestamp=`` arg → no offset on the frame → fall-back path.
+    dispatcher.feed(_program_frame("<id>8D</id><on /><r>260514 16:44:11 </r><s>21</s>"))
+
+    assert program.last_run_time == "2026-05-14T16:44:11+00:00"
 
 
 def test_program_status_writes_next_scheduled_from_nsr_partial_frame() -> None:

--- a/tests/test_runtime/test_events.py
+++ b/tests/test_runtime/test_events.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -25,6 +25,7 @@ from pyisyox.runtime.events import (
     SystemEventControl,
     VariableTableChangeEvent,
     _decode_program_status_byte,
+    _extract_event_tz,
     _extract_lifecycle_node_xml,
     parse_event_frame,
 )
@@ -847,6 +848,28 @@ def test_extract_lifecycle_node_xml_without_inner_node_returns_none() -> None:
     actions carry only the address)."""
     xml = '<Event><control>_3</control><eventInfo><addr>A</addr></eventInfo></Event>'
     assert _extract_lifecycle_node_xml(xml) is None
+
+
+# --- _extract_event_tz direct unit tests ---------------------------------
+
+
+def test_extract_event_tz_empty_returns_none() -> None:
+    assert _extract_event_tz("") is None
+
+
+def test_extract_event_tz_naive_iso_returns_none() -> None:
+    """No offset → ``parsed.tzinfo`` is ``None``; caller falls back to local."""
+    assert _extract_event_tz("2026-05-14T20:47:26.828098") is None
+
+
+def test_extract_event_tz_malformed_returns_none() -> None:
+    assert _extract_event_tz("not-a-timestamp") is None
+
+
+def test_extract_event_tz_offset_bearing_returns_tzinfo() -> None:
+    tz = _extract_event_tz("2026-05-14T20:47:26.828098-05:00")
+    assert tz is not None
+    assert tz.utcoffset(None) == timedelta(hours=-5)
 
 
 # --- dispatcher: listener unsubscribe-twice + lifecycle / program errors --


### PR DESCRIPTION
## Summary

Follow-up to #151 — the system-local fall-back broke for the common devcontainer setup where HA runs in a ``TZ=UTC`` container talking to an eisy in a different zone. The container thinks the wire string is UTC, stores it as UTC, and HA then converts UTC → display-local, showing the timestamp ``host_offset`` hours behind reality.

## Fix

Every WS frame's ``<Event timestamp="...">`` attribute carries the eisy's local time + offset (e.g. ``"2026-05-14T20:47:26.828098-05:00"``). That offset is the most reliable signal pyisyox has for the controller's tz, and it matches the body timestamps on the same frame.

- New ``_extract_event_tz(timestamp: str) -> tzinfo | None`` helper.
- ``_parse_ws_program_timestamp`` accepts an explicit ``tz=`` kwarg.
- ``_apply_program_status`` extracts the frame's tz once and passes it to all three timestamp parses (``<r>`` / ``<f>`` / ``<nsr>``).
- System-local ``astimezone()`` behaviour preserved as the fall-back when the frame lacks an offset (covers test cases and pre-IoX-6 firmware that never emitted one).

## Verified

User-reported live frame from a CDT eisy:

```
<Event timestamp="2026-05-14T20:47:26.828098-05:00">
  <eventInfo><id>2</id><on /><nr /><r>260514 20:42:42 </r>
  <f>260514 20:42:42 </f><s>31</s></eventInfo>
</Event>
```

Stored value:
- **Before**: ``"2026-05-14T20:42:42+00:00"`` (wrong — naive treated as UTC)
- **After**: ``"2026-05-15T01:42:42+00:00"`` (correct — CDT 20:42 → UTC 01:42 next day)

## Test plan

- [x] New ``test_program_status_uses_event_frame_tz_for_body_timestamps`` pins the user's exact wire shape (``-05:00`` offset)
- [x] New ``test_program_status_falls_back_to_system_tz_when_event_timestamp_missing`` covers the system-local fall-back path
- [x] Existing tests still pass (the ``_program_frame`` helper now optionally accepts a ``timestamp=`` kwarg; default omits the attribute → fall-back path, same wall-clock under ``TZ=UTC``)
- [x] Full suite: 802 passing
- [x] pre-commit: all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)