### PR TITLE
fix(editor): send displayed value + UOM, controller scales device-side

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -629,7 +629,7 @@ class IoXClient:
             _LOGGER.debug("optional endpoint %s unavailable: %s", path, exc)
             return ""
 
-    async def send_node_command(self, address: str, command_id: str, *params: int | str) -> str:
+    async def send_node_command(self, address: str, command_id: str, *params: float | str) -> str:
         """Issue ``GET /rest/nodes/{addr}/cmd/{cmd}[/{p1}[/{p2}...]]``.
 
         Params are stringified and joined as-is — the editor codec runs

--- a/pyisyox/runtime/_commands.py
+++ b/pyisyox/runtime/_commands.py
@@ -43,7 +43,7 @@ def encode_command_params(
     command_id: str,
     params: Sequence[float | str],
     target_label: str,
-) -> tuple[tuple[int, str], ...]:
+) -> tuple[tuple[int | float, str], ...]:
     """Look up ``command_id`` on ``nodedef`` and encode each parameter.
 
     Args:
@@ -100,12 +100,12 @@ def _encode(
     profile: Profile,
     family_id: str,
     instance_id: str,
-) -> tuple[tuple[int, str], ...]:
+) -> tuple[tuple[int | float, str], ...]:
     if len(params) > len(command.parameters):
         raise NodeCommandError(
             f"command {command.id!r} accepts {len(command.parameters)} parameter(s); got {len(params)}"
         )
-    encoded: list[tuple[int, str]] = []
+    encoded: list[tuple[int | float, str]] = []
     for idx, param_def in enumerate(command.parameters):
         if idx >= len(params):
             if not param_def.optional:

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -375,7 +375,7 @@ class Node:
             params=params,
             target_label=f"node {self.address!r}",
         )
-        wire_args: list[int | str] = []
+        wire_args: list[int | float | str] = []
         for raw_value, uom in encoded:
             wire_args.append(raw_value)
             if uom and uom != "0":

--- a/pyisyox/schema/editor.py
+++ b/pyisyox/schema/editor.py
@@ -6,15 +6,19 @@ contract — read-side decode and write-side validation/encode. Write-side
 constraints beyond ``min``/``max``/``prec`` are the ``subset`` mask
 (``"0-3,5-7"`` excludes 4) and the ``names`` enum option list.
 
-UOM-101 quirk
--------------
+Send-side scaling
+-----------------
 
-Insteon thermostats encode 0.5°-precision temps as ``raw = 2 * displayed``
-(not a normal ``prec=1`` decimal); the legacy alias ``"degrees"`` behaves
-the same way. When a range carries one of those UOMs and declares
-``prec=0`` we double on encode / halve on decode for codec symmetry. Skip
-when ``prec=1`` (modern profiles), since the regular prec scaling
-already handles it.
+The controller does **all** device-side scaling itself, keyed off the
+UOM appended to the ``/cmd`` URL — proven on hardware:
+``/cmd/DON/100/100`` → 39 % (100 read as a UOM-100 0-255 byte) vs
+``/cmd/DON/100/51`` → 100 % (100 read as UOM-51 percent). So the codec
+**validates** input (enum-name resolution, ``min``/``max``, ``subset``)
+but sends the *displayed* value verbatim with its range UOM; it does
+**not** rewrite the number (no ``*10**prec`` rescale, no half-degree doubling).
+The eisy web UI does the same (``/cmd/setTemp/10.4/17``). ``decode``
+keeps its precision-aware formatting for display helpers, but the
+property read path normalises by the wire UOM and never calls it.
 """
 
 from __future__ import annotations
@@ -280,19 +284,19 @@ class Editor:
             return f"{raw_value / 2.0:.1f}"
         return str(raw_value)
 
-    def encode(self, value: float | str, uom: str | None = None) -> int:
-        """Encode user input to a raw integer the controller will accept.
+    def encode(self, value: float | str, uom: str | None = None) -> int | float:
+        """Validate user input and return the value to put on the wire.
 
         Two paths within a range:
 
-        * **Enum name (str matching ``names``)** — returns the matching raw
-          int verbatim. ``prec`` and ``min``/``max`` don't apply.
-        * **Numeric (int/float, or string parsed as float)** — interpreted as
-          the *displayed* value. Validated against ``[min, max]`` (which
-          the IoX schema stores in displayed form), then scaled to raw via
-          ``raw = round(displayed * 10**prec)``. Symmetric with
-          :meth:`decode`'s ``raw / 10**prec``. Subset validation (when
-          present) runs on the resulting raw int.
+        * **Enum name (str matching ``names``)** — returns the matching
+          raw int verbatim. ``min``/``max`` don't apply.
+        * **Numeric (int/float, or string parsed as float)** — the
+          *displayed* value. Validated against ``[min, max]`` and the
+          ``subset`` mask (both stored in displayed form), then returned
+          **as-is** (int when integral, else float). The controller does
+          device-side scaling from the appended UOM — the codec does not
+          rewrite the number (no ``*10**prec`` rescale, no half-degree doubling).
 
         When ``uom`` is given, only that range is tried. Otherwise every
         range is tried in order and the first that accepts ``value`` wins
@@ -305,15 +309,16 @@ class Editor:
         """
         return self.encode_param(value, uom)[0]
 
-    def encode_param(self, value: float | str, uom: str | None = None) -> tuple[int, str]:
+    def encode_param(self, value: float | str, uom: str | None = None) -> tuple[int | float, str]:
         """Like :meth:`encode`, but also returns the UOM of the range used.
 
-        Command-send code appends each parameter as ``/{raw}/{uom}`` so
-        the controller can do device-side scaling; the UOM has to be the
-        one belonging to the range that actually accepted the value, not
-        always ``ranges[0]`` — for a multi-range editor like
-        ``ZW_DIM_PERCENT`` a plain ``75`` is encoded by the 0-100 %
-        range (uom ``51``), so ``/cmd/DON/75/51`` is what must go on the
+        Command-send code appends each parameter as ``/{value}/{uom}``
+        and the controller scales device-side from that UOM (proven:
+        ``/cmd/DON/100/100`` → 39 %, ``/cmd/DON/100/51`` → 100 %), so the
+        UOM has to be the one belonging to the range that actually
+        accepted the value, not always ``ranges[0]`` — for a multi-range
+        editor like ``ZW_DIM_PERCENT`` a plain ``75`` is encoded by the
+        0-100 % range (uom ``51``), so ``/cmd/DON/75/51`` goes on the
         wire, not ``/cmd/DON/75/25``.
         """
         if uom is not None:
@@ -328,8 +333,16 @@ class Editor:
                 last_error = exc
         raise last_error or EditorCodecError(f"Editor {self.id!r}: cannot encode {value!r}")
 
-    def _encode_in_range(self, rng: EditorRange, value: float | str) -> int:
-        """Encode ``value`` against a single range — see :meth:`encode`."""
+    def _encode_in_range(self, rng: EditorRange, value: float | str) -> int | float:
+        """Validate ``value`` against a single range; return it as-is.
+
+        Enum names resolve to their raw int. Numeric input is range- and
+        subset-checked in *displayed* units and returned unchanged (int
+        when integral so the URL stays ``/72`` not ``/72.0``, else float
+        so a ``/cmd/setTemp/10.4/17`` survives). The controller does the
+        precision / unit scaling from the appended UOM — see the module
+        docstring.
+        """
         if isinstance(value, str):
             stripped = value.strip()
             if not stripped:
@@ -352,15 +365,10 @@ class Editor:
             raise EditorCodecError(f"Editor {self.id!r}: {numeric} is below min={rng.min}")
         if rng.max is not None and numeric > rng.max:
             raise EditorCodecError(f"Editor {self.id!r}: {numeric} is above max={rng.max}")
-        if rng.precision:
-            raw = round(numeric * (10**rng.precision))
-        elif rng.uom in _HALF_DEGREE_UOMS:
-            # Insteon thermostat half-degree encoding (raw = 2 * displayed).
-            # Only triggers on prec=0 ranges — modern prec=1 ranges already
-            # handle the displayed→raw conversion above.
-            raw = round(numeric * 2)
-        else:
-            raw = round(numeric)
-        if rng.subset and raw not in rng.subset:
-            raise EditorCodecError(f"Editor {self.id!r}: value {raw} is not in subset {sorted(rng.subset)}")
-        return int(raw)
+        # Subset masks are integer/index sets (prec-0 index editors);
+        # validate the integral form. They never co-occur with prec>0.
+        if rng.subset and round(numeric) not in rng.subset:
+            raise EditorCodecError(
+                f"Editor {self.id!r}: value {round(numeric)} is not in subset {sorted(rng.subset)}"
+            )
+        return int(numeric) if numeric.is_integer() else numeric

--- a/tests/test_schema/test_editor_codec.py
+++ b/tests/test_schema/test_editor_codec.py
@@ -96,10 +96,17 @@ def test_subset_parsing_with_gaps() -> None:
     assert rng.is_valid(7)
 
 
-def test_encode_accepts_float_via_rounding() -> None:
+def test_encode_sends_value_as_is_controller_scales() -> None:
+    """The codec validates but does not rewrite the number — the
+    controller scales device-side from the appended UOM. An integral
+    value comes back ``int`` (clean URL ``/72``); a fractional one is
+    preserved (``/cmd/.../72.4/17``)."""
     ed = Editor.from_json({"id": "I_F", "ranges": [{"uom": "17", "min": 0, "max": 120, "prec": 0}]})
-    assert ed.encode(72.4) == 72
-    assert ed.encode(72.6) == 73
+    assert ed.encode(72) == 72
+    assert ed.encode(72.0) == 72
+    assert isinstance(ed.encode(72.0), int)
+    assert ed.encode(72.4) == 72.4
+    assert ed.encode(72.6) == 72.6
 
 
 def test_decode_passes_through_when_no_match() -> None:
@@ -109,54 +116,57 @@ def test_decode_passes_through_when_no_match() -> None:
     assert ed.decode(42) == "42"
 
 
-# --- prec-symmetric encode / decode (bug fix 2026-05-09) -----------------
+# --- prec editors: send displayed value, controller scales by UOM --------
+#
+# The controller scales device-side from the appended UOM (proven:
+# /cmd/DON/100/100 -> 39%, /cmd/DON/100/51 -> 100%; eisy UI sends
+# /cmd/setTemp/10.4/17). encode no longer rewrites the number; decode
+# stays a precision-aware *display* helper (not on the read path), so
+# encode and decode are intentionally no longer symmetric.
 
 
-def test_encode_scales_by_prec_for_setpoint_editor() -> None:
-    """Setpoint editors store displayed °F/°C with ``prec=1`` — the
-    *displayed* value 72.0 °F should encode to raw 720, symmetric with
-    decode (which divides raw by 10**prec)."""
+def test_encode_prec_editor_sends_displayed_value_unscaled() -> None:
+    """A ``prec=1`` setpoint editor: the displayed value goes on the
+    wire verbatim (``72.5`` → ``72.5``, not ``725``); the controller
+    applies the precision from UOM 17."""
     ed = Editor.from_json(
         {"id": "I_CLISPH_F", "ranges": [{"uom": "17", "prec": 1, "min": 0.0, "max": 120.0}]}
     )
-    assert ed.encode(72.0) == 720
-    assert ed.encode(72.5) == 725
+    assert ed.encode(72.0) == 72
+    assert ed.encode(72.5) == 72.5
     assert ed.encode(0.0) == 0
-    assert ed.encode(120.0) == 1200
+    assert ed.encode(120.0) == 120
 
 
-def test_encode_decode_round_trip_with_prec() -> None:
-    """encode(decode(raw)) ≈ raw for all prec>0 editors that aren't enums."""
+def test_decode_is_independent_display_helper() -> None:
+    """``decode`` keeps its precision-aware formatting for display
+    helpers and is no longer the inverse of ``encode`` (the controller,
+    not the codec, does the raw scaling now)."""
     ed = Editor.from_json({"id": "I_CLISPC_C", "ranges": [{"uom": "4", "prec": 1, "min": 5.0, "max": 50.0}]})
-    for raw in (50, 100, 220, 500):
-        displayed = ed.decode(raw)
-        assert ed.encode(float(displayed)) == raw
+    assert ed.decode(220) == "22.0"
+    assert ed.encode(22.0) == 22  # sent as-is, NOT 220
 
 
 def test_encode_validates_min_max_against_displayed_value() -> None:
-    """min/max in the IoX schema are stored in *displayed* form. The validator
-    must compare the user's input against them, not the scaled raw int."""
+    """min/max are stored in *displayed* form; the validator compares the
+    user's input against them, and the value is sent unscaled."""
     ed = Editor.from_json({"id": "I_CLISPC_C", "ranges": [{"uom": "4", "prec": 1, "min": 5.0, "max": 50.0}]})
-    # 22.0 °C is in range; raw becomes 220 — must NOT be rejected as ">50"
-    assert ed.encode(22.0) == 220
-    # 50.0 °C is the inclusive max — accepts, raw 500
-    assert ed.encode(50.0) == 500
-    # 51.0 °C exceeds max
+    assert ed.encode(22.0) == 22  # in range, sent as-is
+    assert ed.encode(50.0) == 50  # inclusive max
     with pytest.raises(EditorCodecError, match="above max"):
         ed.encode(51.0)
-    # 4.9 °C below min
     with pytest.raises(EditorCodecError, match="below min"):
         ed.encode(4.9)
 
 
-def test_encode_string_numeric_input_also_scales() -> None:
-    """A consumer passing the displayed value as a string (e.g. from a UI
-    slider) must encode the same way as the float path."""
+def test_encode_string_numeric_input_sent_as_is() -> None:
+    """A consumer passing the displayed value as a string (UI slider)
+    encodes the same as the float path — validated, sent unscaled."""
     ed = Editor.from_json(
         {"id": "I_CLISPH_F", "ranges": [{"uom": "17", "prec": 1, "min": 0.0, "max": 120.0}]}
     )
-    assert ed.encode("72.0") == 720
-    assert ed.encode("72.5") == 725
+    assert ed.encode("72.0") == 72
+    assert ed.encode("72.5") == 72.5
 
 
 def test_encode_enum_name_skips_prec_scaling() -> None:
@@ -177,64 +187,66 @@ def test_encode_enum_name_skips_prec_scaling() -> None:
     assert ed.encode("Heat") == 1
 
 
-def test_encode_prec_zero_is_unchanged() -> None:
-    """For prec=0 editors (the typical enum/index case) encode passes the
-    integer through unchanged — symmetric with the original behaviour."""
+def test_encode_integer_passes_through() -> None:
+    """An integral value is sent unchanged as ``int`` (clean URL); a
+    fractional value is preserved (the controller scales by UOM)."""
     ed = Editor.from_json({"id": "I_PREC0", "ranges": [{"uom": "25", "min": 0, "max": 31, "prec": 0}]})
     assert ed.encode(15) == 15
-    assert ed.encode(15.4) == 15  # rounds
-    assert ed.encode(15.6) == 16
+    assert isinstance(ed.encode(15.0), int)
+    assert ed.encode(15.4) == 15.4
+    assert ed.encode(15.6) == 15.6
 
 
-# --- UOM-101 / "degrees" half-degree encoding ----------------------------
+# --- UOM-101 / "degrees" half-degree ------------------------------------
 #
-# Insteon thermostats (which the user's current setup doesn't include, so
-# this isn't covered by the live capture fixtures) encode 0.5°-precision
-# temperatures as ``raw = 2 * displayed``. The legacy alias ``"degrees"``
-# behaves the same way. We handle it on both encode and decode so a
-# profile that does carry such an editor works correctly without each
-# consumer having to special-case it.
+# Insteon thermostats encode 0.5°-precision temps as ``raw = 2 *
+# displayed``. The controller does that scaling itself from UOM 101 (no
+# Insteon-thermostat hardware in the live capture; the rule is the same
+# proven one — ``/cmd`` sends the displayed value + UOM). ``decode``
+# still halves for display helpers (independent of encode now).
 
 
-def test_encode_uom_101_doubles_displayed_value_when_prec_zero() -> None:
-    """raw = 2 * displayed for UOM 101 with prec=0."""
+def test_encode_uom_101_sends_displayed_value_no_client_doubling() -> None:
+    """UOM 101: the displayed value goes on the wire as-is; the
+    controller applies the half-degree raw doubling, not the codec."""
     ed = Editor.from_json({"id": "I_TEMP", "ranges": [{"uom": "101", "min": 0, "max": 120, "prec": 0}]})
-    assert ed.encode(68) == 136
-    assert ed.encode(72.5) == 145
+    assert ed.encode(68) == 68
+    assert ed.encode(72.5) == 72.5
     assert ed.encode(0) == 0
 
 
 def test_decode_uom_101_halves_raw_value_when_prec_zero() -> None:
-    """display = raw / 2 for UOM 101 with prec=0. Symmetric with encode."""
+    """``decode`` still halves UOM-101 raw for display helpers (it is no
+    longer the inverse of ``encode``)."""
     ed = Editor.from_json({"id": "I_TEMP", "ranges": [{"uom": "101", "min": 0, "max": 120, "prec": 0}]})
     assert ed.decode(136) == "68.0"
     assert ed.decode(145) == "72.5"
     assert ed.decode(0) == "0.0"
 
 
-def test_uom_degrees_alias_doubles() -> None:
-    """The ISY-v4 ``"degrees"`` UOM alias behaves identically."""
+def test_uom_degrees_alias_sends_displayed_value() -> None:
+    """The ISY-v4 ``"degrees"`` alias also sends the displayed value
+    unscaled; ``decode`` still halves for display."""
     ed = Editor.from_json(
         {"id": "I_TEMP_OLD", "ranges": [{"uom": "degrees", "min": 0, "max": 120, "prec": 0}]}
     )
-    assert ed.encode(68) == 136
+    assert ed.encode(68) == 68
     assert ed.decode(136) == "68.0"
 
 
-def test_uom_101_with_prec_one_uses_normal_scaling() -> None:
-    """Modern profiles using UOM 101 with prec=1 (rare but possible) get
-    normal decimal-prec scaling — *not* additional doubling. The half-
-    degree behaviour only kicks in when prec=0 explicitly."""
+def test_uom_101_prec_one_also_sends_displayed_value() -> None:
+    """UOM 101 with prec=1 — still sent unscaled (controller scales);
+    ``decode`` formats by prec for display."""
     ed = Editor.from_json({"id": "I_TEMP_NEW", "ranges": [{"uom": "101", "prec": 1, "min": 0, "max": 120}]})
-    assert ed.encode(68.0) == 680  # decimal prec, no doubling
+    assert ed.encode(68.0) == 68
     assert ed.decode(680) == "68.0"
 
 
 def test_uom_101_validates_min_max_against_displayed_value() -> None:
-    """min/max remain in displayed form even for UOM 101 — validation
-    runs before the *2 raw conversion."""
+    """min/max stay in displayed form for UOM 101; the value is sent
+    unscaled after validation."""
     ed = Editor.from_json({"id": "I_TEMP", "ranges": [{"uom": "101", "min": 0, "max": 120, "prec": 0}]})
-    assert ed.encode(120) == 240  # inclusive max
+    assert ed.encode(120) == 120  # inclusive max, unscaled
     with pytest.raises(EditorCodecError, match="above max"):
         ed.encode(121)
 
@@ -246,8 +258,8 @@ def test_range_parses_step_hint() -> None:
         {"id": "I_CLISPC_C", "ranges": [{"uom": "4", "prec": 1, "step": 0.5, "min": 5.0, "max": 50.0}]}
     )
     assert ed.ranges[0].step == 0.5
-    # Codec behaviour is unchanged by the presence of step.
-    assert ed.encode(21.5) == 215
+    # Codec behaviour is unaffected by step: value sent as-is.
+    assert ed.encode(21.5) == 21.5
     assert ed.decode(215) == "21.5"
 
 


### PR DESCRIPTION
## Problem

The `/cmd` wire contract is **send the displayed value, tail the range UOM, the controller scales device-side** — proven on live hardware:

| URL | Result |
|---|---|
| `/cmd/DON/100/100` | 39 % (100 read as a UOM-100 0-255 byte) |
| `/cmd/DON/100/51` | 100 % (100 read as UOM-51 percent) |

and the eisy web UI sends `/cmd/setTemp/10.4/17` (the displayed float, not a pre-scaled int).

`Editor._encode_in_range` instead rewrote the number client-side: `round(v * 10**prec)`, the half-degree `* 2`, and an unconditional `round()`. So a PG3 `virtualtemp` `setTemp` (UOM 17, prec 1) sent `10` for input `1` ("set 1, reads back 10") and could never emit a fractional `10.4`.

## Fix

`encode` now **validates only** — enum-name resolution, `min`/`max`, `subset`, all in *displayed* units — and returns the value **as-is**: `int` when integral (URL stays `/72`, not `/72.0`), else `float` so `/cmd/setTemp/10.4/17` survives. `encode` / `encode_param` / `_encode_in_range` and the send plumbing (`_commands._encode`, `node.send_command` wire args, `client.send_node_command`) widen to `int | float`.

This **reverts the 2026-05-09 prec-symmetric encode change** — that double-scaled against the controller's own UOM scaling (including for native Insteon, where `/cmd/.../<displayed>/<uom>` is also the contract). `decode` is **unchanged**: it stays a precision-aware *display* helper and is now intentionally decoupled from `encode` (the property read path normalises by the wire UOM and never calls `decode`).

## Verification

- Full suite **821 passed**, ruff + mypy clean. The 11 `test_editor_codec` tests that asserted the old client-scaling contract are rewritten to the new one (encode validates + sends as-is; decode independent).
- Live (eisy `192.168.30.174`): `setTemp` `encode_param(10.4)=(10.4,'17')`, `(1)=(1,'17')`, `(70.5)=(70.5,'17')`; native dimmer `DON` `encode_param(100)=(100,'51')`, `(75)=(75,'51')`.

Surfaced during hacs#67 live testing. Independent of #163 / #164; all three target `6.0.0b6`.

⚠️ No Insteon-thermostat hardware here to re-verify the half-degree UOM-101 path; the change applies the same proven `/cmd displayed-value + UOM` rule (controller does the `*2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)