### PR TITLE
fix(ws): hold SYNCING through the post-connect status replay

### DIFF
--- a/pyisyox/constants.py
+++ b/pyisyox/constants.py
@@ -18,6 +18,14 @@ class EventStreamStatus(StrEnum):
 
     LOST_CONNECTION = "lost_connection"
     CONNECTED = "connected"
+    #: Socket is open but the controller is still replaying every
+    #: node's *current* status (a burst of ST/DON/DOF frames that are
+    #: NOT live changes). Distinct from :attr:`INITIALIZING` (no socket
+    #: yet) and :attr:`CONNECTED` (replay drained, live events flowing).
+    #: Consumers that fire on events (e.g. HA ``event`` entities) should
+    #: treat frames received before ``CONNECTED`` as state sync, not
+    #: real events, to avoid spurious triggers on every (re)connect.
+    SYNCING = "stream_syncing"
     DISCONNECTED = "disconnected"
     START_UPDATES = "start_updates"
     STOP_UPDATES = "stop_updates"

--- a/pyisyox/runtime/ws.py
+++ b/pyisyox/runtime/ws.py
@@ -48,6 +48,15 @@ _LOGGER = logging.getLogger(__name__)
 #: After the last entry the reader stays at the cap (60 s).
 _BACKOFF_SCHEDULE: tuple[float, ...] = (1.0, 2.0, 5.0, 10.0, 30.0, 60.0)
 
+#: After the socket opens the controller replays every node's current
+#: status. The stream stays ``SYNCING`` until that burst goes quiet for
+#: ``_SYNC_QUIET_SECONDS`` (no frame), then flips to ``CONNECTED``.
+#: ``_SYNC_MAX_SECONDS`` is a hard cap so a chatty controller can never
+#: stall the stream in ``SYNCING`` forever. Module-level so tests can
+#: monkeypatch them small.
+_SYNC_QUIET_SECONDS: float = 1.0
+_SYNC_MAX_SECONDS: float = 10.0
+
 
 StatusListener = Callable[[EventStreamStatus], None]
 
@@ -60,7 +69,10 @@ class WebSocketEventStream:
     1. :meth:`start` schedules the read task and returns immediately.
     2. The task connects, dispatches frames, reconnects on transport
        errors, and pumps :class:`EventStreamStatus` notifications to
-       any registered status listener.
+       any registered status listener. On each connect it holds
+       ``SYNCING`` (not ``CONNECTED``) until the controller's initial
+       status replay drains, so consumers don't treat the replay as
+       live events.
     3. :meth:`stop` cancels the task and closes any active WS.
 
     The class deliberately keeps its surface narrow — the consumer is
@@ -72,11 +84,13 @@ class WebSocketEventStream:
         "_backoff_idx",
         "_client",
         "_dispatcher",
+        "_frame_count",
         "_last_event_at",
         "_path",
         "_status",
         "_status_listeners",
         "_stop_requested",
+        "_sync_task",
         "_task",
         "_ws",
     )
@@ -111,6 +125,10 @@ class WebSocketEventStream:
         self._status_listeners: list[StatusListener] = []
         self._status: EventStreamStatus = EventStreamStatus.NOT_STARTED
         self._last_event_at: datetime | None = None
+        #: Bumped on every text frame; the sync watcher samples it to
+        #: tell whether the post-connect status replay has gone quiet.
+        self._frame_count = 0
+        self._sync_task: asyncio.Task[None] | None = None
 
     # --- public API ----------------------------------------------------
 
@@ -133,7 +151,11 @@ class WebSocketEventStream:
 
         Convenience over comparing :attr:`status` directly. Note
         that ``connected`` flipping ``False`` doesn't mean the
-        reader has given up — it may be reconnecting.
+        reader has given up — it may be reconnecting, or in
+        :attr:`EventStreamStatus.SYNCING` (socket open but the
+        controller's initial status replay hasn't drained yet —
+        intentionally *not* "connected" so event consumers don't
+        treat the replay as live changes).
         """
         return self._status == EventStreamStatus.CONNECTED
 
@@ -241,12 +263,20 @@ class WebSocketEventStream:
 
         try:
             self._backoff_idx = 0  # successful connect resets backoff
-            self._notify(EventStreamStatus.CONNECTED)
+            # Socket is open, but the controller now replays every
+            # node's current status — a burst of ST/DON/DOF frames
+            # that are NOT live changes. Hold SYNCING until that burst
+            # drains so event consumers don't fire on the replay
+            # (spurious automation triggers on every connect/restart).
+            self._frame_count = 0
+            self._notify(EventStreamStatus.SYNCING)
+            self._sync_task = asyncio.create_task(self._promote_when_quiet(), name="pyisyox-ws-sync")
             async for msg in self._ws:
                 if self._stop_requested:
                     break
                 if msg.type == aiohttp.WSMsgType.TEXT:
                     self._last_event_at = datetime.now(UTC)
+                    self._frame_count += 1
                     if _LOGGER.isEnabledFor(LOG_VERBOSE):
                         _LOGGER.log(LOG_VERBOSE, "WS frame: %s", msg.data)
                     self._dispatcher.feed(msg.data)
@@ -257,11 +287,48 @@ class WebSocketEventStream:
                     break
                 # BINARY/PING/PONG — ignore.
         finally:
+            if self._sync_task is not None:
+                self._sync_task.cancel()
+                with _suppress_cancellation():
+                    await self._sync_task
+                self._sync_task = None
             current = self._ws
             self._ws = None
             if current is not None and not current.closed:
                 with _suppress_aiohttp_close():
                     await current.close()
+
+    async def _promote_when_quiet(self) -> None:
+        """Flip ``SYNCING`` → ``CONNECTED`` once the post-connect status
+        replay goes quiet (or the hard cap elapses).
+
+        Sampled rather than event-driven so the hot read loop stays a
+        plain ``async for``: every ``_SYNC_QUIET_SECONDS`` we check
+        whether any frame arrived since the last sample. The first idle
+        window means the replay drained (a silent controller promotes
+        after one window). ``_SYNC_MAX_SECONDS`` caps the wait so a
+        perpetually chatty controller still goes live. Cancelled by
+        :meth:`_connect_and_read`'s ``finally`` if the socket drops
+        first, so a connection that never settles never reports
+        ``CONNECTED``.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _SYNC_MAX_SECONDS
+        seen = self._frame_count
+        while not self._stop_requested:
+            await asyncio.sleep(_SYNC_QUIET_SECONDS)
+            # Local copy — mypy narrows ``self._stop_requested`` to its
+            # loop-entry value across the await; the read loop / stop()
+            # may flip it during the sleep (same idiom as ``_run``).
+            stopping: bool = self._stop_requested
+            if stopping:
+                return
+            quiet = self._frame_count == seen
+            seen = self._frame_count
+            if quiet or loop.time() >= deadline:
+                break
+        if not self._stop_requested and self._status == EventStreamStatus.SYNCING:
+            self._notify(EventStreamStatus.CONNECTED)
 
     async def _auth_kwargs(self) -> dict:
         """Authenticate (if not already) and gather aiohttp kwargs."""

--- a/pyisyox/runtime/ws.py
+++ b/pyisyox/runtime/ws.py
@@ -356,7 +356,17 @@ class WebSocketEventStream:
         await asyncio.sleep(delay)
 
     def _notify(self, status: EventStreamStatus) -> None:
-        """Fan a status update out to listeners; suppress listener errors."""
+        """Fan a status update out to listeners; suppress listener errors.
+
+        Logs every lifecycle transition at DEBUG (``pyisyox.runtime.ws``)
+        so the connect → SYNCING → CONNECTED → reconnect sequence is
+        visible in consumer debug logs without attaching a listener.
+        Only real changes are logged — a status re-notified with the
+        same value (e.g. ``INITIALIZING`` each reconnect attempt) is not
+        repeated.
+        """
+        if status != self._status:
+            _LOGGER.debug("WS stream status: %s -> %s", self._status, status)
         self._status = status
         for listener in tuple(self._status_listeners):
             try:

--- a/pyisyox/runtime/ws.py
+++ b/pyisyox/runtime/ws.py
@@ -304,10 +304,18 @@ class WebSocketEventStream:
 
         Sampled rather than event-driven so the hot read loop stays a
         plain ``async for``: every ``_SYNC_QUIET_SECONDS`` we check
-        whether any frame arrived since the last sample. The first idle
-        window means the replay drained (a silent controller promotes
-        after one window). ``_SYNC_MAX_SECONDS`` caps the wait so a
-        perpetually chatty controller still goes live. Cancelled by
+        whether any frame arrived since the last sample.
+
+        Invariant: a window in which ``_frame_count`` did not change
+        from the previous sample is treated as quiet — including the
+        very first window when no frames have arrived yet (a silent
+        controller promotes after one window), and a fast replay that
+        both starts and finishes within a single window (a completed
+        replay *is* quiet). ``_SYNC_MAX_SECONDS`` caps the wait so a
+        perpetually chatty controller still goes live (note the cap is
+        only evaluated after each ``_SYNC_QUIET_SECONDS`` sample, so
+        effective max ≈ next sample boundary ≥ deadline — fine because
+        the real config has quiet ≪ max). Cancelled by
         :meth:`_connect_and_read`'s ``finally`` if the socket drops
         first, so a connection that never settles never reports
         ``CONNECTED``.
@@ -317,9 +325,9 @@ class WebSocketEventStream:
         seen = self._frame_count
         while not self._stop_requested:
             await asyncio.sleep(_SYNC_QUIET_SECONDS)
-            # Local copy — mypy narrows ``self._stop_requested`` to its
-            # loop-entry value across the await; the read loop / stop()
-            # may flip it during the sleep (same idiom as ``_run``).
+            # Read into a local so mypy doesn't narrow `_stop_requested`
+            # to its loop-entry value across the await above (same idiom
+            # as `_run`); stop() flips it during the sleep.
             stopping: bool = self._stop_requested
             if stopping:
                 return

--- a/tests/test_runtime/test_ws.py
+++ b/tests/test_runtime/test_ws.py
@@ -729,6 +729,8 @@ async def test_ws_reader_max_cap_promotes_under_constant_traffic(
     assert EventStreamStatus.CONNECTED in statuses
     # Traffic really was continuous (never went quiet on its own).
     assert frame_count > 5
-    # Did not promote at the first quiet window (~0.05s) as if idle;
-    # waited ~ the 0.2s cap (generous lower bound for loaded CI).
+    # Bound derivation: > 2x the 0.05s quiet window proves no quiet
+    # sample slipped through and promoted early; the only path left is
+    # the 0.2s cap. 0.12 sits between 2*quiet (0.10) and the 0.2 cap —
+    # generous low bound for loaded CI without reaching the cap value.
     assert elapsed >= 0.12

--- a/tests/test_runtime/test_ws.py
+++ b/tests/test_runtime/test_ws.py
@@ -49,17 +49,25 @@ class FakeWebSocket:
     """Minimal aiohttp.ClientWebSocketResponse stand-in."""
 
     def __init__(
-        self, frames: Iterable[FakeWSMessage], *, keep_open: bool = False
+        self,
+        frames: Iterable[FakeWSMessage],
+        *,
+        keep_open: bool = False,
+        repeat: FakeWSMessage | None = None,
     ) -> None:
         self._frames = list(frames)
         self.closed = False
         self._exception: BaseException | None = None
         self.close_called = False
-        # When True, after the scripted frames are exhausted the socket
+        # keep_open: after the scripted frames are exhausted the socket
         # stays open (blocks in __anext__) until close() — lets a test
         # exercise the SYNCING->CONNECTED quiet timer without the socket
         # tearing down first.
+        # repeat: after the scripted frames, keep emitting this frame
+        # forever (continuous traffic) so the stream never goes quiet —
+        # exercises the _SYNC_MAX_SECONDS hard cap.
         self._keep_open = keep_open
+        self._repeat = repeat
         self._closed_evt = asyncio.Event()
 
     def __aiter__(self) -> FakeWebSocket:
@@ -71,7 +79,14 @@ class FakeWebSocket:
         if self._frames:
             await asyncio.sleep(0)
             return self._frames.pop(0)
+        if self._repeat is not None:
+            await asyncio.sleep(0)
+            return self._repeat
         if self._keep_open:
+            # close() sets self.closed AND fires the event; the await
+            # returns, then the self.closed guard on the next __anext__
+            # ends the loop. The fall-through StopAsyncIteration covers
+            # the (rare) case the iterator is re-entered post-close.
             await self._closed_evt.wait()
         raise StopAsyncIteration
 
@@ -100,9 +115,13 @@ class FakeWSSession:
         self._scripted: list[FakeWebSocket | BaseException] = []
 
     def queue_success(
-        self, frames: Iterable[FakeWSMessage], *, keep_open: bool = False
+        self,
+        frames: Iterable[FakeWSMessage],
+        *,
+        keep_open: bool = False,
+        repeat: FakeWSMessage | None = None,
     ) -> FakeWebSocket:
-        ws = FakeWebSocket(frames, keep_open=keep_open)
+        ws = FakeWebSocket(frames, keep_open=keep_open, repeat=repeat)
         self._scripted.append(ws)
         return ws
 
@@ -257,6 +276,10 @@ async def test_ws_reader_holds_syncing_through_replay_then_connects(
         if nodes["3D 7D 87 1"].properties["ST"].formatted == "On":
             break
         await asyncio.sleep(0.005)
+    # Flush any task scheduled on the same tick as the property flip so
+    # the SYNCING assertion can't race a same-tick quiet-timer promote.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
 
     # Replay dispatched (state synced) but we're still SYNCING, not live.
     assert nodes["3D 7D 87 1"].properties["ST"].formatted == "On"
@@ -657,3 +680,55 @@ async def test_ws_reader_logs_status_transitions(
     assert "WS stream status:" in transitions
     assert "stream_syncing" in transitions
     assert "connected" in transitions
+
+
+@pytest.mark.asyncio
+async def test_ws_reader_max_cap_promotes_under_constant_traffic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A controller that never goes quiet (continuous traffic) must
+    still promote SYNCING -> CONNECTED at the _SYNC_MAX_SECONDS hard
+    cap, not stall in SYNCING forever, and not promote early as if the
+    flood were quiet."""
+    monkeypatch.setattr(ws_module, "_SYNC_QUIET_SECONDS", 0.05)
+    monkeypatch.setattr(ws_module, "_SYNC_MAX_SECONDS", 0.2)
+    session = FakeWSSession()
+    # Heartbeat-ish frame repeated forever -> _frame_count keeps moving,
+    # so the quiet check is never satisfied; only the cap can promote.
+    session.queue_success(
+        [],
+        repeat=_text_frame(
+            '<Event seqnum="1"><control>_0</control>'
+            "<action>0</action><node></node></Event>"
+        ),
+    )
+    client = _make_client(session)
+    stream = WebSocketEventStream(client, EventDispatcher({}))
+    statuses: list[EventStreamStatus] = []
+    stream.add_status_listener(statuses.append)
+
+    loop = asyncio.get_running_loop()
+    stream.start()
+    # Wait for SYNCING first (socket open) to time the cap from there.
+    for _ in range(200):
+        if stream.status == EventStreamStatus.SYNCING:
+            break
+        await asyncio.sleep(0.005)
+    t_syncing = loop.time()
+    for _ in range(400):
+        if stream.status == EventStreamStatus.CONNECTED:
+            break
+        await asyncio.sleep(0.01)
+    # Capture before stop() — stop() notifies DISCONNECTED.
+    elapsed = loop.time() - t_syncing
+    reached_connected = stream.status == EventStreamStatus.CONNECTED
+    frame_count = stream._frame_count
+    await stream.stop()
+
+    assert reached_connected  # cap honored, didn't stall in SYNCING
+    assert EventStreamStatus.CONNECTED in statuses
+    # Traffic really was continuous (never went quiet on its own).
+    assert frame_count > 5
+    # Did not promote at the first quiet window (~0.05s) as if idle;
+    # waited ~ the 0.2s cap (generous lower bound for loaded CI).
+    assert elapsed >= 0.12

--- a/tests/test_runtime/test_ws.py
+++ b/tests/test_runtime/test_ws.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any
@@ -625,3 +626,34 @@ async def test_ws_reader_does_not_dispatch_after_stop() -> None:
     # Whether either frame landed depends on scheduling — but the loop
     # must terminate cleanly without errors.
     assert stream._task is None
+
+
+@pytest.mark.asyncio
+async def test_ws_reader_logs_status_transitions(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Lifecycle transitions are logged at DEBUG so the
+    connect → SYNCING → CONNECTED sequence is visible without a
+    listener attached."""
+    monkeypatch.setattr(ws_module, "_SYNC_QUIET_SECONDS", 0.02)
+    monkeypatch.setattr(ws_module, "_SYNC_MAX_SECONDS", 0.5)
+    session = FakeWSSession()
+    session.queue_success([], keep_open=True)
+    client = _make_client(session)
+    stream = WebSocketEventStream(client, EventDispatcher({}))
+
+    with caplog.at_level(logging.DEBUG, logger="pyisyox.runtime.ws"):
+        stream.start()
+        for _ in range(200):
+            if stream.status == EventStreamStatus.CONNECTED:
+                break
+            await asyncio.sleep(0.01)
+        await stream.stop()
+
+    transitions = "\n".join(
+        r.getMessage() for r in caplog.records if r.name == "pyisyox.runtime.ws"
+    )
+    assert "WS stream status:" in transitions
+    assert "stream_syncing" in transitions
+    assert "connected" in transitions

--- a/tests/test_runtime/test_ws.py
+++ b/tests/test_runtime/test_ws.py
@@ -47,24 +47,37 @@ class FakeWSMessage:
 class FakeWebSocket:
     """Minimal aiohttp.ClientWebSocketResponse stand-in."""
 
-    def __init__(self, frames: Iterable[FakeWSMessage]) -> None:
+    def __init__(
+        self, frames: Iterable[FakeWSMessage], *, keep_open: bool = False
+    ) -> None:
         self._frames = list(frames)
         self.closed = False
         self._exception: BaseException | None = None
         self.close_called = False
+        # When True, after the scripted frames are exhausted the socket
+        # stays open (blocks in __anext__) until close() — lets a test
+        # exercise the SYNCING->CONNECTED quiet timer without the socket
+        # tearing down first.
+        self._keep_open = keep_open
+        self._closed_evt = asyncio.Event()
 
     def __aiter__(self) -> FakeWebSocket:
         return self
 
     async def __anext__(self) -> FakeWSMessage:
-        if self.closed or not self._frames:
+        if self.closed:
             raise StopAsyncIteration
-        await asyncio.sleep(0)
-        return self._frames.pop(0)
+        if self._frames:
+            await asyncio.sleep(0)
+            return self._frames.pop(0)
+        if self._keep_open:
+            await self._closed_evt.wait()
+        raise StopAsyncIteration
 
     async def close(self) -> None:
         self.close_called = True
         self.closed = True
+        self._closed_evt.set()
 
     def exception(self) -> BaseException | None:
         return self._exception
@@ -85,8 +98,10 @@ class FakeWSSession:
         # Each entry is one of: FakeWebSocket (success) | Exception (raise).
         self._scripted: list[FakeWebSocket | BaseException] = []
 
-    def queue_success(self, frames: Iterable[FakeWSMessage]) -> FakeWebSocket:
-        ws = FakeWebSocket(frames)
+    def queue_success(
+        self, frames: Iterable[FakeWSMessage], *, keep_open: bool = False
+    ) -> FakeWebSocket:
+        ws = FakeWebSocket(frames, keep_open=keep_open)
         self._scripted.append(ws)
         return ws
 
@@ -163,11 +178,17 @@ async def test_ws_reader_dispatches_property_update() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ws_reader_emits_status_lifecycle() -> None:
+async def test_ws_reader_emits_status_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ws_module, "_SYNC_QUIET_SECONDS", 0.02)
+    monkeypatch.setattr(ws_module, "_SYNC_MAX_SECONDS", 0.5)
     nodes: dict[str, NodeRecord] = {}
     dispatcher = EventDispatcher(nodes)
     session = FakeWSSession()
-    session.queue_success([_closed_frame()])
+    # Socket stays open with no frames -> the quiet timer promotes
+    # SYNCING -> CONNECTED.
+    session.queue_success([], keep_open=True)
     client = _make_client(session)
     stream = WebSocketEventStream(client, dispatcher)
 
@@ -175,16 +196,84 @@ async def test_ws_reader_emits_status_lifecycle() -> None:
     stream.add_status_listener(statuses.append)
 
     stream.start()
-    for _ in range(50):
+    for _ in range(200):
         if EventStreamStatus.CONNECTED in statuses:
             break
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
     await stream.stop()
 
-    # Successful connect emits INITIALIZING -> CONNECTED, stop() emits DISCONNECTED.
+    # Connect now emits INITIALIZING -> SYNCING -> CONNECTED, in that
+    # order; stop() emits DISCONNECTED last.
     assert EventStreamStatus.INITIALIZING in statuses
+    assert EventStreamStatus.SYNCING in statuses
     assert EventStreamStatus.CONNECTED in statuses
+    assert statuses.index(EventStreamStatus.SYNCING) < statuses.index(
+        EventStreamStatus.CONNECTED
+    )
     assert statuses[-1] == EventStreamStatus.DISCONNECTED
+
+
+@pytest.mark.asyncio
+async def test_ws_reader_holds_syncing_through_replay_then_connects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The post-connect status replay must dispatch (records update)
+    while the stream stays SYNCING — CONNECTED only after it goes
+    quiet. This is the guard against spurious event-entity fires on
+    every (re)connect/restart."""
+    monkeypatch.setattr(ws_module, "_SYNC_QUIET_SECONDS", 0.2)
+    monkeypatch.setattr(ws_module, "_SYNC_MAX_SECONDS", 3.0)
+    nodes = {
+        "3D 7D 87 1": NodeRecord(
+            address="3D 7D 87 1",
+            name="Test",
+            nodedef_id="X",
+            family_id="1",
+            instance_id="1",
+            properties={"ST": NodePropertyValue(id="ST", value="0", formatted="Off")},
+        )
+    }
+    dispatcher = EventDispatcher(nodes)
+    session = FakeWSSession()
+    session.queue_success(
+        [
+            _text_frame(
+                '<Event seqnum="1"><control>ST</control>'
+                '<action uom="100">255</action>'
+                "<node>3D 7D 87 1</node><fmtAct>On</fmtAct></Event>"
+            )
+        ],
+        keep_open=True,
+    )
+    client = _make_client(session)
+    stream = WebSocketEventStream(client, dispatcher)
+    statuses: list[EventStreamStatus] = []
+    stream.add_status_listener(statuses.append)
+
+    stream.start()
+    # Wait for the replayed frame to dispatch into the record.
+    for _ in range(200):
+        if nodes["3D 7D 87 1"].properties["ST"].formatted == "On":
+            break
+        await asyncio.sleep(0.005)
+
+    # Replay dispatched (state synced) but we're still SYNCING, not live.
+    assert nodes["3D 7D 87 1"].properties["ST"].formatted == "On"
+    assert stream.status == EventStreamStatus.SYNCING
+    assert stream.connected is False
+    assert EventStreamStatus.CONNECTED not in statuses
+
+    # After the quiet window the stream goes live.
+    for _ in range(200):
+        if stream.status == EventStreamStatus.CONNECTED:
+            break
+        await asyncio.sleep(0.01)
+    await stream.stop()
+
+    assert EventStreamStatus.CONNECTED in statuses
+    assert statuses.index(EventStreamStatus.SYNCING) < statuses.index(
+        EventStreamStatus.CONNECTED
+    )
 
 
 @pytest.mark.asyncio
@@ -225,11 +314,15 @@ async def test_ws_reader_attaches_local_auth() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ws_reader_drops_listener_exceptions() -> None:
+async def test_ws_reader_drops_listener_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A status listener that raises must not break the loop or stop other
     listeners from firing."""
+    monkeypatch.setattr(ws_module, "_SYNC_QUIET_SECONDS", 0.02)
+    monkeypatch.setattr(ws_module, "_SYNC_MAX_SECONDS", 0.5)
     session = FakeWSSession()
-    session.queue_success([_closed_frame()])
+    session.queue_success([], keep_open=True)
     client = _make_client(session)
     stream = WebSocketEventStream(client, EventDispatcher({}))
 
@@ -238,10 +331,10 @@ async def test_ws_reader_drops_listener_exceptions() -> None:
     stream.add_status_listener(received.append)
 
     stream.start()
-    for _ in range(50):
+    for _ in range(200):
         if EventStreamStatus.CONNECTED in received:
             break
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
     await stream.stop()
 
     assert EventStreamStatus.CONNECTED in received
@@ -392,9 +485,11 @@ async def test_ws_reader_401_recoverable_retries_handshake(
         async def close(self, _session: object, _base: str) -> None:
             return None
 
+    monkeypatch.setattr(ws_module, "_SYNC_QUIET_SECONDS", 0.02)
+    monkeypatch.setattr(ws_module, "_SYNC_MAX_SECONDS", 0.5)
     session = FakeWSSession()
     session.queue_failure(_ws_handshake_error(401))
-    session.queue_success([_closed_frame()])
+    session.queue_success([], keep_open=True)
     auth = _RecoverableAuth()
     client = IoXClient(BASE, auth, session)  # type: ignore[arg-type]
     client._authenticated = True
@@ -407,7 +502,7 @@ async def test_ws_reader_401_recoverable_retries_handshake(
     for _ in range(200):
         if EventStreamStatus.CONNECTED in statuses:
             break
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
     await stream.stop()
 
     assert auth.recover_calls == 1
@@ -423,9 +518,11 @@ async def test_ws_reader_non_401_handshake_error_triggers_reconnect(
     catches the exception, notifies ``LOST_CONNECTION`` /
     ``RECONNECTING``, and retries (which succeeds here)."""
     monkeypatch.setattr(ws_module, "_BACKOFF_SCHEDULE", (0.0,))
+    monkeypatch.setattr(ws_module, "_SYNC_QUIET_SECONDS", 0.02)
+    monkeypatch.setattr(ws_module, "_SYNC_MAX_SECONDS", 0.5)
     session = FakeWSSession()
     session.queue_failure(_ws_handshake_error(500))
-    session.queue_success([_closed_frame()])
+    session.queue_success([], keep_open=True)
     client = _make_client(session)
     stream = WebSocketEventStream(client, EventDispatcher({}))
 
@@ -436,7 +533,7 @@ async def test_ws_reader_non_401_handshake_error_triggers_reconnect(
     for _ in range(200):
         if EventStreamStatus.CONNECTED in statuses:
             break
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
     await stream.stop()
 
     assert EventStreamStatus.LOST_CONNECTION in statuses
@@ -453,9 +550,11 @@ async def test_ws_reader_generic_exception_triggers_reconnect(
     must still flow through the reconnect path rather than killing
     the reader task."""
     monkeypatch.setattr(ws_module, "_BACKOFF_SCHEDULE", (0.0,))
+    monkeypatch.setattr(ws_module, "_SYNC_QUIET_SECONDS", 0.02)
+    monkeypatch.setattr(ws_module, "_SYNC_MAX_SECONDS", 0.5)
     session = FakeWSSession()
     session.queue_failure(RuntimeError("transient"))
-    session.queue_success([_closed_frame()])
+    session.queue_success([], keep_open=True)
     client = _make_client(session)
     stream = WebSocketEventStream(client, EventDispatcher({}))
 
@@ -466,7 +565,7 @@ async def test_ws_reader_generic_exception_triggers_reconnect(
     for _ in range(200):
         if EventStreamStatus.CONNECTED in statuses:
             break
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
     await stream.stop()
 
     assert EventStreamStatus.RECONNECTING in statuses


### PR DESCRIPTION
## Problem

The controller replays **every node's current status** (a burst of `ST`/`DON`/`DOF` frames) over the WebSocket on every connect. `WebSocketEventStream` notified `EventStreamStatus.CONNECTED` the instant the socket opened — *before* that burst arrives in the read loop. Consumers that fire on events (most notably Home Assistant `event` entities in `hacs-udi-iox`) therefore treated the replayed status as **live changes**, producing spurious automation triggers on every HA restart, config-entry reload, and WS reconnect.

Empirically reproduced against the IoX-Testing controller: device-triggers, plain state-triggers, and attribute state-triggers on a udi_iox `event` entity all fired with **zero user action** on both a config-entry reload and a full HA restart (`on`+`off` each).

## Fix

Add `EventStreamStatus.SYNCING` — socket is open but the initial status replay is still draining. The reader holds `SYNCING` and only flips to `CONNECTED` once the burst goes quiet for `_SYNC_QUIET_SECONDS` (1.0 s with no frame), with a `_SYNC_MAX_SECONDS` (10 s) hard cap so a perpetually chatty controller can't stall the stream. A small sampled watcher task (`_promote_when_quiet`) does the debounce so the hot read loop stays a plain `async for`; it's cancelled in `_connect_and_read`'s `finally`, so a socket that drops before settling never reports `CONNECTED`.

- Records **still update** during `SYNCING` (the dispatcher keeps feeding, so node/property state stays correct) — only the "stream is live" signal is withheld.
- Re-armed on every reconnect, so the WS-reconnect case is fixed too, not just restart/reload.
- `connected` / `== CONNECTED` consumers are unchanged structurally; they simply see `connected` go true ~1 s later (after the replay), which is the intended behavior.

## Consumer follow-up (separate, in hacs-udi-iox)

`event.py::_on_control` will gate emission on the synced flag (the existing `subscribe_ws_status` → `connected: bool` plumbing already maps `== CONNECTED`). Not in this PR — pyisyox capability lands first; consumer policy follows.

## Tests

- `test_ws.py`: `FakeWebSocket` gained an additive `keep_open` (socket stays open with no frames so the quiet timer can be exercised); `_SYNC_*` are module-level for monkeypatching.
- Rewrote the lifecycle assertions to `INITIALIZING → SYNCING → CONNECTED`; the reconnect-path tests now reach a live connection via `keep_open` instead of an instant-close.
- New `test_ws_reader_holds_syncing_through_replay_then_connects`: a replayed frame **dispatches into the record** while the stream is still `SYNCING` and `connected is False`, and `CONNECTED` is only emitted after the quiet window.
- Full suite: **836 passed**; ruff / ruff-format / mypy / pylint (10.00) / codespell / pre-commit all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)