### PR TITLE
feat(client): restore Node.zwave_props (devtype block on Z-Wave nodes)

### DIFF
--- a/pyisyox/__init__.py
+++ b/pyisyox/__init__.py
@@ -52,6 +52,7 @@ from pyisyox.client import (
     ProgramRecord,
     VariableField,
     VariableRecord,
+    ZWaveProperties,
 )
 from pyisyox.controller import Controller, ControllerNotConnectedError
 from pyisyox.exceptions import (
@@ -175,6 +176,7 @@ __all__ = [
     "VariableTableChangeEvent",
     "VariableTableChangeListener",
     "WebSocketEventStream",
+    "ZWaveProperties",
     "build_sslcontext",
     "classify",
     "describe_system_event",

--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -145,6 +145,68 @@ class NodePropertyValue:
     precision: int = 0
 
 
+@dataclass(slots=True, frozen=True)
+class ZWaveProperties:
+    """Z-Wave product details from the controller's ``devtype`` block.
+
+    Surfaces only on Z-Wave / Z-Matter nodes (family ids ``"4"`` /
+    ``"12"``). Sourced from the ``devtype`` JSON object on
+    ``/api/nodes``: ``cat`` is the Z-Wave generic-class id (e.g.
+    ``"121"`` for a multi-channel composite, ``"155"`` for a notification
+    sensor); ``mfg`` is ``"<mfr_id>.<prod_type_id>.<product_id>"``;
+    ``gen`` is ``"<basic>.<generic>.<specific>"``. The split-out
+    ``basic_type`` / ``generic_type`` / ``specific_type`` and
+    ``mfr_id`` / ``prod_type_id`` / ``product_id`` are convenience
+    accessors over the same values.
+
+    Adapted from the legacy ``PyISY.helpers.ZWaveProperties`` so
+    consumers (notably the hacs-udi-iox device-class lookup) can keep
+    using ``node.zwave_props.category`` instead of re-parsing the
+    triple.
+    """
+
+    category: str = "0"
+    devtype_mfg: str = "0.0.0"
+    devtype_gen: str = "0.0.0"
+    basic_type: str = "0"
+    generic_type: str = "0"
+    specific_type: str = "0"
+    mfr_id: str = "0"
+    prod_type_id: str = "0"
+    product_id: str = "0"
+
+    @classmethod
+    def from_devtype(cls, devtype: Any) -> ZWaveProperties | None:
+        """Parse a ``devtype`` JSON object — or return ``None`` for any
+        non-mapping input (Insteon nodes don't carry one)."""
+        if not isinstance(devtype, dict):
+            return None
+        category = str(devtype.get("cat", "0"))
+        devtype_mfg = str(devtype.get("mfg", "0.0.0"))
+        devtype_gen = str(devtype.get("gen", "0.0.0"))
+        basic_type, generic_type, specific_type = "0", "0", "0"
+        mfr_id, prod_type_id, product_id = "0", "0", "0"
+        if devtype_gen:
+            parts = devtype_gen.split(".")
+            if len(parts) == 3:
+                basic_type, generic_type, specific_type = parts
+        if devtype_mfg:
+            parts = devtype_mfg.split(".")
+            if len(parts) == 3:
+                mfr_id, prod_type_id, product_id = parts
+        return cls(
+            category=category,
+            devtype_mfg=devtype_mfg,
+            devtype_gen=devtype_gen,
+            basic_type=basic_type,
+            generic_type=generic_type,
+            specific_type=specific_type,
+            mfr_id=mfr_id,
+            prod_type_id=prod_type_id,
+            product_id=product_id,
+        )
+
+
 @dataclass(slots=True)
 class NodeRecord:
     """One node from ``/api/nodes``, with property values merged in from
@@ -169,6 +231,8 @@ class NodeRecord:
     #: this node.
     flag: int = 0
     properties: dict[str, NodePropertyValue] = field(default_factory=dict)
+    #: Parsed Z-Wave ``devtype`` block; ``None`` for non-Z-Wave nodes.
+    zwave_props: ZWaveProperties | None = None
 
 
 @dataclass(slots=True)
@@ -1076,6 +1140,7 @@ def _node_from_api_json(item: dict[str, Any]) -> NodeRecord:
         enabled=str(item.get("enabled", "true")).lower() == "true",
         flag=flag_int,
         properties=properties,
+        zwave_props=ZWaveProperties.from_devtype(item.get("devtype")),
     )
 
 

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -40,7 +40,7 @@ from pyisyox.runtime._normalize import normalize_property_value
 _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from pyisyox.client import IoXClient, NodePropertyValue, NodeRecord
+    from pyisyox.client import IoXClient, NodePropertyValue, NodeRecord, ZWaveProperties
     from pyisyox.schema.editor import Editor
     from pyisyox.schema.nodedef import NodeDef
     from pyisyox.schema.profile import Profile
@@ -324,6 +324,12 @@ class Node:
         """
         props = self._record.properties
         return PROP_BATTERY_LEVEL in props and PROP_STATUS not in props
+
+    @property
+    def zwave_props(self) -> ZWaveProperties | None:
+        """Parsed :class:`~pyisyox.client.ZWaveProperties` for Z-Wave /
+        Z-Matter nodes; ``None`` for Insteon and other families."""
+        return self._record.zwave_props
 
     def _has_command(self, cmd_id: str) -> bool:
         """True if ``cmd_id`` appears in this node's ``cmds.accepts``."""

--- a/tests/test_client/test_parsers.py
+++ b/tests/test_client/test_parsers.py
@@ -96,9 +96,7 @@ def test_parse_api_nodes_bare_scalar_family() -> None:
                         "type": "4.17.1.0",
                         "enabled": "true",
                         "pnode": "ZW002_1",
-                        "property": [
-                            {"id": "ST", "value": "37", "formatted": "37%", "uom": "51"}
-                        ],
+                        "property": [{"id": "ST", "value": "37", "formatted": "37%", "uom": "51"}],
                     },
                     {
                         "address": "n012_1",
@@ -124,6 +122,55 @@ def test_parse_api_nodes_handles_empty_payload() -> None:
     assert parse_api_nodes({}) == {}
     assert parse_api_nodes({"data": {}}) == {}
     assert parse_api_nodes({"data": {"nodes": {}}}) == {}
+
+
+def test_parse_api_nodes_zwave_devtype_block_lands_on_record() -> None:
+    """Z-Wave / Z-Matter nodes carry a ``devtype`` JSON object —
+    ``cat`` (generic class), ``mfg`` (mfr.prod_type.product), ``gen``
+    (basic.generic.specific). Adapted from the legacy PyISY
+    ``ZWaveProperties`` so consumers can sort by Z-Wave generic
+    category without re-parsing the JSON.
+    """
+    raw = {
+        "data": {
+            "nodes": {
+                "node": [
+                    {
+                        "address": "ZW019_1",
+                        "name": "ZW 019 Multi-Channel Sensor",
+                        "nodeDefId": "UZW0099",
+                        "family": "4",
+                        "type": "4.16.1.0",
+                        "enabled": "true",
+                        "devtype": {
+                            "gen": "4.16.1",
+                            "mfg": "634.257.13",
+                            "cat": "121",
+                        },
+                    },
+                    {
+                        # Insteon node — no devtype block.
+                        "address": "1A 2B 3C 1",
+                        "name": "Hallway Switch",
+                        "nodeDefId": "DimmerLampSwitch",
+                        "type": "1.65.69.0",
+                    },
+                ]
+            }
+        }
+    }
+    nodes = parse_api_nodes(raw)
+
+    zw = nodes["ZW019_1"].zwave_props
+    assert zw is not None
+    assert zw.category == "121"
+    assert zw.devtype_mfg == "634.257.13"
+    assert zw.devtype_gen == "4.16.1"
+    assert (zw.basic_type, zw.generic_type, zw.specific_type) == ("4", "16", "1")
+    assert (zw.mfr_id, zw.prod_type_id, zw.product_id) == ("634", "257", "13")
+
+    # Insteon nodes get None — the gate consumers use to skip the lookup.
+    assert nodes["1A 2B 3C 1"].zwave_props is None
 
 
 def test_parse_api_nodes_skips_property_entries_without_id() -> None:

--- a/tests/test_runtime/test_node_introspection.py
+++ b/tests/test_runtime/test_node_introspection.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 
 from pyisyox.auth import LocalAuth
-from pyisyox.client import IoXClient, NodePropertyValue, NodeRecord
+from pyisyox.client import IoXClient, NodePropertyValue, NodeRecord, ZWaveProperties
 from pyisyox.constants import NodeFlag, Protocol
 from pyisyox.runtime import Node
 from pyisyox.schema import Profile
@@ -167,6 +167,26 @@ def test_is_battery_node_false_when_st_present(real_profile: Profile) -> None:
     )
     node = _make_node(record, real_profile)
     assert node.is_battery_node is False
+
+
+def test_zwave_props_passes_through_when_devtype_present(real_profile: Profile) -> None:
+    """Z-Wave nodes carry the parsed ``devtype`` block on their record;
+    the runtime ``Node`` re-exposes it so consumers can sort by Z-Wave
+    generic-class category without re-parsing JSON."""
+    record = _make_record(family_id="4", address="ZW019_1")
+    record.zwave_props = ZWaveProperties.from_devtype({"cat": "121", "mfg": "634.257.13", "gen": "4.16.1"})
+    node = _make_node(record, real_profile)
+
+    assert node.zwave_props is not None
+    assert node.zwave_props.category == "121"
+    assert node.zwave_props.basic_type == "4"
+
+
+def test_zwave_props_none_for_insteon_nodes(real_profile: Profile) -> None:
+    """Insteon (and any non-Z-Wave) nodes have no ``devtype`` block —
+    ``zwave_props`` is the gate consumers check before reading category."""
+    node = _make_node(_make_record(family_id="1"), real_profile)
+    assert node.zwave_props is None
 
 
 def test_introspection_safe_when_nodedef_unresolved(real_profile: Profile) -> None:
@@ -383,9 +403,7 @@ def test_is_dimmable_false_when_st_property_missing_from_nodedef(real_profile: P
         "IMETER_SOLO",
     ],
 )
-def test_is_dimmable_false_when_nodedef_does_not_accept_don(
-    real_profile: Profile, nodedef_id: str
-) -> None:
+def test_is_dimmable_false_when_nodedef_does_not_accept_don(real_profile: Profile, nodedef_id: str) -> None:
     """Nodes with a multilevel ``ST`` editor but no ``DON`` in
     ``cmds.accepts`` aren't actually dimmable — sending ``DON`` would
     fail. ``is_dimmable`` must return False so the consumer doesn't


### PR DESCRIPTION
## Summary

- Restores `Node.zwave_props` (dropped in the v6 rewrite) by adapting the legacy v3 `PyISY.helpers.ZWaveProperties` dataclass into the v6 `client.py` model
- Wires the parser to read the `devtype` JSON block off `/api/nodes` — `cat` (Z-Wave generic-class id), `mfg` (mfr.prod_type.product), `gen` (basic.generic.specific)
- Re-exports `ZWaveProperties` from the package root

## Why

The legacy accessor was load-bearing for Z-Wave-side `device_class` assignment in HA consumers (notably hacs-udi-iox's `binary_sensor.py`'s `BINARY_SENSOR_DEVICE_TYPES_ZWAVE` lookup). Without it, every Z-Wave binary sensor (smoke / leak / motion / battery alarm) lands as a generic class-less binary sensor — silent regression. Surfaced during the side-by-side core+hacs sorting audit.

`devtype` shape on the wire (confirmed against a real eisy):

```json
"devtype": {"gen": "4.16.1", "mfg": "634.257.13", "cat": "121"}
```

Returns `None` for non-Z-Wave nodes — the gate consumers check before reading `category`.

## Test plan

- [x] New parser test pins JSON → dataclass round-trip including the convenience splits (`basic_type` / `generic_type` / `specific_type`, `mfr_id` / `prod_type_id` / `product_id`)
- [x] New runtime test pins `Node.zwave_props` passes-through for Z-Wave records and stays `None` for Insteon
- [x] Full suite: `pytest` (810 passed)
- [x] Lint: `ruff check pyisyox tests` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)