### PR TITLE
feat(testing): add program_folders= kwarg to make_load_result

### DIFF
--- a/pyisyox/testing/__init__.py
+++ b/pyisyox/testing/__init__.py
@@ -204,6 +204,29 @@ def make_folder_record(address: str, name: str, *, parent_address: str | None = 
     return FolderRecord(address=address, name=name, parent_address=parent_address)
 
 
+def make_program_folder_record(
+    address: str,
+    name: str,
+    *,
+    parent_address: str | None = None,
+) -> ProgramRecord:
+    """A folder-shaped :class:`ProgramRecord` (``is_folder=True``).
+
+    Program folders live in the same ``programs`` dict as programs
+    themselves — the runtime distinguishes them via ``is_folder``.
+    Use this with :func:`make_load_result`'s ``program_folders=`` kwarg
+    to keep folders mentally separate from programs at the test seam.
+    """
+    return ProgramRecord(
+        address=address,
+        name=name,
+        path=name,
+        parent_address=parent_address,
+        is_folder=True,
+        status=False,
+    )
+
+
 def make_program_record(
     address: str,
     name: str,
@@ -281,6 +304,7 @@ def make_load_result(
     groups: dict[str, GroupRecord] | None = None,
     folders: dict[str, FolderRecord] | None = None,
     programs: dict[str, ProgramRecord] | None = None,
+    program_folders: dict[str, ProgramRecord] | None = None,
     variables: dict[str, dict[str, VariableRecord]] | None = None,
     network_resources: dict[str, NetworkResourceRecord] | None = None,
 ) -> LoadResult:
@@ -292,14 +316,21 @@ def make_load_result(
     introspection (``is_thermostat`` / ``is_lock`` / ``is_dimmable``)
     and editor-codec command validation work the same way they do at
     runtime.
+
+    ``program_folders`` is a convenience overlay onto ``programs`` —
+    program folders live in the same dict at runtime (distinguished by
+    ``ProgramRecord.is_folder``); passing them here keeps the test seam
+    parallel to ``folders=`` for nodes. Use :func:`make_program_folder_record`
+    to build the entries.
     """
+    merged_programs: dict[str, ProgramRecord] = {**(programs or {}), **(program_folders or {})}
     return LoadResult(
         config=ControllerConfig(uuid=uuid, version=version),
         profile=load_profile(),
         nodes=nodes or {},
         groups=groups or {},
         folders=folders or {},
-        programs=programs or {},
+        programs=merged_programs,
         triggers=[],
         variables=variables or {"1": {}, "2": {}},
         network_resources=network_resources or {},
@@ -1322,6 +1353,7 @@ __all__ = [
     "make_profile_with_hub_plugin",
     "make_profile_with_trigger_plugin",
     "make_program",
+    "make_program_folder_record",
     "make_program_record",
     "make_thermostat_binary_records",
     "make_trigger_plugin_load_result",

--- a/pyisyox/testing/__init__.py
+++ b/pyisyox/testing/__init__.py
@@ -208,6 +208,7 @@ def make_program_folder_record(
     address: str,
     name: str,
     *,
+    path: str = "",
     parent_address: str | None = None,
 ) -> ProgramRecord:
     """A folder-shaped :class:`ProgramRecord` (``is_folder=True``).
@@ -216,11 +217,15 @@ def make_program_folder_record(
     themselves — the runtime distinguishes them via ``is_folder``.
     Use this with :func:`make_load_result`'s ``program_folders=`` kwarg
     to keep folders mentally separate from programs at the test seam.
+
+    ``path`` defaults to ``""`` (root-level folder); pass it
+    explicitly with the slash-joined ancestry (excluding the synthetic
+    ``"My Programs"`` root) for nested-folder tests.
     """
     return ProgramRecord(
         address=address,
         name=name,
-        path=name,
+        path=path,
         parent_address=parent_address,
         is_folder=True,
         status=False,

--- a/tests/test_testing/test_builders.py
+++ b/tests/test_testing/test_builders.py
@@ -84,6 +84,7 @@ from pyisyox.testing import (
     make_profile_with_hub_plugin,
     make_profile_with_trigger_plugin,
     make_program,
+    make_program_folder_record,
     make_program_record,
     make_thermostat_binary_records,
     make_trigger_plugin_load_result,
@@ -178,6 +179,23 @@ def test_make_load_result_defaults() -> None:
     assert lr.nodes == {}
     # Variables default seeds both type tables.
     assert set(lr.variables) == {"1", "2"}
+
+
+def test_make_load_result_program_folders_merge_into_programs() -> None:
+    """``program_folders`` is a convenience overlay onto ``programs`` —
+    folders share the runtime ``programs`` dict, distinguished by
+    ``is_folder``. Lets consumer tests keep folders mentally separate
+    at the test seam without reaching into ``controller._loaded``.
+    """
+    program = make_program_record("0010", "Sunset Lights", parent_address="F1")
+    folder = make_program_folder_record("F1", "Lighting")
+    lr = make_load_result(
+        programs={program.address: program},
+        program_folders={folder.address: folder},
+    )
+    assert set(lr.programs) == {"0010", "F1"}
+    assert lr.programs["F1"].is_folder is True
+    assert lr.programs["0010"].is_folder is False
 
 
 def test_make_controller_no_network() -> None:
@@ -468,9 +486,7 @@ def test_make_classified_node_record_lock_family_override_honored() -> None:
     """Caller passing ``family_id="1"`` for a lock target must keep the
     Insteon family — the docstring promises override; the impl had been
     silently clobbering it."""
-    rec = make_classified_node_record(
-        "AA BB CC 1", "L", target="lock", family_id="1"
-    )
+    rec = make_classified_node_record("AA BB CC 1", "L", target="lock", family_id="1")
     assert rec.family_id == "1"
 
 
@@ -560,11 +576,7 @@ def test_make_motion_sensor_records_covers_every_documented_subnode() -> None:
     records = make_motion_sensor_records()
     primary = next(r for r in records.values() if r.pnode == r.address)
     assert primary.type.startswith("16.1.")
-    sub_ids = {
-        int(r.address.split(" ")[-1], 16)
-        for r in records.values()
-        if r.pnode != r.address
-    }
+    sub_ids = {int(r.address.split(" ")[-1], 16) for r in records.values() if r.pnode != r.address}
     assert sub_ids == {
         INSTEON_BSENSOR_SUBNODE_DUSK_DAWN,
         INSTEON_BSENSOR_SUBNODE_LOW_BATTERY,
@@ -579,11 +591,7 @@ def test_make_thermostat_binary_records_has_cool_and_heat_subnodes() -> None:
     records = make_thermostat_binary_records()
     primary = next(r for r in records.values() if r.pnode == r.address)
     assert primary.type.startswith("5.16.")
-    sub_ids = {
-        int(r.address.split(" ")[-1], 16)
-        for r in records.values()
-        if r.pnode != r.address
-    }
+    sub_ids = {int(r.address.split(" ")[-1], 16) for r in records.values() if r.pnode != r.address}
     assert sub_ids == {
         INSTEON_THERMOSTAT_SUBNODE_COOL,
         INSTEON_THERMOSTAT_SUBNODE_HEAT,
@@ -601,9 +609,5 @@ def test_make_insteon_binary_sensor_records_combines_all_families() -> None:
     )
     assert len(combined) == expected_size
     # Address space distinct across families — no key collisions.
-    primary_types = {
-        r.type
-        for r in combined.values()
-        if r.pnode == r.address
-    }
+    primary_types = {r.type for r in combined.values() if r.pnode == r.address}
     assert {"16.8.1.0", "16.9.1.0", "16.1.1.0", "5.16.0.0"} <= primary_types


### PR DESCRIPTION
## Summary

- Adds a `program_folders=` overlay parameter to `pyisyox.testing.make_load_result`
- Adds a `make_program_folder_record(address, name, *, parent_address=None)` shortcut analogous to `make_folder_record`
- Consumer tests no longer have to reach into `controller._loaded.programs` to inject folder-shaped `ProgramRecord` instances by hand

## Why

Program folders live in the same runtime `programs` dict as programs themselves (distinguished via `ProgramRecord.is_folder`), so the existing `programs=` kwarg was technically sufficient — but consumers writing folder-derived behaviour tests ended up doing this:

```python
controller._loaded.programs[folder.address] = ProgramRecord(
    address=folder.address, name=folder.name, path="Lighting",
    parent_address=None, is_folder=True, status=False,
)
```

Awkward and protected-access-violating. With `program_folders=`, the same test simplifies to one constructor call — the kwarg's entries are merged into `programs` before the `LoadResult` is built, keeping folders mentally separate at the test seam (parallel to `folders=` for nodes).

```python
controller = make_controller(
    make_load_result(
        programs={program.address: program},
        program_folders={
            "ROOT": make_program_folder_record("ROOT", "My Programs"),
            "F1": make_program_folder_record("F1", "Lighting", parent_address="ROOT"),
        },
    )
)
```

Closes #153.

## Test plan

- [x] New test pins the merge behaviour (programs + program_folders → single dict, `is_folder` retained)
- [x] hacs-udi-iox `test_program_device.py` migrated to the new kwarg in a follow-up PR — workaround removed
- [x] Full suite: `pytest` (810 passed)
- [x] Lint: `ruff check pyisyox tests` (clean)

Generated with Claude Code
