### PR TITLE
fix(classify): readable aux control survives an unresolvable write editor

### DIFF
--- a/pyisyox/classifier.py
+++ b/pyisyox/classifier.py
@@ -434,12 +434,25 @@ def _aux_from_command(
     is_enum = bool(editor and editor.ranges and editor.ranges[0].names)
     status_id = init_param.init
     if status_id and status_id in props:
+        prop = props[status_id]
+        if candidate is None:
+            # Write editor didn't resolve, but the control is readable:
+            # fall back to the status property's read classification so
+            # a coalesced control is never less surfaceable than the
+            # bare reading (write-only commands keep ``None``).
+            reading = _classify_property(prop, find_editor)
+            candidate = (
+                AuxPlatform.BINARY_SENSOR
+                if reading.platform is ReadingPlatform.BINARY_SENSOR
+                else AuxPlatform.SENSOR
+            )
+            is_enum = is_enum or reading.is_enum
         return AuxControl(
             id=status_id,
             readable=True,
             writable=True,
             candidate_platform=candidate,
-            property=props[status_id],
+            property=prop,
             command=cmd,
             editor_id=editor_id,
             is_enum=is_enum,

--- a/tests/test_schema/test_classifier.py
+++ b/tests/test_schema/test_classifier.py
@@ -204,10 +204,11 @@ def test_classify_works_without_editor_resolver(profile: Profile) -> None:
     assert res.aux_controls
     assert all(a.candidate_platform is AuxPlatform.SENSOR and not a.is_enum for a in res.aux_controls)
 
-    # A writable control with no resolvable editor → candidate None (the
-    # documented fallback path); still flagged writable for the consumer.
-    nd_w = NodeDef(
-        id="w",
+    # A *readable* control whose write editor doesn't resolve falls back
+    # to the property's read classification (SENSOR), so a coalesced
+    # control is never less surfaceable than the bare reading.
+    nd_rw = NodeDef(
+        id="rw",
         family_id="99",
         instance_id="1",
         properties={"GV0": NodeProperty(id="GV0", editor_id="X")},
@@ -215,8 +216,23 @@ def test_classify_works_without_editor_resolver(profile: Profile) -> None:
             accepts=[Command(id="GV0", parameters=[CommandParameter(editor_id="X", init="GV0")])]
         ),
     )
-    (ctrl,) = classify(nd_w).aux_controls  # no resolver
-    assert ctrl.id == "GV0" and ctrl.writable and ctrl.candidate_platform is None
+    (ctrl,) = classify(nd_rw).aux_controls  # no resolver
+    assert ctrl.id == "GV0" and ctrl.readable and ctrl.writable
+    assert ctrl.candidate_platform is AuxPlatform.SENSOR
+
+    # A *write-only* control with no resolvable editor keeps candidate
+    # None (the documented consumer-fallback path) — no read side.
+    nd_w = NodeDef(
+        id="w",
+        family_id="99",
+        instance_id="1",
+        cmds=NodeCommands(
+            accepts=[Command(id="DOIT", parameters=[CommandParameter(editor_id="X")])]
+        ),
+    )
+    (wo,) = classify(nd_w).aux_controls  # no resolver
+    assert wo.id == "DOIT" and wo.writable and not wo.readable
+    assert wo.candidate_platform is None
 
 
 def test_query_is_never_a_button() -> None:


### PR DESCRIPTION
## Problem

`_aux_from_command` coalesces a command parameter (whose `init` names a backing status) with that status into one read/write `AuxControl`. The `candidate_platform` was derived **solely from the write editor**. A PG3 plugin setter on a profile-absent, non-encoded editor → `_aux_write_platform` returns `None` → `candidate_platform=None`.

Consumers drop `None`-candidate controls (there is no platform to render them on), so the **readback is lost** — even though the per-property `readings` path would always have surfaced that status as a `sensor`. Net effect for consumers (hacs#67): plugin nodes whose status is paired with a custom-editor setter (temperature targets, dimmer/switch level setters with plugin editors) **disappear** entirely.

## Fix

When the write editor doesn't resolve **and the control is readable**, fall back to the status property's own read classification (`SENSOR` / `BINARY_SENSOR`, via `_classify_property`). A coalesced control is then never *less* surfaceable than the bare reading would have been. Write-only commands (no backing status) keep `candidate_platform=None` — there is no read side to show; the consumer's existing fallback path handles those.

## Test

- `test_classify_works_without_editor_resolver` updated: a readable+writable control with an unresolvable editor → `candidate_platform is AuxPlatform.SENSOR`; a write-only one → `None`.
- Full suite: 821 passed.

Surfaced during hacs#67 live-controller testing. Targets `6.0.0b6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)