### PR TITLE
fix(client): tolerate malformed /rest/networking XML (#156)

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -1368,6 +1369,24 @@ def parse_zwave_nodedefs(xml: str, *, family_id: str, instance_id: str) -> dict[
     return out
 
 
+#: A ``&`` that is *not* already the start of a valid XML entity
+#: reference (``&amp;`` / ``&lt;`` / ``&#123;`` / ``&#xAF;`` …). eisy
+#: firmware does not entity-encode ``&`` in network-resource URLs or
+#: bodies in its ``/rest/networking`` output, so a resource whose URL
+#: carries a query string (``?a=1&b=2``) makes the whole document
+#: not well-formed — see issue #156.
+_BARE_AMPERSAND_RE = re.compile(r"&(?!#?\w+;)")
+
+
+def _repair_networking_xml(xml: str) -> str:
+    """Best-effort repair of the most common ``/rest/networking``
+    malformation: an unescaped ``&`` inside a resource URL or body
+    (issue #156). Other malformations (bare ``<`` / ``>``, control
+    characters) are deliberately left alone — the caller degrades to
+    an empty resource map for anything this can't safely fix."""
+    return _BARE_AMPERSAND_RE.sub("&amp;", xml)
+
+
 def parse_rest_networking_resources(xml: str) -> dict[str, NetworkResourceRecord]:
     """Decode ``/rest/networking/resources`` XML into a record map.
 
@@ -1384,16 +1403,36 @@ def parse_rest_networking_resources(xml: str) -> dict[str, NetworkResourceRecord
         </NetConfig>
 
     Empty / missing input (controller without networking module
-    enabled) returns ``{}``. Malformed XML raises
-    :class:`ClientError` so initial-load callers can decide whether
-    to abort or treat as "no resources".
+    enabled) returns ``{}``.
+
+    Network resources are an optional, non-critical part of the tree,
+    so a malformed document never aborts the controller load (issue
+    #156). The common eisy firmware bug — an unescaped ``&`` in a
+    resource URL/body — is repaired best-effort and the resources are
+    recovered (logged at WARNING). Anything that still cannot be
+    parsed degrades to ``{}`` (logged at ERROR); the rest of the
+    controller is unaffected.
     """
     if not xml:
         return {}
     try:
         root = ET.fromstring(xml)  # noqa: S314 — eisy LAN traffic
-    except ET.ParseError as exc:
-        raise ClientError(f"failed to parse /rest/networking XML: {exc}") from exc
+    except ET.ParseError:
+        try:
+            root = ET.fromstring(_repair_networking_xml(xml))  # noqa: S314
+        except ET.ParseError as exc:
+            _LOGGER.error(  # noqa: TRY400 — expected firmware malformation, not a bug; traceback is noise
+                "Could not parse /rest/networking XML even after "
+                "ampersand repair; network resources will be "
+                "unavailable (the controller is otherwise usable): %s",
+                exc,
+            )
+            return {}
+        _LOGGER.warning(
+            "Repaired malformed /rest/networking XML (unescaped '&' in "
+            "a network resource — likely an eisy firmware encoding "
+            "bug); network resources recovered"
+        )
 
     resources: dict[str, NetworkResourceRecord] = {}
     for rule_el in root.findall("NetRule"):

--- a/tests/test_client/test_parsers.py
+++ b/tests/test_client/test_parsers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -503,9 +504,38 @@ def test_parse_rest_networking_resources_skips_rules_without_id() -> None:
     assert list(records) == ["5"]
 
 
-def test_parse_rest_networking_resources_raises_on_malformed_xml() -> None:
-    with pytest.raises(ClientError):
-        parse_rest_networking_resources("<not really xml")
+def test_parse_rest_networking_resources_repairs_unescaped_ampersand(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """eisy firmware emits raw ``&`` in network-resource URLs, making
+    ``/rest/networking`` not well-formed. The parser repairs bare
+    ampersands and recovers the resources rather than aborting the
+    controller load (issue #156)."""
+    xml = (
+        '<?xml version="1.0"?>'
+        "<NetConfig>"
+        "<NetRule><id>1</id><name>Webhook</name>"
+        "<url>http://host/api?a=1&b=2&c=3</url></NetRule>"
+        "<NetRule><id>2</id><name>Plain &amp; Fine</name></NetRule>"
+        "</NetConfig>"
+    )
+    with caplog.at_level(logging.WARNING):
+        records = parse_rest_networking_resources(xml)
+    assert list(records) == ["1", "2"]
+    # Pre-existing valid entities are untouched by the repair.
+    assert records["2"].name == "Plain & Fine"
+    assert "Repaired malformed /rest/networking XML" in caplog.text
+
+
+def test_parse_rest_networking_resources_unrepairable_degrades_to_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A malformation the ampersand repair can't fix (here, an
+    unclosed tag) must not abort the controller load — it degrades to
+    ``{}`` with an error log (issue #156)."""
+    with caplog.at_level(logging.ERROR):
+        assert parse_rest_networking_resources("<not really xml") == {}
+    assert "network resources will be unavailable" in caplog.text
 
 
 # --- /api/programs JSON --------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #156. A user's eisy could not be added because `/rest/networking` returned malformed XML (`not well-formed (invalid token): line 1, column 11670`), and `parse_rest_networking_resources` raised, aborting the **entire** controller load.

Network resources are an optional, non-critical part of the tree. `load()` already routes the fetch through `_get_text_or_empty` so a 404 doesn't abort load — but a *parse* failure of the same optional document was still fatal. That inconsistency is the bug: one bad network resource should not lock a user out of an otherwise-usable controller.

Two layers:

- **Salvage** — eisy firmware does not entity-encode `&` in network-resource URLs/bodies, so a resource whose URL carries a query string (`?a=1&b=2`) makes the whole document not well-formed (the likely cause of column 11670, deep in a single-line doc). Bare ampersands are repaired best-effort and the resources are **recovered** (logged WARNING). Pre-existing valid entities (`&amp;` etc.) are left untouched.
- **Resilience** — anything the repair can't fix (bare `<`/`>`, control chars) degrades to `{}` (logged ERROR) instead of raising. The rest of the controller loads normally.

The upstream firmware bug (eisy not escaping `&`) is not fixable on the wire; this makes pyisyox resilient to it and recovers the data in the common case.

## Test plan

- [x] `test_parse_rest_networking_resources_repairs_unescaped_ampersand` — bare `&` in a resource URL is repaired, both resources recovered, WARNING logged, valid entities untouched
- [x] `test_parse_rest_networking_resources_unrepairable_degrades_to_empty` — unparseable input → `{}` + ERROR log, no exception
- [x] Full suite green (811 passed); ruff / ruff format / mypy / pylint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)