### PR TITLE
feat(group): target-aware scene status from /api/groups link data

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -30,10 +30,11 @@ from xml.etree import ElementTree as ET
 import aiohttp
 
 from pyisyox.auth import Auth, AuthError
-from pyisyox.constants import NodeFlag
+from pyisyox.constants import CMD_OFF, CMD_OFF_FAST, CMD_ON, CMD_ON_FAST, NodeFlag
 from pyisyox.logging import LOG_VERBOSE
 from pyisyox.paths import (
     CONFIG_PATH,
+    GROUPS_PATH,
     NETWORK_RESOURCE_ITEM_PATH,
     NETWORKING_RESOURCES_PATH,
     NLS_PATH,
@@ -257,6 +258,17 @@ class GroupRecord:
     #: as scene controllers (rather than responders). Empty when the group has
     #: no explicit controller (e.g. SmartLinc-style virtual scenes).
     controller_addresses: tuple[str, ...] = ()
+    #: Per-member scene intent resolved from ``/api/groups`` link targets:
+    #: address → ``"on"`` | ``"off"`` | ``"discard"``. Empty when
+    #: ``/api/groups`` was unavailable or the group wasn't present there.
+    member_intents: dict[str, str] = field(default_factory=dict)
+    #: ``True`` iff the group's link targets were found *and* every link
+    #: resolved to a known intent (no unknown link ``type``, no ``native``
+    #: link missing its ``OL`` param). When ``False``, consumers fall back
+    #: to the legacy all-member ``ST`` aggregate. A *resolved* group with
+    #: no ``"on"`` members (fire-only / config-only scene) keeps this
+    #: ``True`` with an empty or all-``off``/``discard`` ``member_intents``.
+    targets_resolved: bool = False
 
 
 @dataclass(slots=True)
@@ -415,6 +427,7 @@ class IoXClient:
             vars_int_raw,
             vars_state_raw,
             networking_xml,
+            api_groups_raw,
         ) = await asyncio.gather(
             self._get_json(PROFILES_PATH),
             self._get_json(NODES_PATH),
@@ -428,6 +441,10 @@ class IoXClient:
             # the parser; we don't want a 404 here to abort load, so
             # we fall back to an empty document on HTTP errors.
             self._get_text_or_empty(NETWORKING_RESOURCES_PATH),
+            # /api/groups enriches group membership with per-member
+            # scene-target intent. Optional (absent on older firmware) —
+            # a 404 falls back to {} and groups keep legacy aggregation.
+            self._get_json_or_empty(GROUPS_PATH),
         )
 
         profile = Profile.load_from_json(profile_raw)
@@ -440,6 +457,7 @@ class IoXClient:
         # for LocalAuth (which doesn't expose ``/api/*``) and external
         # consumers that prefer the XML surface.
         groups, folders, root_name = parse_api_nodes_groups_folders(nodes_raw)
+        apply_group_link_targets(groups, api_groups_raw)
         await self._load_dynamic_zwave_nodedefs(profile, nodes)
 
         return LoadResult(
@@ -628,6 +646,16 @@ class IoXClient:
         except HTTPError as exc:
             _LOGGER.debug("optional endpoint %s unavailable: %s", path, exc)
             return ""
+
+    async def _get_json_or_empty(self, path: str) -> Any:
+        """``_get_json`` that swallows HTTPError → ``{}``. For optional
+        endpoints (``/api/groups``) absent on older firmware — a 404
+        here must not abort the load."""
+        try:
+            return await self._get_json(path)
+        except HTTPError as exc:
+            _LOGGER.debug("optional endpoint %s unavailable: %s", path, exc)
+            return {}
 
     async def send_node_command(self, address: str, command_id: str, *params: float | str) -> str:
         """Issue ``GET /rest/nodes/{addr}/cmd/{cmd}[/{p1}[/{p2}...]]``.
@@ -1065,6 +1093,99 @@ def parse_api_nodes_groups_folders(
         )
 
     return groups, folders, root_name
+
+
+#: cmd-link verbs that imply a steady on/off responder target. Anything
+#: else (``BL``, ``BEEP``, ``QUERY``, ``BRT``/``DIM``/``FD*``, ``SETST``…)
+#: is fire-only / config and contributes no on-state for that member.
+_CMD_ON_VERBS = frozenset({CMD_ON, CMD_ON_FAST})
+_CMD_OFF_VERBS = frozenset({CMD_OFF, CMD_OFF_FAST})
+
+#: native > cmd > default — when a member appears under more than one
+#: link in the canonical block the most-specific responder link wins.
+_LINK_PRECEDENCE = {"native": 3, "cmd": 2, "default": 1}
+
+
+def _link_intent(link: dict[str, Any]) -> str | None:
+    """Resolve one ``/api/groups`` link to a member intent.
+
+    Returns ``"on"`` / ``"off"`` / ``"discard"`` for a resolvable
+    responder link, ``""`` for ``type="ignore"`` (not a member), or
+    ``None`` when the link is ambiguous (unknown ``type``, or a
+    ``native`` link with no ``OL`` param) — which forces the whole
+    group back to the legacy aggregate.
+    """
+    ltype = str(link.get("type") or "")
+    if ltype == "ignore":
+        return ""
+    if ltype == "native":
+        for param in link.get("params") or []:
+            if param.get("id") == "OL":
+                value = (param.get("val") or {}).get("value")
+                if value is None:
+                    return None
+                return "on" if float(value) > 0 else "off"
+        return None  # native responder with no OL — ambiguous
+    if ltype == "cmd":
+        verb = str(link.get("cmd") or "")
+        if verb in _CMD_ON_VERBS:
+            return "on"
+        if verb in _CMD_OFF_VERBS:
+            return "off"
+        return "discard"  # BL/BEEP/QUERY/BRT/DIM/FD*/SETST/… — fire-only
+    if ltype == "default":
+        return "on"  # ISY forwards the scene command; state-tracked
+    return None  # unknown link type — ambiguous
+
+
+def apply_group_link_targets(groups: dict[str, GroupRecord], api_groups_raw: dict[str, Any]) -> None:
+    """Enrich ``GroupRecord``s in place with ``/api/groups`` link targets.
+
+    For each group the **canonical** ``ctl`` block — the one whose
+    ``id`` equals the group address — is the scene's own responder
+    definition (per-controller blocks describe cross-controller
+    behaviour, not the scene's resting target, so they're ignored).
+    Each link there resolves via :func:`_link_intent`; the highest
+    :data:`_LINK_PRECEDENCE` link wins when a node appears twice.
+
+    Sets ``member_intents`` + ``targets_resolved`` on the record. A
+    group not present in ``/api/groups`` (older firmware / 404 → empty
+    payload) is left ``targets_resolved=False`` so the consumer keeps
+    the legacy all-member behaviour. A present group whose canonical
+    block has no on-target links (fire-only / config-only / the special
+    auto-DR groups) is ``targets_resolved=True`` with no ``"on"``
+    members — i.e. reads OFF, matching the admin console.
+    """
+    data = api_groups_raw.get("data") if isinstance(api_groups_raw, dict) else None
+    entries = (data or {}).get("groups") or []
+    for entry in entries:
+        gid = str(entry.get("id") or "")
+        record = groups.get(gid)
+        if record is None:
+            continue
+        intents: dict[str, str] = {}
+        ranks: dict[str, int] = {}
+        resolved = True
+        for block in entry.get("ctl") or []:
+            if str(block.get("id") or "") != gid:
+                continue  # not the scene's canonical responder block
+            for link in block.get("links") or []:
+                intent = _link_intent(link)
+                if intent is None:
+                    resolved = False
+                    break
+                node = str(link.get("node") or "")
+                if not node or intent == "":
+                    continue  # ignore-link / malformed
+                rank = _LINK_PRECEDENCE.get(str(link.get("type") or ""), 0)
+                if rank >= ranks.get(node, -1):
+                    intents[node] = intent
+                    ranks[node] = rank
+            if not resolved:
+                break
+        if resolved:
+            record.member_intents = intents
+            record.targets_resolved = True
 
 
 def parse_api_nodes(raw: dict[str, Any]) -> dict[str, NodeRecord]:

--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -648,9 +648,10 @@ class IoXClient:
             return ""
 
     async def _get_json_or_empty(self, path: str) -> Any:
-        """``_get_json`` that swallows HTTPError → ``{}``. For optional
-        endpoints (``/api/groups``) absent on older firmware — a 404
-        here must not abort the load."""
+        """``_get_json`` that swallows any ``HTTPError`` → ``{}`` (404,
+        401, 500, …). For optional endpoints (``/api/groups``) absent on
+        older firmware — an error here must not abort the load. Mirrors
+        :meth:`_get_text_or_empty`."""
         try:
             return await self._get_json(path)
         except HTTPError as exc:
@@ -1117,6 +1118,8 @@ def _link_intent(link: dict[str, Any]) -> str | None:
     """
     ltype = str(link.get("type") or "")
     if ltype == "ignore":
+        # "" = skip just this link (not a member); distinct from None,
+        # which aborts resolution for the whole group.
         return ""
     if ltype == "native":
         for param in link.get("params") or []:
@@ -1178,7 +1181,11 @@ def apply_group_link_targets(groups: dict[str, GroupRecord], api_groups_raw: dic
                 if not node or intent == "":
                     continue  # ignore-link / malformed
                 rank = _LINK_PRECEDENCE.get(str(link.get("type") or ""), 0)
-                if rank >= ranks.get(node, -1):
+                # Strict ``>``: a higher-precedence link still wins
+                # (native > cmd > default), but among duplicate
+                # same-type links for a node the first-seen wins —
+                # safer than last-seen on unexpected malformed data.
+                if rank > ranks.get(node, -1):
                     intents[node] = intent
                     ranks[node] = rank
             if not resolved:

--- a/pyisyox/paths.py
+++ b/pyisyox/paths.py
@@ -25,6 +25,14 @@ CONFIG_PATH = "/api/config"
 #: parent/pnode, flags). Plugin nodes have no ``property[]`` field.
 NODES_PATH = "/api/nodes"
 
+#: ``GET /api/groups`` — per-group controller→responder link records,
+#: including each responder's scene on-level target (``OL`` param). Used
+#: to enrich the group membership from ``/api/nodes`` with per-member
+#: scene intent (on / off / discard) so scene status reflects the
+#: programmed target, not just any member being non-zero. Optional —
+#: absent on older firmware; the load is best-effort.
+GROUPS_PATH = "/api/groups"
+
 #: ``GET /api/programs`` — programs and program-folders.
 PROGRAMS_PATH = "/api/programs"
 

--- a/pyisyox/runtime/group.py
+++ b/pyisyox/runtime/group.py
@@ -54,7 +54,7 @@ def _is_on(record: NodeRecord) -> bool:
 class Group:
     """User-facing handle for one group / scene in the controller."""
 
-    __slots__ = ("_client", "_nodes", "_profile", "_record")
+    __slots__ = ("_client", "_dimmable_cache", "_nodes", "_profile", "_record")
 
     def __init__(
         self,
@@ -79,6 +79,10 @@ class Group:
         self._profile = profile
         self._client = client
         self._nodes = nodes
+        # Memoised `has_dimmable_members` — safe to cache because it's
+        # derived from member nodedefs (static for this record), unlike
+        # the live `group_*_on` aggregates which must re-read `ST`.
+        self._dimmable_cache: bool | None = None
 
     @classmethod
     def from_record(
@@ -206,17 +210,24 @@ class Group:
         commands — so "light" here is on/off only.
 
         Returns ``False`` without a node-registry reference. Members
-        missing from the registry are skipped (defensive).
+        missing from the registry are skipped (defensive). Memoised on
+        first access (one ``Node`` + ``find_nodedef`` per member) — the
+        result is static for this record, so repeated reads (e.g.
+        ``to_dict``) don't rebuild it.
         """
-        if self._nodes is None:
-            return False
-        for addr in self._record.member_addresses:
-            record = self._nodes.get(addr)
-            if record is None:
-                continue
-            if Node.from_record(record, self._profile, self._client).is_dimmable:
-                return True
-        return False
+        if self._dimmable_cache is not None:
+            return self._dimmable_cache
+        result = False
+        if self._nodes is not None:
+            for addr in self._record.member_addresses:
+                record = self._nodes.get(addr)
+                if record is None:
+                    continue
+                if Node.from_record(record, self._profile, self._client).is_dimmable:
+                    result = True
+                    break
+        self._dimmable_cache = result
+        return result
 
     @property
     def group_all_on(self) -> bool:

--- a/pyisyox/runtime/group.py
+++ b/pyisyox/runtime/group.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 from pyisyox.client import NodeType
 from pyisyox.constants import INSTEON_STATELESS_NODEDEFID, PROP_STATUS
+from pyisyox.runtime.node import Node
 
 if TYPE_CHECKING:
     from pyisyox.client import GroupRecord, IoXClient, NodeRecord
@@ -190,6 +191,34 @@ class Group:
         return any(intent in ("on", "off") for intent in self._record.member_intents.values())
 
     @property
+    def has_dimmable_members(self) -> bool:
+        """True iff any member node is a dimmable load.
+
+        Nodedef-derived via :attr:`pyisyox.runtime.Node.is_dimmable`,
+        so it's robust and — unlike :attr:`has_state_target` — does
+        **not** depend on ``/api/groups`` link resolution (works on
+        older firmware too). Consumers pair it with
+        :attr:`has_state_target` to pick the scene's HA platform:
+        no state target → **button**; else dimmable members → on/off
+        **light** (preserving light semantics + the group/more-info
+        framework, no ``switch_as_x``); else → **switch**. Scenes have
+        no settable brightness — fade/brt/dim are separate manual
+        commands — so "light" here is on/off only.
+
+        Returns ``False`` without a node-registry reference. Members
+        missing from the registry are skipped (defensive).
+        """
+        if self._nodes is None:
+            return False
+        for addr in self._record.member_addresses:
+            record = self._nodes.get(addr)
+            if record is None:
+                continue
+            if Node.from_record(record, self._profile, self._client).is_dimmable:
+                return True
+        return False
+
+    @property
     def group_all_on(self) -> bool:
         """True iff every on-target member currently reports an "on" state.
 
@@ -306,6 +335,7 @@ class Group:
         payload["group_all_on"] = self.group_all_on
         payload["group_any_on"] = self.group_any_on
         payload["has_state_target"] = self.has_state_target
+        payload["has_dimmable_members"] = self.has_dimmable_members
         return payload
 
     def __repr__(self) -> str:

--- a/pyisyox/runtime/group.py
+++ b/pyisyox/runtime/group.py
@@ -153,32 +153,73 @@ class Group:
     def _is_stateless(self, record: NodeRecord) -> bool:
         return record.nodedef_id in _STATELESS_NODEDEF_IDS
 
+    def _on_set(self) -> tuple[str, ...] | None:
+        """Member addresses the scene drives *on*, or ``None`` for legacy.
+
+        When ``/api/groups`` link targets resolved (see
+        :attr:`pyisyox.client.GroupRecord.targets_resolved`) this is the
+        subset of members whose scene intent is ``"on"`` — the only
+        members whose ``ST`` defines whether the scene is active.
+        ``off`` / ``discard`` members and members the scene merely
+        fires a one-shot command at are excluded. A *resolved* scene
+        with no ``"on"`` members (fire-only / config-only / auto-DR)
+        yields an empty tuple → reads OFF, matching the admin console.
+
+        ``None`` means targets are unresolved (``/api/groups`` absent,
+        or an ambiguous link) → callers fall back to the legacy
+        all-member aggregate so behaviour never regresses.
+        """
+        if not self._record.targets_resolved:
+            return None
+        return tuple(addr for addr, intent in self._record.member_intents.items() if intent == "on")
+
+    @property
+    def has_state_target(self) -> bool:
+        """Whether the scene maintains any member on/off state.
+
+        ``True`` when link targets resolved and at least one member has
+        an ``on``/``off`` intent. A *resolved* scene with only fire-only
+        / config links (``cmd`` ``BL``/``BEEP``/…, or empty) → ``False``:
+        it has no steady state, so a consumer should model it as a
+        momentary **button**, not a switch. When targets are unresolved
+        we can't tell, so assume ``True`` (the safe default — keep it a
+        stateful scene).
+        """
+        if not self._record.targets_resolved:
+            return True
+        return any(intent in ("on", "off") for intent in self._record.member_intents.values())
+
     @property
     def group_all_on(self) -> bool:
-        """True iff every stateful member node currently reports an "on" state.
+        """True iff every on-target member currently reports an "on" state.
 
-        Computed on access from the controller's node registry. Stateless
-        members — motion sensors, RemoteLincs, binary-alarm devices, see
-        :data:`_STATELESS_NODEDEF_IDS` — are excluded; their ``ST`` isn't
-        a persistent state. Returns ``False`` when:
+        Computed on access from the controller's node registry.
+        Stateless members — motion sensors, RemoteLincs, binary-alarm
+        devices, see :data:`_STATELESS_NODEDEF_IDS` — are excluded;
+        their ``ST`` isn't a persistent state.
 
-        * the group was constructed without a node-registry reference
-          (the optional ``nodes`` arg to :meth:`from_record`);
-        * the group has no stateful members;
-        * any stateful member is not currently in the registry (defensive
-          — the member may have been removed since load and the controller
-          hasn't surfaced the lifecycle event yet);
-        * any stateful member's ``ST`` property is missing or zero.
+        When ``/api/groups`` link targets resolved, the aggregate is
+        over the scene's **on-target** members only (see
+        :meth:`_on_set`) — so a radio-style keypad scene (one button
+        on-target, the rest driven off) tracks correctly instead of
+        being structurally never-all-on. Otherwise it falls back to the
+        legacy all-member behaviour. Returns ``False`` when the group
+        has no node-registry reference, the (on-target / member) set is
+        empty, a member is missing from the registry, or any counted
+        member's ``ST`` is missing or zero.
 
-        Cheap: ``O(N)`` where N is the member count, only computed
-        when read. No event-subscription plumbing — the underlying
-        ``ST`` values mutate in place via the WS dispatcher, so each
-        access reflects the latest state.
+        Cheap: ``O(N)``, computed on read — the underlying ``ST`` values
+        mutate in place via the WS dispatcher, so each access reflects
+        the latest state.
         """
-        if self._nodes is None or not self._record.member_addresses:
+        if self._nodes is None:
+            return False
+        on_set = self._on_set()
+        addresses = on_set if on_set is not None else self._record.member_addresses
+        if not addresses:
             return False
         saw_stateful = False
-        for addr in self._record.member_addresses:
+        for addr in addresses:
             record = self._nodes.get(addr)
             if record is None:
                 return False
@@ -191,27 +232,27 @@ class Group:
 
     @property
     def group_any_on(self) -> bool:
-        """True iff at least one stateful member node currently reports "on".
+        """True iff at least one on-target member currently reports "on".
 
         Companion to :attr:`group_all_on`; this is the aggregation HA
-        scene-switch consumers want for their ``is_on`` — the legacy
-        ``pyisy.Group.status`` did the same thing (non-zero on any
-        stateful responder). Stateless members and members not currently
-        in the registry are skipped — see :data:`_STATELESS_NODEDEF_IDS`.
+        scene-switch consumers want for their ``is_on``. When
+        ``/api/groups`` link targets resolved it considers only the
+        scene's **on-target** members (see :meth:`_on_set`), so a scene
+        reads on iff a member it actually drives on is on — not merely
+        because some always-lit keypad button is non-zero. Otherwise it
+        falls back to the legacy "any stateful member non-zero"
+        behaviour (what ``pyisy.Group.status`` did). Stateless members
+        and members not in the registry are skipped.
 
-        Returns ``False`` when:
-
-        * the group was constructed without a node-registry reference;
-        * the group has no members;
-        * every present stateful member's ``ST`` property is missing or
-          zero.
-
-        Cheap: ``O(N)`` where N is the member count, only computed
-        when read.
+        Returns ``False`` with no node-registry reference, an empty
+        (on-target / member) set, or when every counted member's ``ST``
+        is missing or zero. Cheap: ``O(N)``, computed on read.
         """
-        if self._nodes is None or not self._record.member_addresses:
+        if self._nodes is None:
             return False
-        for addr in self._record.member_addresses:
+        on_set = self._on_set()
+        addresses = on_set if on_set is not None else self._record.member_addresses
+        for addr in addresses:
             record = self._nodes.get(addr)
             if record is None or self._is_stateless(record):
                 continue
@@ -264,6 +305,7 @@ class Group:
         payload = asdict(self._record)
         payload["group_all_on"] = self.group_all_on
         payload["group_any_on"] = self.group_any_on
+        payload["has_state_target"] = self.has_state_target
         return payload
 
     def __repr__(self) -> str:

--- a/tests/test_client/conftest.py
+++ b/tests/test_client/conftest.py
@@ -41,6 +41,13 @@ class FakeSession:
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
         self._routes: dict[tuple[str, str], list[FakeResponse]] = {}
         self._defaults: dict[tuple[str, str], FakeResponse] = {}
+        # /api/groups is an optional link-target enrichment endpoint
+        # (#174). Default it to an empty payload so the many full-load
+        # tests don't each have to script it; tests exercising the
+        # enrichment override via set_route().
+        self._defaults[("GET", "/api/groups")] = FakeResponse(
+            200, _to_body({"successful": True, "data": {"groups": []}})
+        )
 
     # --- scripting -----------------------------------------------------
 

--- a/tests/test_client/test_client.py
+++ b/tests/test_client/test_client.py
@@ -203,6 +203,7 @@ async def test_connect_runs_full_load_with_real_profile_fixture(session: FakeSes
         200,
         '<?xml version="1.0"?><NetConfig><NetRule><id>1</id><name>Reboot Router</name></NetRule></NetConfig>',
     )
+    session.set_route("GET", "/api/groups", 200, {"successful": True, "data": {"groups": []}})
 
     client = IoXClient(BASE, PortalAuth("u@example.com", "pass"), session)  # type: ignore[arg-type]
     result = await client.connect()
@@ -228,13 +229,14 @@ async def test_connect_runs_full_load_with_real_profile_fixture(session: FakeSes
     assert list(result.network_resources) == ["1"]
     assert result.network_resources["1"].name == "Reboot Router"
 
-    # Total HTTP cost: 1 (config setup) + 1 (login setup) + 8 (parallel
-    # fan-out) = 10 calls. The fan-out covers: profiles, /api/nodes
+    # Total HTTP cost: 1 (config setup) + 1 (login setup) + 9 (parallel
+    # fan-out) = 11 calls. The fan-out covers: profiles, /api/nodes
     # (which now carries groups + folders too, see #127), /rest/status,
     # /api/programs, /api/triggers, /api/variables/1, /api/variables/2,
-    # /rest/networking/resources. Still constant w.r.t. node-server count.
+    # /rest/networking/resources, /api/groups (link-target enrichment).
+    # Still constant w.r.t. node-server count.
     fanout = [c for c in session.calls if c[0] == "GET" and c[1] not in ("/api/config",)]
-    assert len(fanout) == 8
+    assert len(fanout) == 9
 
 
 def _empty_fanout_routes(session: FakeSession) -> None:
@@ -249,6 +251,7 @@ def _empty_fanout_routes(session: FakeSession) -> None:
     session.set_route("GET", "/api/variables/1", 200, {"successful": True, "data": []})
     session.set_route("GET", "/api/variables/2", 200, {"successful": True, "data": []})
     session.set_route("GET", "/rest/networking/resources", 404)
+    session.set_route("GET", "/api/groups", 200, {"successful": True, "data": {"groups": []}})
 
 
 @pytest.mark.asyncio

--- a/tests/test_client/test_client.py
+++ b/tests/test_client/test_client.py
@@ -203,6 +203,9 @@ async def test_connect_runs_full_load_with_real_profile_fixture(session: FakeSes
         200,
         '<?xml version="1.0"?><NetConfig><NetRule><id>1</id><name>Reboot Router</name></NetRule></NetConfig>',
     )
+    # Scripted explicitly even though FakeSession defaults /api/groups —
+    # this full-load test intentionally pins every fan-out route so the
+    # call-count assertion below is self-contained.
     session.set_route("GET", "/api/groups", 200, {"successful": True, "data": {"groups": []}})
 
     client = IoXClient(BASE, PortalAuth("u@example.com", "pass"), session)  # type: ignore[arg-type]

--- a/tests/test_runtime/test_groups.py
+++ b/tests/test_runtime/test_groups.py
@@ -929,3 +929,72 @@ def test_group_unresolved_uses_legacy_all_member_aggregate():
 def test_group_has_state_target_true_when_off_intent_present():
     g = Group.from_record(_resolved_group({"A": "off"}), _profile(), _make_client(FakeSession(BASE)))
     assert g.has_state_target is True
+
+
+# --- review follow-ups (PR #175) --------------------------------------
+
+
+def test_apply_targets_no_ctl_block_resolves_empty():
+    # group entry present but no "ctl" key at all -> resolved, empty
+    groups = {"G": _grec("G", ("X",))}
+    apply_group_link_targets(groups, _api_groups({"id": "G"}))
+    assert groups["G"].targets_resolved is True
+    assert groups["G"].member_intents == {}
+
+
+def test_apply_targets_native_beats_default_reverse_order():
+    # native BEFORE default for the same node -> native still wins
+    groups = {"G": _grec("G", ("X",))}
+    apply_group_link_targets(
+        groups,
+        _api_groups(
+            {"id": "G", "ctl": [{"id": "G", "links": [_native("X", 0), {"type": "default", "node": "X"}]}]}
+        ),
+    )
+    assert groups["G"].member_intents == {"X": "off"}
+
+
+def _rec_nodedef(addr, nodedef_id):
+    return NodeRecord(
+        address=addr, name=addr, nodedef_id=nodedef_id, family_id="1", instance_id="1", properties={}
+    )
+
+
+def test_group_all_on_resolved_on_set_all_stateless_is_false():
+    # resolved on-set whose only member is stateless -> saw_stateful
+    # never set -> group_all_on False (documents the silent-False edge)
+    stateless_id = next(iter(INSTEON_STATELESS_NODEDEFID))
+    nodes = {"M": _rec_nodedef("M", stateless_id)}
+    rec = _resolved_group({"M": "on"})
+    rec.member_addresses = ("M",)
+    group = Group.from_record(rec, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.group_all_on is False
+    assert group.group_any_on is False
+
+
+def test_group_has_dimmable_members_true_for_dimmer_member():
+    nodes = {"D": _rec_nodedef("D", "DimmerLampSwitch")}
+    rec = _grec("G", ("D",))
+    group = Group.from_record(rec, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.has_dimmable_members is True
+
+
+def test_group_has_dimmable_members_false_for_relay_only_member():
+    nodes = {"R": _rec_nodedef("R", "RelayLampOnly")}
+    rec = _grec("G", ("R",))
+    group = Group.from_record(rec, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.has_dimmable_members is False
+
+
+def test_group_has_dimmable_members_false_without_nodes_ref():
+    rec = _grec("G", ("D",))
+    group = Group.from_record(rec, _profile(), _make_client(FakeSession(BASE)))
+    assert group.has_dimmable_members is False
+
+
+def test_group_has_dimmable_members_independent_of_targets_resolved():
+    # works on the legacy/unresolved path too (no /api/groups data)
+    nodes = {"D": _rec_nodedef("D", "DimmerLampSwitch"), "R": _rec_nodedef("R", "RelayLampOnly")}
+    rec = _grec("G", ("R", "D"))  # targets_resolved defaults False
+    group = Group.from_record(rec, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.has_dimmable_members is True

--- a/tests/test_runtime/test_groups.py
+++ b/tests/test_runtime/test_groups.py
@@ -16,6 +16,7 @@ from pyisyox.client import (
     IoXClient,
     NodePropertyValue,
     NodeRecord,
+    apply_group_link_targets,
     parse_api_nodes_groups_folders,
     parse_rest_nodes_groups_folders,
 )
@@ -703,3 +704,228 @@ async def test_group_rename_posts_name_and_type_group() -> None:
     method, path, kwargs = session.calls[-1]
     assert (method, path) == ("POST", "/api/nodes/55090")
     assert kwargs["json"] == {"name": "Front Yard", "nodeType": "group"}
+
+
+# --- /api/groups link-target enrichment (#174) ---
+
+
+def _api_groups(*entries):
+    return {"successful": True, "data": {"groups": list(entries)}}
+
+
+def _native(node, ol):
+    return {
+        "type": "native",
+        "node": node,
+        "linkdef": "I_RELAY",
+        "params": [{"type": "val", "id": "OL", "val": {"uom": 51, "prec": 0, "value": ol}}],
+    }
+
+
+def _grec(addr, members):
+    return GroupRecord(
+        address=addr, name=addr, nodedef_id="InsteonDimmer", family_id="6", member_addresses=members
+    )
+
+
+def test_apply_targets_radio_scene_only_on_level_member_is_on_intent():
+    # one native OL>0 member, the rest OL=0 (radio KPL scene)
+    groups = {"8499": _grec("8499", ("A", "B", "C"))}
+    apply_group_link_targets(
+        groups,
+        _api_groups(
+            {
+                "id": "8499",
+                "ctl": [{"id": "8499", "links": [_native("A", 0), _native("B", 100), _native("C", 0)]}],
+            }
+        ),
+    )
+    rec = groups["8499"]
+    assert rec.targets_resolved is True
+    assert rec.member_intents == {"A": "off", "B": "on", "C": "off"}
+
+
+def test_apply_targets_default_and_cmd_on_canonical_block_only():
+    # default -> on; cmd DON -> on; cmd SETST in a non-canonical block ignored
+    groups = {"46389": _grec("46389", ("ZW1", "ZW2", "N1"))}
+    apply_group_link_targets(
+        groups,
+        _api_groups(
+            {
+                "id": "46389",
+                "ctl": [
+                    {
+                        "id": "N9",
+                        "links": [
+                            {
+                                "type": "cmd",
+                                "node": "N1",
+                                "cmd": "SETST",
+                                "params": [{"type": "val", "id": "", "val": {"uom": 56, "value": 15}}],
+                            }
+                        ],
+                    },
+                    {
+                        "id": "46389",
+                        "links": [
+                            {"type": "cmd", "node": "ZW1", "cmd": "DON", "params": []},
+                            {"type": "default", "node": "ZW2"},
+                            {"type": "default", "node": "N1"},
+                        ],
+                    },
+                ],
+            }
+        ),
+    )
+    rec = groups["46389"]
+    assert rec.targets_resolved is True
+    assert rec.member_intents == {"ZW1": "on", "ZW2": "on", "N1": "on"}
+
+
+def test_apply_targets_fire_only_cmd_scene_resolves_no_on_members():
+    groups = {"G": _grec("G", ("X",))}
+    apply_group_link_targets(
+        groups,
+        _api_groups(
+            {
+                "id": "G",
+                "ctl": [
+                    {
+                        "id": "G",
+                        "links": [
+                            {
+                                "type": "cmd",
+                                "node": "X",
+                                "cmd": "BL",
+                                "params": [{"type": "val", "id": "", "val": {"uom": 25, "value": 124}}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+    )
+    assert groups["G"].targets_resolved is True
+    assert groups["G"].member_intents == {"X": "discard"}
+
+
+def test_apply_targets_cmd_dfon_is_on():
+    groups = {"G": _grec("G", ("X",))}
+    apply_group_link_targets(
+        groups,
+        _api_groups(
+            {
+                "id": "G",
+                "ctl": [{"id": "G", "links": [{"type": "cmd", "node": "X", "cmd": "DFON", "params": []}]}],
+            }
+        ),
+    )
+    assert groups["G"].member_intents == {"X": "on"}
+    assert groups["G"].targets_resolved is True
+
+
+def test_apply_targets_native_without_ol_falls_back_unresolved():
+    groups = {"G": _grec("G", ("X",))}
+    apply_group_link_targets(
+        groups,
+        _api_groups(
+            {
+                "id": "G",
+                "ctl": [
+                    {
+                        "id": "G",
+                        "links": [{"type": "native", "node": "X", "linkdef": "I_RELAY", "params": []}],
+                    }
+                ],
+            }
+        ),
+    )
+    assert groups["G"].targets_resolved is False
+    assert groups["G"].member_intents == {}
+
+
+def test_apply_targets_unknown_link_type_falls_back_unresolved():
+    groups = {"G": _grec("G", ("X",))}
+    apply_group_link_targets(
+        groups,
+        _api_groups({"id": "G", "ctl": [{"id": "G", "links": [{"type": "weird_future_type", "node": "X"}]}]}),
+    )
+    assert groups["G"].targets_resolved is False
+
+
+def test_apply_targets_ignore_link_excludes_node_but_resolves():
+    groups = {"G": _grec("G", ("X", "Y"))}
+    apply_group_link_targets(
+        groups,
+        _api_groups(
+            {"id": "G", "ctl": [{"id": "G", "links": [{"type": "ignore", "node": "X"}, _native("Y", 100)]}]}
+        ),
+    )
+    assert groups["G"].targets_resolved is True
+    assert groups["G"].member_intents == {"Y": "on"}
+
+
+def test_apply_targets_group_absent_from_payload_stays_unresolved():
+    groups = {"G": _grec("G", ("X",))}
+    apply_group_link_targets(groups, _api_groups())
+    assert groups["G"].targets_resolved is False
+    assert groups["G"].member_intents == {}
+
+
+def test_apply_targets_empty_canonical_block_resolves_empty():
+    groups = {"ADR0001": _grec("ADR0001", ())}
+    apply_group_link_targets(groups, _api_groups({"id": "ADR0001", "ctl": [{"id": "ADR0001", "links": []}]}))
+    assert groups["ADR0001"].targets_resolved is True
+    assert groups["ADR0001"].member_intents == {}
+
+
+def test_apply_targets_native_beats_default_for_same_node():
+    groups = {"G": _grec("G", ("X",))}
+    apply_group_link_targets(
+        groups,
+        _api_groups(
+            {"id": "G", "ctl": [{"id": "G", "links": [{"type": "default", "node": "X"}, _native("X", 0)]}]}
+        ),
+    )
+    assert groups["G"].member_intents == {"X": "off"}
+
+
+def _resolved_group(intents):
+    rec = _grec("G", tuple(intents))
+    rec.member_intents = dict(intents)
+    rec.targets_resolved = True
+    return rec
+
+
+def test_group_any_on_ignores_off_target_member():
+    nodes = {"ON1": _record_with_st("ON1", "0"), "OFF1": _record_with_st("OFF1", "255")}
+    rec = _resolved_group({"ON1": "on", "OFF1": "off"})
+    group = Group.from_record(rec, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.group_any_on is False
+    assert group.group_all_on is False
+    nodes["ON1"] = _record_with_st("ON1", "255")
+    assert group.group_any_on is True
+    assert group.group_all_on is True
+
+
+def test_group_fire_only_scene_reads_off_and_has_no_state_target():
+    rec = _resolved_group({"X": "discard"})
+    nodes = {"X": _record_with_st("X", "255")}
+    group = Group.from_record(rec, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.group_any_on is False
+    assert group.group_all_on is False
+    assert group.has_state_target is False
+
+
+def test_group_unresolved_uses_legacy_all_member_aggregate():
+    rec = _grec("G", ("M1", "M2"))
+    nodes = {"M1": _record_with_st("M1", "0"), "M2": _record_with_st("M2", "255")}
+    group = Group.from_record(rec, _profile(), _make_client(FakeSession(BASE)), nodes=nodes)
+    assert group.group_any_on is True
+    assert group.group_all_on is False
+    assert group.has_state_target is True
+
+
+def test_group_has_state_target_true_when_off_intent_present():
+    g = Group.from_record(_resolved_group({"A": "off"}), _profile(), _make_client(FakeSession(BASE)))
+    assert g.has_state_target is True


### PR DESCRIPTION
Implements the first slice of #174. Composes with #172 (merged) — that
delivers the change *notification* (member→group re-emit); this makes
the *value* correct.

## Problem

`group_any_on` / `group_all_on` were a coarse "any/all stateful member
ST non-zero" aggregate. For a radio-style KeypadLinc scene a keypad
always has exactly one button lit, so `group_any_on` was permanently
True and `group_all_on` structurally impossible — the scene switch
never reflected reality.

## Fix

Fetch the optional `/api/groups` endpoint during load and resolve each
member's scene intent from the **canonical** ctl block (the one whose
`id` == the group address — the scene's own responder definition;
per-controller cross-link blocks are ignored):

| link `type` | intent |
|---|---|
| `native` | `OL > 0` → on, `OL == 0` → off |
| `default` | on (ISY forwards the scene command; state-tracked) |
| `cmd` | `DON`/`DFON` → on, `DOF`/`DFOF` → off, anything else (`BL`/`BEEP`/`SETST`/`BRT`/`DIM`/`FD*`) → discard |
| `ignore` | not a member |
| unknown / `native` w/o `OL` | unresolved → **legacy aggregate** (never regress) |

`group_any_on`/`group_all_on` now aggregate over the **on-target**
subset. An empty on-set (fire-only / config-only / the auto-DR groups)
reads **OFF**, matching the IoX admin console. `Group.has_state_target`
exposes whether the scene maintains any on/off state — `False` for a
fire-only scene, so a consumer can model it as a momentary **button**
rather than a stuck switch (hacs-udi-iox#86).

Strictly additive and consumer-transparent: `/api/groups` is
best-effort (older firmware 404 → `{}` → groups keep legacy behaviour);
exact on-level match (`scene_matches_target`) is deliberately deferred.

Validated against real captures: radio scene `8499` (one `OL=100`
member, rest `OL=0`), curtain `19359`, the auto-DR `ADR0001` (empty
canonical block → OFF), and the `default`+`cmd`/`BL`-only test scenes.

## Changes

- `paths`: `GROUPS_PATH`
- `client`: `_get_json_or_empty`; `GroupRecord.member_intents` +
  `targets_resolved`; `apply_group_link_targets()`; wired into `load()`
  (so `refresh()` re-enriches too)
- `runtime/group`: `_on_set()`, `has_state_target`, target-aware
  `group_any_on`/`group_all_on` with legacy fallback; `to_dict` adds
  `has_state_target`
- tests: 18 parse + aggregation cases; `FakeSession` defaults
  `/api/groups` to an empty payload so the many full-load tests need no
  per-test scripting; full-load fan-out asserted 8 → 9

## Scene HA-platform inputs (`has_state_target` + `has_dimmable_members`)

pyisyox exposes two **orthogonal capability booleans**; the consumer
composes the platform (capability stays here, the HA light/switch/button
decision stays policy):

- `Group.has_state_target` — `False` only for a *resolved* fire-only /
  config scene (→ **button**); `True` otherwise (incl. unresolved:
  conservative, stays a switch).
- `Group.has_dimmable_members` — `True` iff any member node
  `is_dimmable` (nodedef-derived; **independent of `/api/groups`** so it
  works on older firmware / unresolved groups too).

Consumer mapping: `not has_state_target` → button; else
`has_dimmable_members` → **on/off `light`** (lets hacs create the scene
natively at the right platform, preserving the `Entity.group` /
more-info framework instead of losing it through `switch_as_x`); else →
switch. **Scenes have no settable brightness** — ISY groups don't take a
scene-level on-level; fade/brt/dim are separate manual commands
(reachable via `send_node_command`; scene `accepts` aren't exposed as
buttons yet) — so the light is on/off only.

Review nits from the first pass are addressed (rank `>` first-seen,
`""`-sentinel comment, docstring, +no-ctl / reverse-precedence /
all-stateless / has_dimmable tests).

867 passed · mypy clean · pylint 10/10 · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
