### PR TITLE
feat(classify): emit coalesced aux_controls (#160)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,12 @@ linkdefs, UOMs.
 `classify(nodedef, ...)` → `ClassificationResult` — a nodedef →
 HA-platform fallback classification (`ControllablePlatform` /
 `ReadingPlatform` / `Reading`). Used when a node's nodedef doesn't map
-to a more specific handler.
+to a more specific handler. `ClassificationResult.aux_controls`
+(`AuxControl` / `AuxPlatform`) is the unified read/write-coalesced view
+that supersedes the `readings` / `parameterized_commands` / `buttons`
+split — paired via a command parameter's `init` (the `<st>` it syncs
+with; not naive id matching). The three legacy buckets stay populated
+unchanged; new consumers prefer `aux_controls` (issue #160 / hacs#67).
 
 ### `constants.py`
 

--- a/pyisyox/__init__.py
+++ b/pyisyox/__init__.py
@@ -31,6 +31,8 @@ from importlib.metadata import PackageNotFoundError, version
 
 from pyisyox.auth import Auth, AuthError, LocalAuth, PortalAuth
 from pyisyox.classifier import (
+    AuxControl,
+    AuxPlatform,
     ClassificationResult,
     ControllablePlatform,
     Reading,
@@ -114,6 +116,8 @@ __all__ = [
     "NODE_LIFECYCLE_EVENT_INFO_TAGS",
     "Auth",
     "AuthError",
+    "AuxControl",
+    "AuxPlatform",
     "ClassificationResult",
     "ClientError",
     "ControllablePlatform",

--- a/pyisyox/classifier.py
+++ b/pyisyox/classifier.py
@@ -36,8 +36,14 @@ contributions, not a single platform pick:
 * ``readings`` — one entity per property, after filtering out properties
   already represented by the controllable platform (e.g., ``ST``/``OL``/
   ``RR`` on a light are the light's state, not separate sensors).
+* ``aux_controls`` — the unified successor to the
+  ``readings`` / ``parameterized_commands`` / ``buttons`` split: one
+  :class:`AuxControl` per logical control, with a status and its
+  ``init``-linked write command folded together (read/write coalesced).
+  New consumers should prefer this; the three legacy buckets stay
+  populated unchanged for now.
 
-One HA *device* per node aggregates entities from all five buckets.
+One HA *device* per node aggregates entities from these buckets.
 """
 
 from __future__ import annotations
@@ -71,8 +77,10 @@ from pyisyox.constants import (
     PROP_STATUS,
     PROP_TEMPERATURE,
     UOM_BOOLEAN,
+    UOM_INDEX,
     UOM_ON_OFF,
     UOM_OPEN_CLOSED,
+    UOM_PERCENTAGE,
 )
 from pyisyox.schema.cmd import Command
 from pyisyox.schema.editor import Editor
@@ -114,6 +122,64 @@ class Reading:
     is_enum: bool = False
 
 
+class AuxPlatform(StrEnum):
+    """Candidate HA platform for one coalesced aux control.
+
+    A *candidate* — the consumer keeps final say (type-tier-1,
+    bespoke/service routing, HA-device grouping sit on top).
+    """
+
+    SENSOR = "sensor"
+    BINARY_SENSOR = "binary_sensor"
+    NUMBER = "number"
+    SELECT = "select"
+    SWITCH = "switch"
+    BUTTON = "button"
+
+
+@dataclass(slots=True)
+class AuxControl:
+    """One logical aux control = a read status and/or a write command,
+    coalesced.
+
+    The IoX nodedef expresses the read/write pairing via a command
+    parameter's ``init`` (the id of the ``<st>`` status it is
+    "initialized and synchronized with" — e.g. a heat-setpoint
+    command's param ``init="CLISPH"``; an Insteon i3 flags sub-node's
+    ``GV0`` param ``init="ST"`` ⇄ the ``ST`` "Mode" status). This is
+    the authoritative pairing key — **not** naive id matching: the cmd
+    id and the status id can differ (i3 ``GV0`` ⇄ ``ST``).
+
+    Controllable-owned ids and ``QUERY`` are already excluded (the
+    controllable platform represents those). ``ST`` is *not* special
+    here: it is removed only when a controllable platform owns it;
+    otherwise it is an ordinary coalescable status.
+
+    Attributes:
+        id: The control id (the status id when read/write paired, else
+            the command id, else the property id).
+        readable: A backing status property exists (readback source).
+        writable: An accept command drives it.
+        candidate_platform: Editor-shape-derived HA platform candidate,
+            or ``None`` when no editor resolves (consumer falls back).
+        property: The backing :class:`NodeProperty`, if readable.
+        command: The driving :class:`Command`, if writable.
+        editor_id: The editor governing the control — the write
+            command's parameter editor when writable (the write
+            affordance is authoritative), else the property editor.
+        is_enum: The governing editor carries an enum ``names`` map.
+    """
+
+    id: str
+    readable: bool
+    writable: bool
+    candidate_platform: AuxPlatform | None = None
+    property: NodeProperty | None = None
+    command: Command | None = None
+    editor_id: str | None = None
+    is_enum: bool = False
+
+
 @dataclass(slots=True)
 class ClassificationResult:
     """The set of HA platform contributions for one nodedef.
@@ -134,6 +200,13 @@ class ClassificationResult:
             parameter editors to input entities. Same QUERY / controllable
             exclusions as ``buttons``.
         readings: Per-property reading entities.
+        aux_controls: Coalesced read/write controls — the unified view
+            that supersedes the separate ``readings`` /
+            ``parameterized_commands`` / ``buttons`` split: each is one
+            logical control (status + its ``init``-linked writer folded
+            together). ``readings`` / ``parameterized_commands`` /
+            ``buttons`` are retained unchanged for now; new consumers
+            should prefer ``aux_controls``.
     """
 
     controllable: ControllablePlatform | None = None
@@ -142,6 +215,7 @@ class ClassificationResult:
     buttons: list[Command] = field(default_factory=list)
     parameterized_commands: list[Command] = field(default_factory=list)
     readings: list[Reading] = field(default_factory=list)
+    aux_controls: list[AuxControl] = field(default_factory=list)
 
 
 #: ``QUERY`` is implicitly accepted by every node — never a "button".
@@ -196,6 +270,15 @@ _ALARM_STATE_PROPS = frozenset({PROP_STATUS})
 #: where Open=0, Closed=100") are also two-state in practice and
 #: belong here even though their value range is wider than 0/1.
 _BINARY_UOMS = frozenset({UOM_BOOLEAN, UOM_ON_OFF, UOM_OPEN_CLOSED})
+#: Always-numeric UOMs: percent (0-100) and the 8-bit byte range
+#: (0-255). NUMBER even when the profile spells the span as a wide
+#: ``subset`` rather than ``min``/``max``.
+_NUMERIC_UOMS = frozenset({UOM_PERCENTAGE, "100"})
+#: Generic editor ids that name a value *shape* regardless of UOM (PG3
+#: plugin nodedefs lean on these; firmware nodedefs carry ``I_*`` /
+#: ``ZW_*`` ids whose shape is read off the range instead).
+_NUMERIC_EDITOR_IDS = frozenset({"INTEGER", "FLOAT"})
+_BOOL_EDITOR_IDS = frozenset({"BOOL", "bool", "I_BOOL"})
 
 
 EditorResolver = Callable[[str], Editor | None]
@@ -244,24 +327,27 @@ def _detect_controllable(
     return None, frozenset()
 
 
+def _controllable_owned_prop_ids(controllable: ControllablePlatform | None) -> frozenset[str]:
+    """Property ids the controllable platform represents itself (so they
+    don't surface as separate readings / aux controls)."""
+    if controllable in (ControllablePlatform.LIGHT, ControllablePlatform.SWITCH):
+        return _LIGHT_STATE_PROPS
+    if controllable is ControllablePlatform.CLIMATE:
+        return _THERMOSTAT_STATE_PROPS
+    if controllable is ControllablePlatform.LOCK:
+        return _LOCK_STATE_PROPS
+    if controllable is ControllablePlatform.COVER:
+        return _COVER_STATE_PROPS
+    if controllable is ControllablePlatform.ALARM_CONTROL_PANEL:
+        return _ALARM_STATE_PROPS
+    return frozenset()
+
+
 def _filter_state_properties(
     controllable: ControllablePlatform | None, properties: dict[str, NodeProperty]
 ) -> list[NodeProperty]:
     """Drop properties already represented by the controllable platform."""
-    if controllable is None:
-        return list(properties.values())
-    if controllable in (ControllablePlatform.LIGHT, ControllablePlatform.SWITCH):
-        skip = _LIGHT_STATE_PROPS
-    elif controllable is ControllablePlatform.CLIMATE:
-        skip = _THERMOSTAT_STATE_PROPS
-    elif controllable is ControllablePlatform.LOCK:
-        skip = _LOCK_STATE_PROPS
-    elif controllable is ControllablePlatform.COVER:
-        skip = _COVER_STATE_PROPS
-    elif controllable is ControllablePlatform.ALARM_CONTROL_PANEL:
-        skip = _ALARM_STATE_PROPS
-    else:
-        skip = frozenset()
+    skip = _controllable_owned_prop_ids(controllable)
     return [p for p in properties.values() if p.id not in skip]
 
 
@@ -289,6 +375,133 @@ def _classify_property(prop: NodeProperty, find_editor: EditorResolver | None) -
     return Reading(property=prop, platform=platform, is_enum=is_enum)
 
 
+def _aux_write_platform(editor: Editor | None) -> AuxPlatform | None:
+    """Editor shape → candidate platform for a *writable* aux control.
+
+    Layered, cheapest signal first (mirrors the consumer's historical
+    ``platform_for_control``): generic numeric/bool editor id; then
+    binary / always-numeric / index UOM; then range shape (``names`` or
+    a bare ``subset`` with no numeric bounds → a discrete choice;
+    ``min``/``max`` → a scalar). ``None`` when nothing resolves — the
+    consumer falls back.
+    """
+    if editor is None or not editor.ranges:
+        return None
+    if editor.id in _NUMERIC_EDITOR_IDS:
+        return AuxPlatform.NUMBER
+    if editor.id in _BOOL_EDITOR_IDS:
+        return AuxPlatform.SWITCH
+    rng = editor.ranges[0]
+    if rng.uom in _BINARY_UOMS:
+        return AuxPlatform.SWITCH
+    if rng.uom in _NUMERIC_UOMS:
+        return AuxPlatform.NUMBER
+    if rng.uom == UOM_INDEX:
+        return AuxPlatform.SELECT
+    has_bounds = rng.min is not None or rng.max is not None
+    if rng.names and not has_bounds:
+        return AuxPlatform.SELECT
+    if rng.subset and not rng.names and not has_bounds:
+        return AuxPlatform.SELECT
+    if has_bounds:
+        return AuxPlatform.NUMBER
+    return None
+
+
+def _aux_from_command(
+    cmd: Command, props: dict[str, NodeProperty], find_editor: EditorResolver | None
+) -> AuxControl:
+    """Build the aux control for one (non-controllable, non-QUERY)
+    accept command.
+
+    Button-shaped (sendable with no positional args) → a fire BUTTON.
+    Otherwise the parameter's ``init`` names the ``<st>`` it is
+    "initialized and synchronized with" — pair with that status (read +
+    write) when it exists, else a write-only control keyed by command
+    id. Pairing is by ``init``, **not** id matching: the command id and
+    status id can differ (Insteon i3 ``GV0`` ``init="ST"`` ⇄ ``ST``).
+    """
+    params = cmd.parameters
+    if all(p.optional for p in params):
+        return AuxControl(
+            id=cmd.id,
+            readable=False,
+            writable=True,
+            candidate_platform=AuxPlatform.BUTTON,
+            command=cmd,
+            editor_id=(params[0].editor_id or None) if params else None,
+        )
+    init_param = next((p for p in params if p.init), params[0])
+    editor_id = init_param.editor_id or None
+    editor = find_editor(editor_id) if (find_editor and editor_id) else None
+    candidate = _aux_write_platform(editor)
+    is_enum = bool(editor and editor.ranges and editor.ranges[0].names)
+    status_id = init_param.init
+    if status_id and status_id in props:
+        return AuxControl(
+            id=status_id,
+            readable=True,
+            writable=True,
+            candidate_platform=candidate,
+            property=props[status_id],
+            command=cmd,
+            editor_id=editor_id,
+            is_enum=is_enum,
+        )
+    return AuxControl(
+        id=cmd.id,
+        readable=False,
+        writable=True,
+        candidate_platform=candidate,
+        command=cmd,
+        editor_id=editor_id,
+        is_enum=is_enum,
+    )
+
+
+def _build_aux_controls(
+    nodedef: NodeDef,
+    controllable: ControllablePlatform | None,
+    controllable_cmd_ids: frozenset[str],
+    find_editor: EditorResolver | None,
+) -> list[AuxControl]:
+    """Coalesce non-controllable status/command pairs into one control
+    each: writable controls first (in ``accepts`` order), then the
+    remaining read-only properties. Controllable-owned ids and ``QUERY``
+    are already excluded; a paired writer still reads its status back
+    even when the property is controllable-filtered from standalone
+    readings (e.g. a light's ``OL`` setter)."""
+    props = nodedef.properties
+    cmd_controls = [
+        _aux_from_command(cmd, props, find_editor)
+        for cmd in nodedef.cmds.accepts
+        if cmd.id not in _QUERY_CMDS and cmd.id not in controllable_cmd_ids
+    ]
+    consumed = {c.property.id for c in cmd_controls if c.property is not None}
+
+    read_controls: list[AuxControl] = []
+    for prop in _filter_state_properties(controllable, props):
+        if prop.id in consumed:
+            continue
+        reading = _classify_property(prop, find_editor)
+        read_controls.append(
+            AuxControl(
+                id=prop.id,
+                readable=True,
+                writable=False,
+                candidate_platform=(
+                    AuxPlatform.BINARY_SENSOR
+                    if reading.platform is ReadingPlatform.BINARY_SENSOR
+                    else AuxPlatform.SENSOR
+                ),
+                property=prop,
+                editor_id=prop.editor_id or None,
+                is_enum=reading.is_enum,
+            )
+        )
+    return cmd_controls + read_controls
+
+
 def classify(nodedef: NodeDef, find_editor: EditorResolver | None = None) -> ClassificationResult:
     """Classify a nodedef into HA platform contributions.
 
@@ -304,7 +517,10 @@ def classify(nodedef: NodeDef, find_editor: EditorResolver | None = None) -> Cla
 
     Returns:
         A :class:`ClassificationResult` with controllable / triggers /
-        buttons / parameterized_commands / readings populated.
+        buttons / parameterized_commands / readings / aux_controls
+        populated. ``find_editor`` also drives ``aux_controls``
+        candidate platforms; without it writable controls fall back to
+        ``candidate_platform=None`` for the consumer to resolve.
     """
     accept_ids = frozenset(c.id for c in nodedef.cmds.accepts)
     on_cmd = next((c for c in nodedef.cmds.accepts if c.id == CMD_ON), None)
@@ -328,6 +544,8 @@ def classify(nodedef: NodeDef, find_editor: EditorResolver | None = None) -> Cla
         for prop in _filter_state_properties(controllable, nodedef.properties)
     ]
 
+    aux_controls = _build_aux_controls(nodedef, controllable, controllable_cmd_ids, find_editor)
+
     return ClassificationResult(
         controllable=controllable,
         controllable_command_ids=controllable_cmd_ids,
@@ -335,4 +553,5 @@ def classify(nodedef: NodeDef, find_editor: EditorResolver | None = None) -> Cla
         buttons=buttons,
         parameterized_commands=parameterized_commands,
         readings=readings,
+        aux_controls=aux_controls,
     )

--- a/pyisyox/classifier.py
+++ b/pyisyox/classifier.py
@@ -77,6 +77,7 @@ from pyisyox.constants import (
     PROP_STATUS,
     PROP_TEMPERATURE,
     UOM_BOOLEAN,
+    UOM_BYTE,
     UOM_INDEX,
     UOM_ON_OFF,
     UOM_OPEN_CLOSED,
@@ -268,7 +269,7 @@ _BINARY_UOMS = frozenset({UOM_BOOLEAN, UOM_ON_OFF, UOM_OPEN_CLOSED})
 #: Always-numeric UOMs: percent (0-100) and the 8-bit byte range
 #: (0-255). NUMBER even when the profile spells the span as a wide
 #: ``subset`` rather than ``min``/``max``.
-_NUMERIC_UOMS = frozenset({UOM_PERCENTAGE, "100"})
+_NUMERIC_UOMS = frozenset({UOM_PERCENTAGE, UOM_BYTE})
 #: Generic editor ids that name a value *shape* regardless of UOM (PG3
 #: plugin nodedefs lean on these; firmware nodedefs carry ``I_*`` /
 #: ``ZW_*`` ids whose shape is read off the range instead).
@@ -461,11 +462,12 @@ def _build_aux_controls(
     find_editor: EditorResolver | None,
 ) -> list[AuxControl]:
     """Coalesce non-controllable status/command pairs into one control
-    each: writable controls first (in ``accepts`` order), then the
-    remaining read-only properties. Controllable-owned ids and ``QUERY``
-    are already excluded; a paired writer still reads its status back
-    even when the property is controllable-filtered from standalone
-    readings (e.g. a light's ``OL`` setter)."""
+    each. Stable, intentional order (consumers may rely on it): writable
+    controls first in ``accepts`` order, then read-only residuals in
+    ``properties`` order. Controllable-owned ids and ``QUERY`` are
+    already excluded; a paired writer still reads its status back even
+    when the property is controllable-filtered from standalone readings
+    (e.g. a light's ``OL`` setter)."""
     props = nodedef.properties
     # Two accepts shouldn't legitimately pair to the same control id
     # (UDI won't ship two writers for one status), but guard it: first

--- a/pyisyox/classifier.py
+++ b/pyisyox/classifier.py
@@ -378,12 +378,17 @@ def _classify_property(prop: NodeProperty, find_editor: EditorResolver | None) -
 def _aux_write_platform(editor: Editor | None) -> AuxPlatform | None:
     """Editor shape → candidate platform for a *writable* aux control.
 
-    Layered, cheapest signal first (mirrors the consumer's historical
-    ``platform_for_control``): generic numeric/bool editor id; then
-    binary / always-numeric / index UOM; then range shape (``names`` or
-    a bare ``subset`` with no numeric bounds → a discrete choice;
-    ``min``/``max`` → a scalar). ``None`` when nothing resolves — the
-    consumer falls back.
+    Layered, cheapest signal first (intentionally mirrors the
+    consumer's historical ``platform_for_control`` so the candidate
+    matches what the consumer already does): generic numeric/bool
+    editor id; then binary / always-numeric / index UOM; then range
+    shape — ``names`` or a bare ``subset`` with **no numeric bounds** →
+    a discrete choice (SELECT); ``min``/``max`` present → a scalar
+    (NUMBER). An editor carrying ``names`` *and* numeric bounds (an
+    enum with a declared range — unusual but legal) therefore resolves
+    to NUMBER, not SELECT, matching the consumer; the candidate is
+    advisory and the consumer has final say. ``None`` when nothing
+    resolves — the consumer falls back.
     """
     if editor is None or not editor.ranges:
         return None
@@ -472,11 +477,20 @@ def _build_aux_controls(
     even when the property is controllable-filtered from standalone
     readings (e.g. a light's ``OL`` setter)."""
     props = nodedef.properties
-    cmd_controls = [
-        _aux_from_command(cmd, props, find_editor)
-        for cmd in nodedef.cmds.accepts
-        if cmd.id not in _QUERY_CMDS and cmd.id not in controllable_cmd_ids
-    ]
+    # Two accepts shouldn't legitimately pair to the same control id
+    # (UDI won't ship two writers for one status), but guard it: first
+    # in ``accepts`` order wins, so a stray duplicate can't emit two
+    # controls with the same id.
+    cmd_controls: list[AuxControl] = []
+    seen: set[str] = set()
+    for cmd in nodedef.cmds.accepts:
+        if cmd.id in _QUERY_CMDS or cmd.id in controllable_cmd_ids:
+            continue
+        control = _aux_from_command(cmd, props, find_editor)
+        if control.id in seen:
+            continue
+        seen.add(control.id)
+        cmd_controls.append(control)
     consumed = {c.property.id for c in cmd_controls if c.property is not None}
 
     read_controls: list[AuxControl] = []

--- a/pyisyox/classifier.py
+++ b/pyisyox/classifier.py
@@ -139,8 +139,7 @@ class AuxPlatform(StrEnum):
 
 @dataclass(slots=True)
 class AuxControl:
-    """One logical aux control = a read status and/or a write command,
-    coalesced.
+    """One logical aux control: a read status and/or a write command, coalesced.
 
     The IoX nodedef expresses the read/write pairing via a command
     parameter's ``init`` (the id of the ``<st>`` status it is
@@ -200,13 +199,9 @@ class ClassificationResult:
             parameter editors to input entities. Same QUERY / controllable
             exclusions as ``buttons``.
         readings: Per-property reading entities.
-        aux_controls: Coalesced read/write controls — the unified view
-            that supersedes the separate ``readings`` /
-            ``parameterized_commands`` / ``buttons`` split: each is one
-            logical control (status + its ``init``-linked writer folded
-            together). ``readings`` / ``parameterized_commands`` /
-            ``buttons`` are retained unchanged for now; new consumers
-            should prefer ``aux_controls``.
+        aux_controls: Coalesced read/write controls (see the module
+            docstring) — the unified successor to ``readings`` /
+            ``parameterized_commands`` / ``buttons``.
     """
 
     controllable: ControllablePlatform | None = None
@@ -378,17 +373,12 @@ def _classify_property(prop: NodeProperty, find_editor: EditorResolver | None) -
 def _aux_write_platform(editor: Editor | None) -> AuxPlatform | None:
     """Editor shape → candidate platform for a *writable* aux control.
 
-    Layered, cheapest signal first (intentionally mirrors the
-    consumer's historical ``platform_for_control`` so the candidate
-    matches what the consumer already does): generic numeric/bool
-    editor id; then binary / always-numeric / index UOM; then range
-    shape — ``names`` or a bare ``subset`` with **no numeric bounds** →
-    a discrete choice (SELECT); ``min``/``max`` present → a scalar
-    (NUMBER). An editor carrying ``names`` *and* numeric bounds (an
-    enum with a declared range — unusual but legal) therefore resolves
-    to NUMBER, not SELECT, matching the consumer; the candidate is
-    advisory and the consumer has final say. ``None`` when nothing
-    resolves — the consumer falls back.
+    Layered, cheapest signal first — intentionally mirrors the
+    consumer's historical ``platform_for_control`` so the advisory
+    candidate matches what the consumer already does. Note ``names``
+    *and* numeric bounds together resolves to NUMBER, not SELECT (an
+    enum with a declared range — unusual but legal; matches the
+    consumer). ``None`` when nothing resolves — the consumer falls back.
     """
     if editor is None or not editor.ranges:
         return None
@@ -546,10 +536,8 @@ def classify(nodedef: NodeDef, find_editor: EditorResolver | None = None) -> Cla
     candidate_cmds = [
         c for c in nodedef.cmds.accepts if c.id not in _QUERY_CMDS and c.id not in controllable_cmd_ids
     ]
-    # A command is button-shaped when it can be sent with no positional
-    # args: parameterless, or every parameter ``optional`` (controller
-    # applies defaults — e.g. Insteon BEEP's optional ``level``).
-    # ``all([])`` is True, so parameterless commands fall through here.
+    # Button-shaped = sendable with no positional args: parameterless or
+    # every param optional (controller defaults — e.g. Insteon BEEP).
     buttons = [c for c in candidate_cmds if all(p.optional for p in c.parameters)]
     parameterized_commands = [c for c in candidate_cmds if not all(p.optional for p in c.parameters)]
 

--- a/pyisyox/classifier.py
+++ b/pyisyox/classifier.py
@@ -483,7 +483,13 @@ def _build_aux_controls(
             continue
         seen.add(control.id)
         cmd_controls.append(control)
-    consumed = {c.property.id for c in cmd_controls if c.property is not None}
+    # Any id already surfaced by a command-side control owns that id:
+    # a same-id property is its readback, not a separate sensor. Keying
+    # on every cmd-control id (not just paired status ids) also blocks a
+    # write-only command (e.g. a no-``init`` ``BL`` setter) from
+    # colliding with an unrelated same-id property. No real UDI nodedef
+    # hits this today — invariant guard, not a live fix.
+    consumed = {c.id for c in cmd_controls}
 
     read_controls: list[AuxControl] = []
     for prop in _filter_state_properties(controllable, props):

--- a/pyisyox/constants.py
+++ b/pyisyox/constants.py
@@ -322,6 +322,7 @@ UOM_ISYV4_DEGREES = "degrees"
 UOM_ISYV4_NONE = "n/a"
 
 UOM_BOOLEAN = "2"  # 0 = False / 1 = True
+UOM_BYTE = "100"  # 0-255 8-bit range, no unit
 UOM_CLIMATE_MODES = "98"
 UOM_CLIMATE_MODES_ZWAVE = "67"
 UOM_DOUBLE_TEMP = "101"

--- a/tests/test_schema/test_classifier.py
+++ b/tests/test_schema/test_classifier.py
@@ -478,3 +478,32 @@ def test_aux_controls_is_additive_legacy_unchanged(profile: Profile) -> None:
     assert res.aux_controls  # new field populated
     assert res.readings  # legacy still present
     assert res.parameterized_commands or res.buttons
+
+
+def test_aux_controls_writeonly_cmd_does_not_dup_same_id_property() -> None:
+    """Invariant guard: an id surfaced by a command-side control is
+    never re-emitted as a standalone read-only control. Models a
+    write-only ``BL``-style setter (one param, no ``init`` — the real
+    Insteon backlight shape) alongside an (unrelated) same-id ``BL``
+    property. No real UDI nodedef ships this combination — the bundled
+    profile has 22 no-``init`` ``BL`` commands but zero ``BL``
+    properties — so this is a synthetic consistency check, not a live
+    repro.
+    """
+    editors = {
+        "ENUMED": _ed({"id": "ENUMED", "ranges": [{"uom": "25", "names": {"0": "A", "1": "B"}}]}),
+    }
+    nd = NodeDef(
+        id="synthetic_bl",
+        family_id="99",
+        instance_id="1",
+        properties={"BL": NodeProperty(id="BL", editor_id="ENUMED")},
+        cmds=NodeCommands(
+            accepts=[Command(id="BL", name="Backlight", parameters=[CommandParameter(editor_id="ENUMED")])]
+        ),
+    )
+    controls = [a for a in classify(nd, find_editor=editors.get).aux_controls if a.id == "BL"]
+    assert len(controls) == 1, "BL must not surface as both a write control and a read-only sensor"
+    (bl,) = controls
+    assert bl.writable and not bl.readable
+    assert bl.candidate_platform is AuxPlatform.SELECT

--- a/tests/test_schema/test_classifier.py
+++ b/tests/test_schema/test_classifier.py
@@ -7,6 +7,8 @@ from functools import partial
 import pytest
 
 from pyisyox.classifier import (
+    AuxControl,
+    AuxPlatform,
     ClassificationResult,
     ControllablePlatform,
     ReadingPlatform,
@@ -324,3 +326,138 @@ def test_controllable_assignment_matrix(
 ) -> None:
     res = _result_for(profile, nodedef_id, family, instance)
     assert res.controllable is expected
+
+
+# --- aux_controls (coalesced read/write controls, issue #160) -------------
+
+
+def _aux_by_id(res: ClassificationResult) -> dict[str, AuxControl]:
+    by_id: dict[str, AuxControl] = {}
+    for a in res.aux_controls:
+        assert a.id not in by_id, f"duplicate aux control id {a.id!r}"
+        by_id[a.id] = a
+    return by_id
+
+
+def test_aux_controls_i3_flags_coalesce_via_init(profile: Profile) -> None:
+    """The Insteon i3 ``I3PaddleFlags`` config sub-node: each ``GVx``
+    write command coalesces with the status it is ``init``-synchronized
+    with into ONE read/write control — no duplicate read-only sensor +
+    writable switch pair (issue #160 / #67).
+
+    Crucially ``GV0``'s param ``init="ST"`` (cmd-id != status-id): it
+    must pair with the ``ST`` "Mode" status, proving the key is
+    ``param.init``, not naive id matching.
+    """
+    res = _result_for(profile, "I3PaddleFlags", "1", "1")
+    assert res.controllable is None  # no DON/DOF on the flags sub-node
+    aux = _aux_by_id(res)
+
+    mode = aux["ST"]  # keyed by the status id, not the command id
+    assert mode.command is not None and mode.command.id == "GV0"
+    assert mode.property is not None and mode.property.id == "ST"
+    assert mode.readable and mode.writable
+    assert mode.candidate_platform is AuxPlatform.SWITCH
+    assert "GV0" not in aux  # not a separate write-only control
+
+    for gv in ("GV1", "GV2", "GV3", "GV4", "GV5", "GV7"):
+        c = aux[gv]
+        assert c.readable and c.writable
+        assert c.command is not None and c.command.id == gv
+        assert c.property is not None and c.property.id == gv
+        assert c.candidate_platform is AuxPlatform.SWITCH
+
+    assert aux["WDU"].writable and not aux["WDU"].readable
+    assert aux["WDU"].candidate_platform is AuxPlatform.BUTTON
+    assert aux["ERR"].readable and not aux["ERR"].writable
+    assert aux["ERR"].candidate_platform is AuxPlatform.SENSOR
+
+
+def test_aux_controls_exclude_controllable_owned(profile: Profile) -> None:
+    """A climate nodedef's setpoint/mode commands+status are owned by
+    the controllable platform — they must not surface as aux controls."""
+    res = _result_for(profile, "Thermostat", "1", "1")
+    assert res.controllable is ControllablePlatform.CLIMATE
+    ids = {a.id for a in res.aux_controls}
+    assert ids.isdisjoint({"ST", "CLISPH", "CLISPC", "CLIMD", "CLIFS"})
+
+
+def test_aux_controls_light_pairs_setters_with_props(profile: Profile) -> None:
+    """On a light, ``ST`` is controllable-owned (no aux), but the
+    ``OL``/``RR`` setters still pair with their properties → readable +
+    writable aux controls (a paired writer reads its status back even
+    when the property is controllable-filtered from standalone
+    readings)."""
+    res = _result_for(profile, "KeypadDimmer", "1", "1")
+    assert res.controllable is ControllablePlatform.LIGHT
+    aux = _aux_by_id(res)
+    assert "ST" not in aux
+    assert aux["OL"].readable and aux["OL"].writable
+    assert aux["OL"].candidate_platform is AuxPlatform.NUMBER
+    assert aux["RR"].readable and aux["RR"].writable
+    assert aux["RR"].candidate_platform is AuxPlatform.SELECT
+    # Backlight has no backing property → write-only.
+    assert aux["BL"].writable and not aux["BL"].readable
+
+
+def _ed(raw: dict) -> Editor:
+    return Editor.from_json(raw)
+
+
+def test_aux_control_candidate_platform_matrix() -> None:
+    """Editor shape → candidate platform, for writable controls, plus
+    a write-only (no ``init``) and a read-only (no writer) control."""
+    editors = {
+        "BOOLED": _ed(
+            {"id": "BOOLED", "ranges": [{"uom": "2", "subset": "0,1", "names": {"0": "Off", "1": "On"}}]}
+        ),
+        "NUMED": _ed({"id": "NUMED", "ranges": [{"uom": "56", "min": 0, "max": 100}]}),
+        "ENUMED": _ed({"id": "ENUMED", "ranges": [{"uom": "25", "names": {"0": "A", "1": "B"}}]}),
+        "PCTED": _ed({"id": "PCTED", "ranges": [{"uom": "51", "min": 0, "max": 100}]}),
+    }
+    nd = NodeDef(
+        id="synthetic",
+        family_id="99",
+        instance_id="1",
+        properties={
+            "GV0": NodeProperty(id="GV0", editor_id="BOOLED"),
+            "GV1": NodeProperty(id="GV1", editor_id="NUMED"),
+            "RO": NodeProperty(id="RO", editor_id="BOOLED"),
+        },
+        cmds=NodeCommands(
+            accepts=[
+                Command(
+                    id="GV0", name="Toggle", parameters=[CommandParameter(editor_id="BOOLED", init="GV0")]
+                ),
+                Command(id="GV1", name="Level", parameters=[CommandParameter(editor_id="NUMED", init="GV1")]),
+                Command(id="PICK", name="Pick", parameters=[CommandParameter(editor_id="ENUMED")]),
+                Command(id="PCT", name="Pct", parameters=[CommandParameter(editor_id="PCTED")]),
+                Command(id="GO", name="Go", parameters=[CommandParameter(editor_id="NUMED", optional=True)]),
+            ]
+        ),
+    )
+    res = classify(nd, find_editor=editors.get)
+    aux = _aux_by_id(res)
+
+    assert aux["GV0"].readable and aux["GV0"].writable
+    assert aux["GV0"].candidate_platform is AuxPlatform.SWITCH
+    assert aux["GV1"].candidate_platform is AuxPlatform.NUMBER
+    # No init → write-only, keyed by command id.
+    assert aux["PICK"].writable and not aux["PICK"].readable
+    assert aux["PICK"].candidate_platform is AuxPlatform.SELECT
+    assert aux["PCT"].candidate_platform is AuxPlatform.NUMBER
+    # All-optional param → button-shaped.
+    assert aux["GO"].candidate_platform is AuxPlatform.BUTTON
+    assert aux["GO"].writable and not aux["GO"].readable
+    # Property with no writer → read-only.
+    assert aux["RO"].readable and not aux["RO"].writable
+    assert aux["RO"].candidate_platform is AuxPlatform.BINARY_SENSOR
+
+
+def test_aux_controls_is_additive_legacy_unchanged(profile: Profile) -> None:
+    """``aux_controls`` is purely additive — the legacy
+    readings/parameterized_commands/buttons split is still populated."""
+    res = _result_for(profile, "KeypadDimmer", "1", "1")
+    assert res.aux_controls  # new field populated
+    assert res.readings  # legacy still present
+    assert res.parameterized_commands or res.buttons

--- a/tests/test_schema/test_classifier.py
+++ b/tests/test_schema/test_classifier.py
@@ -200,6 +200,23 @@ def test_classify_works_without_editor_resolver(profile: Profile) -> None:
     res = classify(nd)  # no resolver
     assert all(r.platform is ReadingPlatform.SENSOR for r in res.readings)
     assert all(r.is_enum is False for r in res.readings)
+    # aux_controls degrade the same way: read-only → SENSOR, is_enum False.
+    assert res.aux_controls
+    assert all(a.candidate_platform is AuxPlatform.SENSOR and not a.is_enum for a in res.aux_controls)
+
+    # A writable control with no resolvable editor → candidate None (the
+    # documented fallback path); still flagged writable for the consumer.
+    nd_w = NodeDef(
+        id="w",
+        family_id="99",
+        instance_id="1",
+        properties={"GV0": NodeProperty(id="GV0", editor_id="X")},
+        cmds=NodeCommands(
+            accepts=[Command(id="GV0", parameters=[CommandParameter(editor_id="X", init="GV0")])]
+        ),
+    )
+    (ctrl,) = classify(nd_w).aux_controls  # no resolver
+    assert ctrl.id == "GV0" and ctrl.writable and ctrl.candidate_platform is None
 
 
 def test_query_is_never_a_button() -> None:


### PR DESCRIPTION
## Summary

Closes #160. `classify()` returned `readings` (properties) and `parameterized_commands`/`buttons` (accept commands) as separate, mutually-unaware buckets. A control that is **both** a read status and a write command — Insteon i3 `I3*Flags` `GVx`, `CLISPH` on a thermostat — was split into two, forcing every consumer to re-derive the pairing and re-encode controllable-ownership (the duplication that drove hacs-udi-iox#67).

Adds `ClassificationResult.aux_controls: list[AuxControl]` — one logical control each, status + its writer folded together.

- **Pairing key is the command parameter's `init`** (the `<st>` it is "initialized and synchronized with" per the UDI DynamicProfiles spec) — **not** naive id matching. Verified the cases differ: i3 `GV0` param `init="ST"` ⇄ the `ST` "Mode" status (cmd-id ≠ status-id); id-union would mismodel the most user-visible i3 flag as two controls.
- **Controllable-owned ids + `QUERY` excluded** via the existing single source of truth (`_controllable_owned_prop_ids` extracted from `_filter_state_properties`; `controllable_command_ids`). `ST` is special **only** when a controllable platform owns it — otherwise an ordinary coalescable status (i3 flags sub-node).
- **`candidate_platform`** is editor-shape-derived (`AuxPlatform`: SENSOR/BINARY_SENSOR/NUMBER/SELECT/SWITCH/BUTTON) — a *candidate*; the consumer keeps final say (type-tier-1, bespoke/service routing, HA-device grouping stay consumer-side per the capability-vs-policy boundary).
- **Purely additive:** `readings`/`parameterized_commands`/`buttons` retained unchanged — the 815 existing tests are untouched (820 total with the new ones).

Validated against the bundled profile: i3 `I3PaddleFlags/I3DialFlags/I3KeypadFlags` → each `GVx` one RW SWITCH (GV0⇄ST "Mode"), `WDU` write-only BUTTON, `ERR` read-only SENSOR; `Thermostat` → setpoints/mode correctly excluded; `KeypadDimmer` (light) → `ST` excluded, `OL`/`RR` RW NUMBER/SELECT, `BL` write-only SELECT.

## Test plan

- [x] `test_aux_controls_i3_flags_coalesce_via_init` — i3 read/write coalescing, GV0⇄ST init-pairing (cmd-id≠status-id), no duplicate read+write
- [x] `test_aux_controls_exclude_controllable_owned` — climate setpoints not aux
- [x] `test_aux_controls_light_pairs_setters_with_props` — OL/RR paired; ST excluded; BL write-only
- [x] `test_aux_control_candidate_platform_matrix` — SWITCH/NUMBER/SELECT/BUTTON/SENSOR/BINARY_SENSOR + write-only + read-only
- [x] `test_aux_controls_is_additive_legacy_unchanged` — legacy buckets still populated
- [x] Full suite **820 passed**; ruff / ruff format / mypy / pylint (10.00/10) clean

## Downstream / sequencing

Consumer half is hacs-udi-iox#67 (collapse the 3 aux passes into one `_fan_out_aux` render + own HA-device dedup). Mirrors the #64 prong split: land + release this first, then hacs#67 pins to it. Legacy buckets stay until #67 migrates the consumer; a later cleanup can remove them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)