### PR TITLE
fix(schema): resolve open-ended subset bounds instead of crashing the load

### DIFF
--- a/pyisyox/schema/editor.py
+++ b/pyisyox/schema/editor.py
@@ -32,19 +32,32 @@ from dataclasses import dataclass, field
 _HALF_DEGREE_UOMS = frozenset({"101", "degrees"})
 
 
-def _parse_subset(spec: str) -> set[int]:
-    """Expand a subset spec like ``"0-3,5-7"`` into ``{0,1,2,3,5,6,7}``."""
+def _parse_subset(spec: str, lo_default: int | None = None, hi_default: int | None = None) -> set[int]:
+    """Expand a subset spec like ``"0-3,5-7"`` into ``{0,1,2,3,5,6,7}``.
+
+    Some IoX 6.x firmware (eisy 6.0.5) emits an open-ended bound —
+    ``"5-"``, ``"-7"``, ``"-"`` — resolved against ``lo_default`` /
+    ``hi_default`` (the editor's min/max or names-index extremes). A
+    piece that still can't resolve (or is garbage) is skipped rather
+    than raising and aborting the whole profile load.
+    """
     out: set[int] = set()
     for raw_piece in spec.split(","):
         piece = raw_piece.strip()
         if not piece:
             continue
-        if "-" in piece:
-            lo_s, hi_s = piece.split("-", 1)
-            lo, hi = int(lo_s), int(hi_s)
-            out.update(range(lo, hi + 1))
-        else:
-            out.add(int(piece))
+        try:
+            if "-" in piece:
+                lo_s, hi_s = (p.strip() for p in piece.split("-", 1))
+                lo = int(lo_s) if lo_s else lo_default
+                hi = int(hi_s) if hi_s else hi_default
+                if lo is None or hi is None:
+                    continue
+                out.update(range(lo, hi + 1))
+            else:
+                out.add(int(piece))
+        except ValueError:
+            continue
     return out
 
 
@@ -121,14 +134,21 @@ class EditorRange:
         """Build a range from a JSON object."""
         subset_raw = raw.get("subset")
         names_raw = raw.get("names", {}) or {}
+        names = {int(k): v for k, v in names_raw.items()}
         step_raw = raw.get("step")
+        # Open-ended-bound floor/ceiling: own min/max, else names extremes.
+        rng_min, rng_max = raw.get("min"), raw.get("max")
+        lo_default = int(rng_min) if isinstance(rng_min, (int, float)) else (min(names) if names else None)
+        hi_default = int(rng_max) if isinstance(rng_max, (int, float)) else (max(names) if names else None)
         return cls(
             uom=str(raw.get("uom", "0")),
-            min=raw.get("min"),
-            max=raw.get("max"),
+            min=rng_min,
+            max=rng_max,
             precision=int(raw.get("prec", 0)),
-            subset=_parse_subset(subset_raw) if isinstance(subset_raw, str) else set(),
-            names={int(k): v for k, v in names_raw.items()},
+            subset=(
+                _parse_subset(subset_raw, lo_default, hi_default) if isinstance(subset_raw, str) else set()
+            ),
+            names=names,
             step=float(step_raw) if isinstance(step_raw, (int, float)) else None,
         )
 

--- a/tests/test_schema/test_editor_codec.py
+++ b/tests/test_schema/test_editor_codec.py
@@ -96,6 +96,63 @@ def test_subset_parsing_with_gaps() -> None:
     assert rng.is_valid(7)
 
 
+@pytest.mark.parametrize(
+    ("subset_spec", "expected"),
+    [
+        ("5-", {5, 6, 7}),  # open-ended high → resolves to max
+        ("-2", {0, 1, 2}),  # open-ended low → resolves from min
+        ("-", {0, 1, 2, 3, 4, 5, 6, 7}),  # bare separator → whole universe
+        ("0-3,5-,7", {0, 1, 2, 3, 5, 6, 7}),  # bad piece resolved, others kept
+        ("x", set()),  # non-numeric single value still skipped
+    ],
+)
+def test_subset_open_ended_bound_resolves_to_min_max(
+    subset_spec: str, expected: set[int]
+) -> None:
+    """An open-ended subset bound resolves against the editor's min/max.
+
+    Regression for hacs-udi-iox#71: eisy IoX 6.0.5 emits a subset with an
+    empty bound; ``int('')`` aborted the whole profile load and blocked
+    integration install. Dropping the piece would empty the subset and
+    *widen* the valid set, so we resolve the open side against the range.
+    """
+    ed = Editor.from_json(
+        {
+            "id": "I_OPEN",
+            "ranges": [{"uom": "25", "min": 0, "max": 7, "subset": subset_spec}],
+        }
+    )
+    assert ed.range_for("25").subset == expected
+
+
+def test_subset_open_ended_bound_resolves_via_names_when_no_min_max() -> None:
+    """A pure enum editor (no min/max) resolves the bound via names extremes."""
+    ed = Editor.from_json(
+        {
+            "id": "I_ENUM",
+            "ranges": [
+                {
+                    "uom": "25",
+                    "subset": "1-",
+                    "names": {"0": "Off", "1": "Low", "2": "Med", "3": "High"},
+                }
+            ],
+        }
+    )
+    assert ed.range_for("25").subset == {1, 2, 3}
+
+
+def test_subset_open_ended_bound_skipped_without_context() -> None:
+    """No min/max and no names → the open bound can't be resolved, so skip.
+
+    Crash-safety floor: still no ``ValueError``, the load survives.
+    """
+    ed = Editor.from_json(
+        {"id": "I_NOCTX", "ranges": [{"uom": "25", "subset": "5-,2"}]}
+    )
+    assert ed.range_for("25").subset == {2}
+
+
 def test_encode_sends_value_as_is_controller_scales() -> None:
     """The codec validates but does not rewrite the number — the
     controller scales device-side from the appended UOM. An integral


### PR DESCRIPTION
## Problem

eisy on **IoX firmware 6.0.5** emits an editor `subset` spec with an
empty range bound — e.g. `"5-"`, `"-7"`, or a bare `"-"`.
`_parse_subset` split on `-` and passed the empty side to `int()`:

```
ValueError: invalid literal for int() with base 10: ''
```

This bubbled out of `Profile.load_from_json` → `Editor.from_json` →
`EditorRange.from_json` → `_parse_subset`, **aborting the entire
profile load**. Every user on 6.0.5 hits an "Unexpected exception" at
config-flow time and the integration won't install at all.

Reported downstream: shbatm/hacs-udi-iox#71 (full traceback there).

## Fix

`-` is unambiguously the range separator (a subset can't contain
negatives), so an **empty side means open-ended**: `"5-"` is "5 up to
the editor's ceiling", `"-7"` is "from the floor through 7".

`_parse_subset` now resolves the open side against `lo_default` /
`hi_default`, which `EditorRange.from_json` derives from the range's
`min`/`max` — falling back to the `names` index extremes for a pure
enum (UOM-25) editor that carries no `min`/`max`. So an open-ended
piece resolves to the indices the firmware actually meant to
whitelist.

Just *dropping* the piece (an earlier approach) would empty the subset
and make `is_valid` fall back to `[min, max]` — **widening** the valid
set, the wrong direction. A piece with no resolvable context (no
`min`/`max`/`names`), or genuine garbage, is still skipped rather than
fatal — graceful degradation as the crash-safety floor.

## Tests

- `test_subset_open_ended_bound_resolves_to_min_max` — `"5-"`, `"-2"`,
  `"-"`, mixed `"0-3,5-,7"`, garbage `"x"`, against a `min:0 max:7`
  editor.
- `test_subset_open_ended_bound_resolves_via_names_when_no_min_max` —
  enum editor, bound resolved from `names` extremes.
- `test_subset_open_ended_bound_skipped_without_context` — no context
  → skipped, load survives (crash-safety floor).

Full editor-codec suite green (41 passed); schema + controller suites
green (169 passed).

Closes shbatm/hacs-udi-iox#71

🤖 Generated with [Claude Code](https://claude.com/claude-code)