### PR TITLE
fix(testing): PluginDimmer DON takes an on-level param so it classifies LIGHT

### DIFF
--- a/pyisyox/testing/__init__.py
+++ b/pyisyox/testing/__init__.py
@@ -903,9 +903,12 @@ _PG_BOOL_EDITOR = {
 
 
 def _build_plugin_dimmer_nodedef() -> NodeDef:
-    """PG3-shape dimmer nodedef — ``DON``/``DOF`` (light controllable),
-    a ``SETMODE`` setter on a pure-enum editor (→ SELECT) and a
-    ``THRESHOLD`` setter on the ``INTEGER`` editor (→ NUMBER)."""
+    """PG3-shape dimmer nodedef — ``DON`` (with an on-level param) /
+    ``DOF`` so it classifies LIGHT (post-#158 a *parameterless* ``DON``
+    is SWITCH; the on-level param is what makes HA's brightness slider
+    work, hence LIGHT), a ``SETMODE`` setter on a pure-enum editor
+    (→ SELECT) and a ``THRESHOLD`` setter on the ``INTEGER`` editor
+    (→ NUMBER)."""
     return NodeDef.from_json(
         {
             "id": PLUGIN_DIMMER_NODEDEF_ID,
@@ -914,7 +917,11 @@ def _build_plugin_dimmer_nodedef() -> NodeDef:
             "cmds": {
                 "sends": [],
                 "accepts": [
-                    {"id": "DON", "name": "On"},
+                    {
+                        "id": "DON",
+                        "name": "On",
+                        "parameters": [{"id": "", "editor": "I_OL"}],
+                    },
                     {"id": "DOF", "name": "Off"},
                     {"id": "BRT", "name": "Brighten"},
                     {"id": "DIM", "name": "Dim"},

--- a/tests/test_testing/test_builders.py
+++ b/tests/test_testing/test_builders.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from pyisyox import ControllablePlatform, classify
 from pyisyox.client import (
     FolderRecord,
     GroupRecord,
@@ -49,6 +50,8 @@ from pyisyox.testing import (
     NODEDEF_FOR_PLATFORM,
     PLUGIN_COVER_FAMILY_ID,
     PLUGIN_DIMMER_FAMILY_ID,
+    PLUGIN_DIMMER_INSTANCE_ID,
+    PLUGIN_DIMMER_NODEDEF_ID,
     PLUGIN_HUB_FAMILY_ID,
     PLUGIN_TRIGGER_FAMILY_ID,
     RecordedCall,
@@ -407,6 +410,21 @@ def test_dimmer_plugin_profile_grafts_family_103_with_editors() -> None:
     rec = make_plugin_dimmer_node_record()
     lr = make_dimmer_plugin_load_result(nodes={rec.address: rec})
     assert PLUGIN_DIMMER_FAMILY_ID in lr.profile.families
+
+
+def test_dimmer_plugin_nodedef_classifies_light() -> None:
+    """Regression guard for #159: the PluginDimmer fixture's ``DON``
+    carries an on-level param, so it must classify LIGHT. A
+    parameterless ``DON`` would degrade to SWITCH post-#158 and
+    silently contradict the fixture's name/docstring."""
+    profile = make_profile_with_dimmer_plugin()
+    nd = profile.find_nodedef(
+        PLUGIN_DIMMER_NODEDEF_ID,
+        PLUGIN_DIMMER_FAMILY_ID,
+        PLUGIN_DIMMER_INSTANCE_ID,
+    )
+    assert nd is not None
+    assert classify(nd).controllable is ControllablePlatform.LIGHT
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #159

## Problem

`pyisyox/testing/__init__.py` `_build_plugin_dimmer_nodedef()` is named/exposed as a dimmer (`PLUGIN_DIMMER_NODEDEF_ID = "PluginDimmer"`, docstring "light controllable") but its `DON` was **parameterless**:

```python
{"id": "DON", "name": "On"},
```

Post-#158, a parameterless `DON` correctly classifies as **SWITCH** (HA can't drive brightness via a bare `DON`). The fixture's name/docstring then contradicted its actual classification. The pyisyox suite never asserted its `controllable`, so it slipped through; it surfaced downstream in hacs-udi-iox's suite.

## Fix — resolution (1) from the issue (maintainer-preferred)

Give `DON` an `I_OL` on-level param so it genuinely classifies LIGHT (the on-level param is exactly what `_detect_controllable`'s `on_takes_level` looks for; combined with the fixture's existing `BRT`/`DIM` dimmer hints → LIGHT). The fixture's name/docstring are now accurate. Param style matches the fixture's own `SETMODE`/`THRESHOLD` params (`{"id": "", "editor": "..."}`).

Docstring updated to state *why* the param matters (so it can't be "cleaned up" back to parameterless).

## Regression guard

New `test_dimmer_plugin_nodedef_classifies_light` asserts `classify(nd).controllable is ControllablePlatform.LIGHT` — the assertion the issue explicitly asked for, so the fixture can't silently drift again.

## Verification

- New test passes; **full suite 839 passed** — no regressions, confirming nothing in the pyisyox suite relied on the old SWITCH misclassification.
- ruff / ruff-format / mypy / pylint(10) / codespell / pre-commit green.

Test-infra only; not user-facing. Pairs with #170 for the upcoming beta bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)