### PR TITLE
chore: address review nits on #163–#166

### DIFF
--- a/pyisyox/classifier.py
+++ b/pyisyox/classifier.py
@@ -160,8 +160,11 @@ class AuxControl:
             the command id, else the property id).
         readable: A backing status property exists (readback source).
         writable: An accept command drives it.
-        candidate_platform: Editor-shape-derived HA platform candidate,
-            or ``None`` when no editor resolves (consumer falls back).
+        candidate_platform: Editor-shape-derived HA platform candidate.
+            ``None`` only when no editor resolves *and* there is no
+            readable backing status (a readable control falls back to
+            its property's read classification — SENSOR/BINARY_SENSOR);
+            write-only with no editor stays ``None`` for the consumer.
         property: The backing :class:`NodeProperty`, if readable.
         command: The driving :class:`Command`, if writable.
         editor_id: The editor governing the control — the write
@@ -544,8 +547,10 @@ def classify(nodedef: NodeDef, find_editor: EditorResolver | None = None) -> Cla
         A :class:`ClassificationResult` with controllable / triggers /
         buttons / parameterized_commands / readings / aux_controls
         populated. ``find_editor`` also drives ``aux_controls``
-        candidate platforms; without it writable controls fall back to
-        ``candidate_platform=None`` for the consumer to resolve.
+        candidate platforms; without it a *readable* writable control
+        falls back to its property's read classification, and a
+        *write-only* control falls back to ``candidate_platform=None``
+        for the consumer to resolve.
     """
     accept_ids = frozenset(c.id for c in nodedef.cmds.accepts)
     on_cmd = next((c for c in nodedef.cmds.accepts if c.id == CMD_ON), None)

--- a/pyisyox/runtime/_normalize.py
+++ b/pyisyox/runtime/_normalize.py
@@ -45,16 +45,22 @@ def _byte_to_percent(displayed: float) -> float:
 
 
 #: ``(reported_uom, editor_uom) -> (transform, target_precision)``. The
-#: transform receives the *displayed* value (raw already divided by
-#: ``10**precision``) and returns the displayed value in the target UOM.
+#: transform receives the *displayed* value (already precision-decoded)
+#: and returns the displayed value in the target UOM. ``target_precision``
+#: **must be 0** — the post-condition of ``normalize_property_value`` is
+#: ``precision == 0`` (the value is fully decoded; consumers never
+#: re-shift). A non-zero entry would violate that invariant.
 _CONVERSIONS: dict[tuple[str, str], tuple[Callable[[float], float], int]] = {
     ("100", "51"): (_byte_to_percent, 0),
 }
 
 
-def _num_text(value: float) -> str:
-    """Stringify so an integral value stays ``"75"`` not ``"75.0"``."""
-    return str(int(value)) if float(value).is_integer() else f"{value}"
+def _num_text(value: float, prec: int) -> str:
+    """Stringify to ``prec`` decimals; an integral value stays ``"75"``
+    not ``"75.0"``. Fixed-point (``f"{value:.{prec}f}"``) — never
+    ``f"{value}"``, which flips to scientific notation below ~1e-4
+    (a ``prec=5`` reading would otherwise wire ``"1e-05"``)."""
+    return str(int(value)) if value.is_integer() else f"{value:.{prec}f}"
 
 
 def _decode_precision(prop: NodePropertyValue) -> NodePropertyValue:
@@ -73,7 +79,7 @@ def _decode_precision(prop: NodePropertyValue) -> NodePropertyValue:
     displayed = round(raw / (10**prop.precision), prop.precision)
     return NodePropertyValue(
         id=prop.id,
-        value=_num_text(displayed),
+        value=_num_text(displayed, prop.precision),
         formatted=prop.formatted,
         uom=prop.uom,
         name=prop.name,
@@ -106,11 +112,12 @@ def normalize_property_value(prop: NodePropertyValue, editor: Editor | None) -> 
             raw = float(prop.value)
         except (TypeError, ValueError):
             return prop
-        # ``prop`` is already precision-decoded (precision == 0).
+        # ``prop`` is already precision-decoded (precision == 0); the
+        # transform output is in displayed units, ``target_prec`` is 0.
         new_value = transform(raw)
         return NodePropertyValue(
             id=prop.id,
-            value=_num_text(new_value),
+            value=_num_text(new_value, target_prec),
             formatted=prop.formatted,
             uom=target_uom,
             name=prop.name,

--- a/pyisyox/runtime/node.py
+++ b/pyisyox/runtime/node.py
@@ -386,6 +386,9 @@ class Node:
         int, no UOM) so the node stays controllable without validation.
         """
         if self._nodedef is None:
+            # No editor / UOM context here, so a fractional param is
+            # truncated to int intentionally — nothing can tell the
+            # controller how to scale it anyway.
             passthrough: list[int | str] = [int(p) if isinstance(p, (int, float)) else p for p in params]
             await self._client.send_node_command(self.address, command_id, *passthrough)
             return

--- a/pyisyox/schema/editor.py
+++ b/pyisyox/schema/editor.py
@@ -136,11 +136,12 @@ class EditorRange:
         """True if ``raw_value`` is acceptable for outbound commands.
 
         Used for **subset** validation only (prec=0, enum-shaped editors).
-        Numeric editors with ``prec>0`` validate against the displayed
-        value before scaling — see :meth:`Editor.encode`. ``min``/``max``
-        in the IoX schema are stored in **displayed form** (e.g.
-        ``min=5.0`` on a UOM-4 °C setpoint editor with ``prec=1`` means
-        5.0 °C, not raw 5).
+        Numeric editors with ``prec>0`` validate the displayed value and
+        send it as-is (no scaling — the controller scales device-side
+        from the UOM; see :meth:`Editor.encode`). ``min``/``max`` in the
+        IoX schema are stored in **displayed form** (e.g. ``min=5.0`` on
+        a UOM-4 °C setpoint editor with ``prec=1`` means 5.0 °C, not raw
+        5).
         """
         if self.subset:
             return raw_value in self.subset
@@ -365,10 +366,17 @@ class Editor:
             raise EditorCodecError(f"Editor {self.id!r}: {numeric} is below min={rng.min}")
         if rng.max is not None and numeric > rng.max:
             raise EditorCodecError(f"Editor {self.id!r}: {numeric} is above max={rng.max}")
-        # Subset masks are integer/index sets (prec-0 index editors);
-        # validate the integral form. They never co-occur with prec>0.
-        if rng.subset and round(numeric) not in rng.subset:
-            raise EditorCodecError(
-                f"Editor {self.id!r}: value {round(numeric)} is not in subset {sorted(rng.subset)}"
-            )
+        # Subset masks are discrete integer/index sets (prec-0 index
+        # editors; never co-occur with prec>0). Reject non-integral
+        # input outright — a fractional index is meaningless and must
+        # not reach the wire.
+        if rng.subset:
+            if not numeric.is_integer():
+                raise EditorCodecError(
+                    f"Editor {self.id!r}: {numeric} is not a valid index (subset {sorted(rng.subset)})"
+                )
+            if int(numeric) not in rng.subset:
+                raise EditorCodecError(
+                    f"Editor {self.id!r}: value {int(numeric)} is not in subset {sorted(rng.subset)}"
+                )
         return int(numeric) if numeric.is_integer() else numeric

--- a/tests/test_runtime/test_node.py
+++ b/tests/test_runtime/test_node.py
@@ -727,6 +727,7 @@ async def test_set_on_level_rejects_out_of_range(real_profile: Profile) -> None:
     node = Node.from_record(record, real_profile, _make_client(session))
     with pytest.raises(NodeCommandError, match="above max"):
         await node.set_on_level(300)
+    assert session.calls == [], "must short-circuit before HTTP"
 
 
 # --- control-id → accept-command resolution (init pairing) ---------------

--- a/tests/test_runtime/test_normalize.py
+++ b/tests/test_runtime/test_normalize.py
@@ -111,3 +111,11 @@ def test_precision_decode_then_uom_conversion_compose() -> None:
 def test_non_numeric_with_precision_passes_through() -> None:
     prop = NodePropertyValue(id="ST", value="n/a", uom="17", precision=1)
     assert normalize_property_value(prop, _editor(TEMP)) is prop
+
+
+def test_non_numeric_precision_and_mismatched_uom_passes_through() -> None:
+    """Non-numeric + prec>0 + a UOM that *would* hit the conversion loop:
+    ``_decode_precision`` returns the original (non-numeric), then the
+    UOM step also fails to ``float()`` it and returns it unchanged."""
+    prop = NodePropertyValue(id="OL", value="n/a", uom="100", precision=1)
+    assert normalize_property_value(prop, _editor(PCT)) is prop


### PR DESCRIPTION
## Summary

Post-merge cleanup of the `claude-review` findings on the four aux/codec fixes (#163–#166), now on `main`. **No behaviour change** except #165's subset hardening (rejecting a fractional index that previously could reach the wire).

- **#163** — `AuxControl.candidate_platform` + `classify()` docstrings: `None` only when no editor resolves **and** there's no readable backing status (a readable control falls back to its property's read classification).
- **#164** — restore the dropped `assert session.calls == []` ("must short-circuit before HTTP") in `test_set_on_level_rejects_out_of_range`. Confirmed genuinely lost: pre-#164 `315a0e0` had it; it was removed when the resolver test was added adjacent to it.
- **#165** — (a) `EditorRange.is_valid` docstring no longer says "before scaling" (encode validates + sends as-is); (b) subset editors now reject non-integral input outright instead of `round()`-checking then sending the float; (c) comment the intentional `int()` truncation on the no-nodedef passthrough. UOM-101 half-degree stays the tracked validation item (no Insteon-thermostat hardware).
- **#166** — (a) `_num_text` takes `prec` and uses fixed-point `f"{v:.{prec}f}"` so a `prec>=5` reading can't wire scientific notation (`"1e-05"`); (b) document the `_CONVERSIONS` `target_prec`-must-be-0 post-condition; (c) drop the redundant `float()`; (d) add the non-numeric + prec>0 + mismatched-UOM passthrough test.

## Test plan

- [x] `pytest tests/` — 828 passed (restored #164 assertion + new #166 test)
- [x] ruff + mypy clean
- [x] No fallout from the subset tightening (no test passed a fractional to a subset editor)

Targets `6.0.0b6` alongside #163–#166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)