### PR TITLE
fix(normalize): decode reported precision on property reads

### DIFF
--- a/pyisyox/runtime/_normalize.py
+++ b/pyisyox/runtime/_normalize.py
@@ -1,21 +1,30 @@
-"""UOM normalization for live node-property values.
+"""Normalization for live node-property values.
 
-Some IoX devices report a property in a different unit-of-measure than
-its nodedef *editor* declares. The classic case: an Insteon dimmer
-reports ``OL`` (and ``ST``) as a **UOM-100 0-255 byte** (``191`` for
-"75%"), while the ``I_OL`` editor — the one the ``/rest/nodes/.../cmd``
-write surface uses — describes the **UOM-51 0-100% slider**. Z-Wave /
-Zigbee / Matter dimmers may report either form depending on firmware.
+Two transforms, applied on every ``node.properties`` / ``node.status``
+read so consumers see one consistent shape regardless of firmware or
+transport (REST load vs. a WebSocket ``<action>`` frame):
 
-This module converts a reported :class:`~pyisyox.client.NodePropertyValue`
-into the editor's canonical UOM so consumers see one consistent shape
-regardless of which firmware or transport produced it (REST load vs. a
-WebSocket ``<action>`` frame). When the reported UOM already matches one
-of the editor's ranges — the common case — the value passes through
-untouched.
+1. **Precision decode.** IoX reports a value as an integer plus a
+   ``prec`` decimal shift — ``value="954" prec="1"`` is ``95.4`` (the
+   controller's own ``formatted`` confirms: ``"95.4°F"``). This is the
+   read-side counterpart of the send contract (the controller scales
+   device-side; see :mod:`pyisyox.schema.editor`): the displayed value
+   is ``raw / 10**prec``, and the returned :class:`NodePropertyValue`
+   carries that with ``precision=0`` so consumers never re-shift it.
+   Independent of the editor — the wire frame is self-describing.
 
-The conversion set is intentionally tiny; only genuinely mismatched
-pairs belong here.
+2. **UOM canonicalization.** Some devices report a property in a
+   different unit than its nodedef *editor* declares — the classic
+   case: an Insteon dimmer reports ``OL``/``ST`` as a **UOM-100 0-255
+   byte** (``191`` for "75%") while the ``I_OL`` editor (and the
+   ``/cmd`` write surface) speak the **UOM-51 0-100% slider**. The
+   conversion set is intentionally tiny; only genuinely mismatched
+   pairs belong here. When the reported UOM already matches one of the
+   editor's ranges — the common case — only step 1 applies.
+
+(UOM-101 / "degrees" half-degree raw is *not* handled here — that legacy
+Insteon-thermostat encoding stays a consumer concern; there's no such
+hardware in any capture to verify against.)
 """
 
 from __future__ import annotations
@@ -43,14 +52,46 @@ _CONVERSIONS: dict[tuple[str, str], tuple[Callable[[float], float], int]] = {
 }
 
 
-def normalize_property_value(prop: NodePropertyValue, editor: Editor | None) -> NodePropertyValue:
-    """Return ``prop`` re-expressed in its editor's canonical UOM.
+def _num_text(value: float) -> str:
+    """Stringify so an integral value stays ``"75"`` not ``"75.0"``."""
+    return str(int(value)) if float(value).is_integer() else f"{value}"
 
-    Passes ``prop`` through unchanged when there's no editor, no UOM on
-    the value, the UOM already matches one of the editor's ranges, no
-    conversion is defined for the ``(reported, editor)`` UOM pair, or the
-    value isn't numeric.
+
+def _decode_precision(prop: NodePropertyValue) -> NodePropertyValue:
+    """Apply the reported ``prec`` decimal shift; ``precision`` → 0.
+
+    Passthrough when ``prec`` is 0 (nothing to shift) or the value isn't
+    numeric (plugin nodes legitimately report non-numeric readings —
+    consumers fall back to ``formatted``).
     """
+    if not prop.precision:
+        return prop
+    try:
+        raw = float(prop.value)
+    except (TypeError, ValueError):
+        return prop
+    displayed = round(raw / (10**prop.precision), prop.precision)
+    return NodePropertyValue(
+        id=prop.id,
+        value=_num_text(displayed),
+        formatted=prop.formatted,
+        uom=prop.uom,
+        name=prop.name,
+        precision=0,
+    )
+
+
+def normalize_property_value(prop: NodePropertyValue, editor: Editor | None) -> NodePropertyValue:
+    """Return ``prop`` precision-decoded and re-expressed in its editor's
+    canonical UOM.
+
+    Step 1 (precision) always runs — it's editor-independent. Step 2
+    (UOM conversion) passes through unchanged when there's no editor, no
+    UOM, the UOM already matches one of the editor's ranges, no
+    conversion is defined for the ``(reported, editor)`` UOM pair, or
+    the value isn't numeric.
+    """
+    prop = _decode_precision(prop)
     if editor is None or not prop.uom:
         return prop
     editor_uoms = {r.uom for r in editor.ranges}
@@ -65,12 +106,11 @@ def normalize_property_value(prop: NodePropertyValue, editor: Editor | None) -> 
             raw = float(prop.value)
         except (TypeError, ValueError):
             return prop
-        displayed = raw / (10**prop.precision) if prop.precision else raw
-        new_value = transform(displayed)
-        text = str(int(new_value)) if float(new_value).is_integer() else f"{new_value}"
+        # ``prop`` is already precision-decoded (precision == 0).
+        new_value = transform(raw)
         return NodePropertyValue(
             id=prop.id,
-            value=text,
+            value=_num_text(new_value),
             formatted=prop.formatted,
             uom=target_uom,
             name=prop.name,

--- a/tests/test_runtime/test_normalize.py
+++ b/tests/test_runtime/test_normalize.py
@@ -58,3 +58,56 @@ def test_unknown_conversion_pair_passes_through() -> None:
 def test_non_numeric_value_passes_through() -> None:
     prop = NodePropertyValue(id="ST", value="", uom="100", precision=0)
     assert normalize_property_value(prop, _editor(PCT)) is prop
+
+
+# --- precision decode (read-side counterpart of the send contract) -------
+
+TEMP = EditorRange(uom="17", min=-30.0, max=130.0, precision=1)
+
+
+def test_reported_precision_is_decoded_when_uom_matches() -> None:
+    """``value="954" prec=1`` (a PG3 ``virtualtemp`` reading) decodes to
+    ``95.4`` with ``precision=0``; the UOM already matches the editor so
+    only the precision step applies. ``formatted`` is preserved."""
+    prop = NodePropertyValue(
+        id="GV1", value="954", formatted="95.4°F", uom="17", precision=1
+    )
+    out = normalize_property_value(prop, _editor(TEMP))
+    assert out.value == "95.4"
+    assert out.precision == 0
+    assert out.uom == "17"
+    assert out.formatted == "95.4°F"
+
+
+def test_reported_precision_decoded_without_editor() -> None:
+    """Precision decode is editor-independent (the wire frame is
+    self-describing) — works for dynamically-provisioned nodes with no
+    nodedef/editor."""
+    prop = NodePropertyValue(id="GV2", value="11114", uom="69", precision=4)
+    out = normalize_property_value(prop, None)
+    assert out.value == "1.1114"
+    assert out.precision == 0
+
+
+def test_precision_decode_integral_result_has_no_dot() -> None:
+    """``950`` prec 1 → ``95`` (not ``95.0``) so the URL/state stays clean."""
+    prop = NodePropertyValue(id="GV3", value="950", uom="17", precision=1)
+    out = normalize_property_value(prop, _editor(TEMP))
+    assert out.value == "95"
+    assert out.precision == 0
+
+
+def test_precision_decode_then_uom_conversion_compose() -> None:
+    """Both steps apply: a byte reported with a prec shift is first
+    precision-decoded, then byte→percent canonicalised."""
+    prop = NodePropertyValue(id="OL", value="1910", uom="100", precision=1)
+    out = normalize_property_value(prop, _editor(PCT))
+    # 1910 / 10**1 = 191 (byte) → round(191*100/255) = 75 %
+    assert out.value == "75"
+    assert out.uom == "51"
+    assert out.precision == 0
+
+
+def test_non_numeric_with_precision_passes_through() -> None:
+    prop = NodePropertyValue(id="ST", value="n/a", uom="17", precision=1)
+    assert normalize_property_value(prop, _editor(TEMP)) is prop


### PR DESCRIPTION
## Problem

IoX reports a property value as an integer plus a `prec` decimal shift — `value="954" prec="1"` is **95.4** (the controller's own `formatted` says `"95.4°F"`). `normalize_property_value` only canonicalised UOM, so a `prec>0` property passed through **raw**. Every consumer then had to re-shift it independently, and they were inconsistent: `sensor.py` (`convert_isy_value_to_hass`) and the variable entity decoded it; `ISYAuxControlNumberEntity` did **not** — so a `virtualtemp` setpoint set to 95.4 in the eisy UI surfaced in HA as **954**.

## Fix

Decode the reported precision in `_normalize` — the single chokepoint hit by `node.properties` / `node.status` on every read (REST load **and** WebSocket `<action>` frame). It returns the displayed value with `precision=0`, so consumers never re-shift (their `convert_isy_value_to_hass` precision arg now always sees 0 and no-ops — no double-scale).

- Editor-independent: the wire frame is self-describing, so it also works for nodedef-less dynamically-provisioned nodes.
- Composes with the existing byte→percent UOM step (precision decode first, then UOM).
- `prec=0` returns the **same object** (identity preserved — zero churn for the common case).
- UOM-101 / "degrees" half-degree raw is intentionally **out of scope** (legacy Insteon-thermostat encoding, no hardware in any capture to verify; stays a consumer concern).

This is the read-side counterpart of the send contract (#165 — the controller scales device-side; the codec sends the displayed value + UOM).

## Test

- 5 new `test_normalize` cases (prec decode w/ matching UOM, no-editor, integral result, prec+UOM compose, non-numeric passthrough). Full suite **826 passed**, ruff + mypy clean.

Coordinated with a hacs#67 update (consumers stop re-decoding). Independent of #163 / #164 / #165; all target `6.0.0b6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)