### PR TITLE
fix(classifier): require parameterized DON for LIGHT/dimmable (#64 prong 2)

### DIFF
--- a/pyisyox/classifier.py
+++ b/pyisyox/classifier.py
@@ -202,13 +202,25 @@ EditorResolver = Callable[[str], Editor | None]
 
 
 def _detect_controllable(
-    accept_ids: frozenset[str], properties: dict[str, NodeProperty]
+    accept_ids: frozenset[str],
+    properties: dict[str, NodeProperty],
+    on_takes_level: bool,
 ) -> tuple[ControllablePlatform | None, frozenset[str]]:
     """Pick the single controllable platform plus the commands that belong to it.
 
     Order matters: thermostat is checked before light/switch because the
     Insteon Thermostat nodedef accepts ``BRT``/``DIM`` (interpreted as
     setpoint up/down on a thermostat, not as a light dimmer).
+
+    ``on_takes_level`` is True when the accepted ``DON`` declares at
+    least one parameter (the on-level). A node is only a *dimmer* —
+    LIGHT rather than SWITCH — if it can actually be commanded to a
+    level via ``DON``. Some node-server nodedefs (and the legacy
+    ``X10`` nodedef) carry on-level properties or ``BRT``/``DIM`` hints
+    but a *parameterless* ``DON``; HA's light platform drives
+    brightness with ``DON <level>``, so without the param the slider
+    just fails. Those degrade to SWITCH (their level-set verbs still
+    surface as ``parameterized_commands`` / ``buttons``).
     """
     has_dim_or_switch = CMD_ON in accept_ids and CMD_OFF in accept_ids
     has_thermostat_setpoint = PROP_SETPOINT_COOL in accept_ids or PROP_SETPOINT_HEAT in accept_ids
@@ -226,7 +238,7 @@ def _detect_controllable(
     if has_cover_only:
         return ControllablePlatform.COVER, _COVER_CMDS & accept_ids
     if has_dim_or_switch:
-        is_dimmer = has_on_level or bool(_LIGHT_DIMMER_HINTS & accept_ids)
+        is_dimmer = (has_on_level or bool(_LIGHT_DIMMER_HINTS & accept_ids)) and on_takes_level
         platform = ControllablePlatform.LIGHT if is_dimmer else ControllablePlatform.SWITCH
         return platform, _LIGHT_SWITCH_CMDS & accept_ids
     return None, frozenset()
@@ -295,7 +307,9 @@ def classify(nodedef: NodeDef, find_editor: EditorResolver | None = None) -> Cla
         buttons / parameterized_commands / readings populated.
     """
     accept_ids = frozenset(c.id for c in nodedef.cmds.accepts)
-    controllable, controllable_cmd_ids = _detect_controllable(accept_ids, nodedef.properties)
+    on_cmd = next((c for c in nodedef.cmds.accepts if c.id == CMD_ON), None)
+    on_takes_level = on_cmd is not None and len(on_cmd.parameters) > 0
+    controllable, controllable_cmd_ids = _detect_controllable(accept_ids, nodedef.properties, on_takes_level)
 
     triggers = list(nodedef.cmds.sends)
 

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -282,9 +282,10 @@ class Node:
 
     @property
     def is_dimmable(self) -> bool:
-        """True if the node has a multilevel ``ST`` state **and** accepts ``DON``.
+        """True if the node has a multilevel ``ST`` state **and** accepts
+        a *parameterized* ``DON``.
 
-        Two conditions must both hold for a real dimmer:
+        Three conditions must all hold for a real dimmer:
 
         1. ``ST`` editor reports a multilevel range (not a binary
            ``{0, 100}`` subset). Relay nodedefs accept ``DON`` with an
@@ -299,10 +300,19 @@ class Node:
            ``is_dimmable`` returns True for them and consumers route
            them onto the LIGHT platform where DON-based turn_on
            silently fails.
+        3. The accepted ``DON`` declares at least one parameter (the
+           on-level). HA's light platform sets brightness with
+           ``DON <level>``; a parameterless ``DON`` cannot take one, so
+           the node is on/off-only even with a multilevel ``ST`` (some
+           node-server nodedefs set level via a separate ``SETST`` /
+           ``SETOL`` command instead — issue #64 / Virtual#11). Real
+           Insteon/Z-Wave dimmers declare ``DON`` with an optional
+           on-level param, so they still qualify.
         """
         if self._nodedef is None:
             return False
-        if not self._has_command(CMD_ON):
+        on_cmd = next((c for c in self._nodedef.cmds.accepts if c.id == CMD_ON), None)
+        if on_cmd is None or not on_cmd.parameters:
             return False
         st_prop = self._nodedef.properties.get(PROP_STATUS)
         if st_prop is None or st_prop.editor_id is None:

--- a/tests/test_runtime/test_node_introspection.py
+++ b/tests/test_runtime/test_node_introspection.py
@@ -21,6 +21,8 @@ from pyisyox.client import IoXClient, NodePropertyValue, NodeRecord, ZWaveProper
 from pyisyox.constants import NodeFlag, Protocol
 from pyisyox.runtime import Node
 from pyisyox.schema import Profile
+from pyisyox.schema.cmd import Command, CommandParameter
+from pyisyox.schema.nodedef import NodeCommands, NodeDef, NodeProperty
 from tests.test_client.conftest import FakeSession
 
 FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "eisy6"
@@ -411,6 +413,53 @@ def test_is_dimmable_false_when_nodedef_does_not_accept_don(real_profile: Profil
     break (this is the user-reported RemoteLinc2 / IMETER bug)."""
     node = _make_node(_make_record(nodedef_id=nodedef_id), real_profile)
     assert node.is_dimmable is False
+
+
+def _multilevel_st_nodedef(*, don_param: bool) -> NodeDef:
+    """Synthetic nodedef with a genuinely multilevel ``ST`` (encoded
+    UOM-51 0-100 editor, resolves scope-free) and a ``DON`` that does or
+    doesn't declare the on-level param. The ``virtualgeneric`` shape
+    (issue #64 / Virtual#11): multilevel ST alone used to be enough to
+    call this dimmable; it must now also require a parameterized DON."""
+    enc = "_51_0_R_0_101_N_IX_DIM_REP"  # multilevel: uom 51, min 0, max 101
+    don = Command(id="DON", name="On")
+    if don_param:
+        don = Command(
+            id="DON",
+            name="On",
+            parameters=[CommandParameter(editor_id=enc, init="ST", optional=True)],
+        )
+    return NodeDef(
+        id="virtualgeneric",
+        family_id="10",
+        instance_id="4",
+        properties={"ST": NodeProperty(id="ST", editor_id=enc)},
+        cmds=NodeCommands(accepts=[don, Command(id="DOF", name="Off")]),
+    )
+
+
+def test_is_dimmable_false_for_multilevel_st_with_parameterless_don(
+    real_profile: Profile,
+) -> None:
+    """The Virtual#11 regression: a multilevel ``ST`` editor used to be
+    sufficient for ``is_dimmable`` even when ``DON`` takes no level
+    param. HA's light platform sets brightness via ``DON <level>``, so
+    such a node is on/off-only — ``is_dimmable`` must return False (the
+    consumer then routes it to SWITCH, level via the SETST/SETOL aux)."""
+    node = _make_node(_make_record(nodedef_id="virtualgeneric"), real_profile)
+    node._nodedef = _multilevel_st_nodedef(don_param=False)  # type: ignore[assignment]
+    assert node.is_dimmable is False
+
+
+def test_is_dimmable_true_for_multilevel_st_with_parameterized_don(
+    real_profile: Profile,
+) -> None:
+    """Pivot: identical multilevel-``ST`` node, but ``DON`` now declares
+    the on-level param → genuinely HA-dimmable → True. Confirms the new
+    guard keys solely on DON parameterization, not the ST editor."""
+    node = _make_node(_make_record(nodedef_id="virtualgeneric"), real_profile)
+    node._nodedef = _multilevel_st_nodedef(don_param=True)  # type: ignore[assignment]
+    assert node.is_dimmable is True
 
 
 # --- ergonomic wrappers: end-to-end via real fixture nodedefs ------------

--- a/tests/test_schema/test_classifier.py
+++ b/tests/test_schema/test_classifier.py
@@ -113,6 +113,71 @@ def test_insteon_dimmer_is_light_with_filtered_state(profile: Profile) -> None:
     assert "RR" not in reading_ids
 
 
+def _virtualgeneric_nodedef(*, don_param: bool) -> NodeDef:
+    """The Virtual node-server ``virtualgeneric`` shape (issue #64 /
+    UniversalDevicesInc-PG3/Virtual#11): multilevel ``ST``/``OL``, the
+    dimmer hint verbs ``BRT``/``DIM``, level set via ``SETST``/``SETOL``
+    — and a ``DON`` that takes no level parameter. ``don_param`` flips
+    only whether ``DON`` declares the on-level (the pivotal signal)."""
+    don = Command(id="DON", name="On")
+    if don_param:
+        don = Command(
+            id="DON",
+            name="On",
+            parameters=[CommandParameter(editor_id="value", init="ST", optional=True)],
+        )
+    return NodeDef(
+        id="virtualgeneric",
+        family_id="10",
+        instance_id="4",
+        properties={
+            "ST": NodeProperty(id="ST", editor_id="value"),
+            "OL": NodeProperty(id="OL", editor_id="value"),
+        },
+        cmds=NodeCommands(
+            accepts=[
+                don,
+                Command(id="DOF", name="Off"),
+                Command(id="BRT", name="Brighten"),
+                Command(id="DIM", name="Dim"),
+                Command(
+                    id="SETST",
+                    name="Set Status",
+                    parameters=[CommandParameter(editor_id="value", init="ST")],
+                ),
+                Command(
+                    id="SETOL",
+                    name="Set On Level",
+                    parameters=[CommandParameter(editor_id="value", init="OL")],
+                ),
+            ]
+        ),
+    )
+
+
+def test_parameterless_don_classifies_as_switch_not_light() -> None:
+    """``virtualgeneric`` has an ``OL`` property and ``BRT``/``DIM`` hints
+    (both would say "dimmer") but a *parameterless* ``DON`` — HA drives
+    brightness with ``DON <level>``, so it can't actually be dimmed via
+    the light platform. It must degrade to SWITCH, with the level-set
+    commands still surfaced for the consumer (issue #64 / Virtual#11)."""
+    res = classify(_virtualgeneric_nodedef(don_param=False))
+    assert res.controllable is ControllablePlatform.SWITCH
+    assert res.controllable_command_ids == frozenset({"DON", "DOF"})
+    param_ids = {c.id for c in res.parameterized_commands}
+    assert {"SETST", "SETOL"} <= param_ids
+    assert {"BRT", "DIM"} <= {c.id for c in res.buttons}
+
+
+def test_parameterized_don_same_shape_stays_light() -> None:
+    """Pivot test: the *only* difference from the SWITCH case above is
+    that ``DON`` declares the on-level param — that alone makes it a
+    real, HA-drivable dimmer → LIGHT."""
+    res = classify(_virtualgeneric_nodedef(don_param=True))
+    assert res.controllable is ControllablePlatform.LIGHT
+    assert res.controllable_command_ids == frozenset({"DON", "DOF"})
+
+
 def test_insteon_oncontrol_is_pure_trigger_source(profile: Profile) -> None:
     """OnOffControl accepts nothing, sends DON/DOF — a paddle/remote, not a controllable."""
     res = _result_for(profile, "OnOffControl", "1", "1")


### PR DESCRIPTION
## Summary

Prong 2 of shbatm/hacs-udi-iox#64 (root cause UniversalDevicesInc-PG3/Virtual#11).

`classify()`'s controllable detection and `Node.is_dimmable` concluded "dimmer" from an `OL` property / `BRT`-`DIM` hints / multilevel `ST` **+ accepts `DON`** — without checking that `DON` declares an on-level parameter. HA's light platform sets brightness with `DON <level>`; a parameterless `DON` can't take one, so the node is on/off-only even with a multilevel `ST`. The Virtual node-server `virtualgeneric` hit this: classified `LIGHT`, brightness slider then raised `command 'DON' accepts 0 parameter(s); got 1`.

Both paths now require the accepted `DON` to declare ≥1 parameter before `LIGHT`/dimmable.

## Regression audit (blanket rule, not node-server-scoped)

Swept all 80 bundled-profile nodedefs that accept `DON`&`DOF`:

- **`is_dimmable`: 0 regressions.** No bundled nodedef is `is_dimmable=True` with a parameterless `DON`.
- **All 10+ real Insteon/Z-Wave dimmers** (`DimmerLampSwitch`, `KeypadDimmer`, `InsteonDimmer`, …) declare `DON` with an optional on-level param → **stay LIGHT**.
- **Relays** pair binary `ST` + parameterless `DON` → already excluded by the binary-`ST` gate, unaffected.
- **One native flip: `X10`** (parameterless `DON` + binary `ST` + `BRT`/`DIM` hints). Its brightness slider was already non-functional (binary ST, no settable level); `SWITCH` + `BRT`/`DIM` buttons is a correctness improvement, not a regression. The issue's "downgrade to node-server-only if a real *multilevel* dimmer flips" trigger is **not met** (X10 is a binary relay, not a multilevel dimmer), so the blanket rule stands. Decision confirmed with the maintainer.

`virtualgeneric` now classifies `SWITCH`; its `SETST`/`SETOL` level setters still surface as `parameterized_commands` for the consumer (relevant to the #64 prong-1 rework).

## Test plan

- [x] `test_parameterless_don_classifies_as_switch_not_light` / `test_parameterized_don_same_shape_stays_light` — synthetic real `virtualgeneric` shape; DON param is the sole pivot SWITCH↔LIGHT
- [x] `test_is_dimmable_false_for_multilevel_st_with_parameterless_don` / `..._true_..._parameterized_don` — multilevel ST held constant, DON param pivots `is_dimmable`
- [x] Existing `test_insteon_dimmer_is_light_with_filtered_state` etc. unchanged (parameterized-DON dimmers stay LIGHT)
- [x] Full suite green: **815 passed**; ruff / ruff format / mypy / pylint clean (pre-commit)

## Release

Should ship as **`6.0.0b5`** (version is `setuptools_scm` tag-derived). hacs-udi-iox then bumps its pin to `6.0.0b5` and the #64 prong-1 rework lands against the corrected classifier. Tag is the maintainer's to cut on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)