### PR TITLE
fix(client): keep program/folder address as the classic hex id

### DIFF
--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -1727,7 +1727,14 @@ def parse_api_programs(raw: list[dict[str, Any]]) -> dict[str, ProgramRecord]:
         # looking string by re-parsing it as decimal would silently
         # corrupt it (e.g. "0010" -> "000A"), so only `int` values are
         # upconverted -- `str` values pass through untouched.
-        if value is None or value == "":
+        #
+        # Falsy (`None` / `""` / `0`) means "no id" either way -- same
+        # convention `_path()` above and the pre-fix `parent_address`
+        # already used for a root-level `parentId` -- so it collapses
+        # to `None` here too rather than upconverting `0` to `"0000"`,
+        # which would dangle (id `0` entries are excluded from `by_id`)
+        # and violate `parent_address`'s "`None` for the root" contract.
+        if not value:
             return None
         if isinstance(value, int):
             return f"{value:04X}"

--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -295,6 +295,13 @@ class ProgramRecord:
     (``"idle"`` / ``"running then"`` / the cookbook ``<s>`` byte) — the
     typed :attr:`Program.run_state` / :attr:`Program.eval_state`
     accessors decode it.
+
+    ``address`` / ``parent_address`` are the classic 4-character hex
+    id (e.g. ``"0095"``) — matching what the ISY/IoX UIs display and
+    what the legacy ``/rest/programs/{id}/...`` command endpoint
+    requires — not the plain decimal integer ``/api/programs`` reports
+    as ``id``/``parentId``. :func:`parse_api_programs` upconverts at
+    parse time (see #193).
     """
 
     address: str
@@ -887,6 +894,12 @@ class IoXClient:
         IoX 6 keeps this legacy path; no ``/api/programs/{id}/...``
         equivalent has been observed. The controller acknowledges
         receipt only — status changes flow back over the WebSocket.
+
+        ``program_id`` is expected as the legacy 4-character hex id
+        (``ProgramRecord.address``) -- this endpoint 404s on the plain
+        decimal id ``/api/programs`` reports as ``id`` (#193); the
+        upconversion happens once, at parse time, in
+        :func:`parse_api_programs`.
         """
         return await self._get_text(PROGRAM_COMMAND_PATH.format(program_id=program_id, command=command))
 
@@ -1667,6 +1680,20 @@ def parse_api_programs(raw: list[dict[str, Any]]) -> dict[str, ProgramRecord]:
     Folders inherit ``status`` from the eisy-side aggregation but
     don't carry ``enabled`` / ``run_at_startup`` / ``running`` /
     timing fields — those stay ``None`` on the record.
+
+    ``id`` / ``parentId`` are hex on older firmware (a JSON string,
+    already the classic 4-character id, e.g. ``"009C"``) but a plain
+    decimal JSON number on current firmware (``"id": 149`` — #193).
+    The classic hex id is what the ISY/IoX UIs display and what the
+    legacy ``/rest/programs/{id}/...`` command endpoint requires
+    (current firmware 404s on decimal), so ``address`` / ``parent_address``
+    on the returned records are upconverted to hex here, once, at the
+    parse chokepoint — keyed on the wire *type* (``int`` -> convert,
+    ``str`` -> already hex, pass through) rather than the string shape,
+    since a numeric-looking hex string (``"0010"`` = hex 0x10) would
+    otherwise be silently corrupted by a naive decimal reparse. The
+    ``parentId`` chain walk below stays in the wire's native domain
+    (whichever the raw entries carry); only the final records are hex.
     """
     by_id: dict[str, dict[str, Any]] = {str(entry.get("id") or ""): entry for entry in raw if entry.get("id")}
 
@@ -1691,15 +1718,36 @@ def parse_api_programs(raw: list[dict[str, Any]]) -> dict[str, ProgramRecord]:
         text = str(value).strip()
         return text or None
 
+    def _hex_id(value: Any) -> str | None:
+        # The wire type is the discriminator, not the string shape:
+        # older IoX firmware sends id/parentId as a JSON string that's
+        # already the classic hex id ("0010" meaning hex 0x10, i.e.
+        # decimal 16); current firmware sends a JSON number instead
+        # (#193's `"id": 149`). Reformatting an already-hex numeric-
+        # looking string by re-parsing it as decimal would silently
+        # corrupt it (e.g. "0010" -> "000A"), so only `int` values are
+        # upconverted -- `str` values pass through untouched.
+        if value is None or value == "":
+            return None
+        if isinstance(value, int):
+            return f"{value:04X}"
+        text = str(value).strip()
+        return text or None
+
     records: dict[str, ProgramRecord] = {}
     for prog_id, entry in by_id.items():
         is_folder = bool(entry.get("folder", False))
         status_raw = entry.get("status", "")
-        records[prog_id] = ProgramRecord(
-            address=prog_id,
+        # ``prog_id`` (the ``by_id`` key) is already stringified for
+        # the parent-chain walk above; re-read ``entry["id"]`` here so
+        # ``_hex_id`` still sees its original wire type (``int`` vs
+        # ``str``) rather than the coerced string.
+        address = _hex_id(entry.get("id")) or prog_id
+        records[address] = ProgramRecord(
+            address=address,
             name=str(entry.get("name") or ""),
             path=_path(entry),
-            parent_address=(str(entry.get("parentId")) if entry.get("parentId") else None),
+            parent_address=_hex_id(entry.get("parentId")),
             is_folder=is_folder,
             status=str(status_raw).lower() == "true",
             enabled=entry.get("enabled") if not is_folder else None,

--- a/pyisyox/client.py
+++ b/pyisyox/client.py
@@ -296,12 +296,9 @@ class ProgramRecord:
     typed :attr:`Program.run_state` / :attr:`Program.eval_state`
     accessors decode it.
 
-    ``address`` / ``parent_address`` are the classic 4-character hex
-    id (e.g. ``"0095"``) — matching what the ISY/IoX UIs display and
-    what the legacy ``/rest/programs/{id}/...`` command endpoint
-    requires — not the plain decimal integer ``/api/programs`` reports
-    as ``id``/``parentId``. :func:`parse_api_programs` upconverts at
-    parse time (see #193).
+    ``address`` / ``parent_address`` are always the classic hex id,
+    not the decimal ``id``/``parentId`` the wire may send —
+    :func:`parse_api_programs` upconverts at parse time (#193).
     """
 
     address: str
@@ -895,11 +892,8 @@ class IoXClient:
         equivalent has been observed. The controller acknowledges
         receipt only — status changes flow back over the WebSocket.
 
-        ``program_id`` is expected as the legacy 4-character hex id
-        (``ProgramRecord.address``) -- this endpoint 404s on the plain
-        decimal id ``/api/programs`` reports as ``id`` (#193); the
-        upconversion happens once, at parse time, in
-        :func:`parse_api_programs`.
+        ``program_id`` must already be the hex id (``ProgramRecord.address``)
+        -- :func:`parse_api_programs` does the decimal-to-hex conversion (#193).
         """
         return await self._get_text(PROGRAM_COMMAND_PATH.format(program_id=program_id, command=command))
 
@@ -1719,21 +1713,11 @@ def parse_api_programs(raw: list[dict[str, Any]]) -> dict[str, ProgramRecord]:
         return text or None
 
     def _hex_id(value: Any) -> str | None:
-        # The wire type is the discriminator, not the string shape:
-        # older IoX firmware sends id/parentId as a JSON string that's
-        # already the classic hex id ("0010" meaning hex 0x10, i.e.
-        # decimal 16); current firmware sends a JSON number instead
-        # (#193's `"id": 149`). Reformatting an already-hex numeric-
-        # looking string by re-parsing it as decimal would silently
-        # corrupt it (e.g. "0010" -> "000A"), so only `int` values are
-        # upconverted -- `str` values pass through untouched.
-        #
-        # Falsy (`None` / `""` / `0`) means "no id" either way -- same
-        # convention `_path()` above and the pre-fix `parent_address`
-        # already used for a root-level `parentId` -- so it collapses
-        # to `None` here too rather than upconverting `0` to `"0000"`,
-        # which would dangle (id `0` entries are excluded from `by_id`)
-        # and violate `parent_address`'s "`None` for the root" contract.
+        # int -> hex, str -> already hex (see the docstring above for why).
+        # Falsy (None/""/0) is "no id" either way -- same convention as
+        # _path() above -- so a root-level parentId of 0 collapses to
+        # None instead of the dangling "0000" (id-0 entries are excluded
+        # from by_id, and parent_address documents None for the root).
         if not value:
             return None
         if isinstance(value, int):

--- a/pyisyox/runtime/program.py
+++ b/pyisyox/runtime/program.py
@@ -148,7 +148,11 @@ class _ProgramBase:
 
     @property
     def address(self) -> str:
-        """Program / folder id (4-character hex string)."""
+        """Program / folder id (classic 4-character hex string, e.g.
+        ``"0095"``) -- matching the ISY/IoX UIs, not the plain decimal
+        integer ``/api/programs`` reports as ``id``.
+        :func:`pyisyox.client.parse_api_programs` upconverts at parse
+        time (#193)."""
         return self._record.address
 
     @property

--- a/pyisyox/runtime/program.py
+++ b/pyisyox/runtime/program.py
@@ -148,11 +148,8 @@ class _ProgramBase:
 
     @property
     def address(self) -> str:
-        """Program / folder id (classic 4-character hex string, e.g.
-        ``"0095"``) -- matching the ISY/IoX UIs, not the plain decimal
-        integer ``/api/programs`` reports as ``id``.
-        :func:`pyisyox.client.parse_api_programs` upconverts at parse
-        time (#193)."""
+        """Program / folder id, always the classic hex string (e.g.
+        ``"0095"``) -- see :func:`pyisyox.client.parse_api_programs` (#193)."""
         return self._record.address
 
     @property

--- a/tests/test_client/test_client.py
+++ b/tests/test_client/test_client.py
@@ -457,3 +457,23 @@ async def test_send_json_rejects_unsupported_method(session: FakeSession) -> Non
 
     with pytest.raises(ValueError, match="unsupported _send_json method"):
         await client._send_json("PATCH", "/anywhere", {"x": 1})  # type: ignore[arg-type]
+
+
+# --- run_program_command ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_program_command_sends_id_verbatim(session: FakeSession) -> None:
+    """``run_program_command`` no longer converts anything -- callers
+    (``Program`` / ``ProgramFolder``) always hold the classic hex id
+    off ``ProgramRecord.address``, which ``parse_api_programs``
+    upconverts once at parse time (#193); this method just formats it
+    into the URL."""
+    session.set_route("GET", "/rest/programs/0095/runElse", 200, "<RestResponse status='200'/>")
+    client = IoXClient(BASE, LocalAuth("admin", "p"), session)  # type: ignore[arg-type]
+    client._authenticated = True
+
+    await client.run_program_command("0095", "runElse")
+
+    _, path, _ = session.calls[-1]
+    assert path == "/rest/programs/0095/runElse"

--- a/tests/test_client/test_client.py
+++ b/tests/test_client/test_client.py
@@ -464,11 +464,9 @@ async def test_send_json_rejects_unsupported_method(session: FakeSession) -> Non
 
 @pytest.mark.asyncio
 async def test_run_program_command_sends_id_verbatim(session: FakeSession) -> None:
-    """``run_program_command`` no longer converts anything -- callers
-    (``Program`` / ``ProgramFolder``) always hold the classic hex id
-    off ``ProgramRecord.address``, which ``parse_api_programs``
-    upconverts once at parse time (#193); this method just formats it
-    into the URL."""
+    """The decimal-to-hex conversion happens once, in
+    ``parse_api_programs`` (#193) -- this method just passes the id
+    through into the URL."""
     session.set_route("GET", "/rest/programs/0095/runElse", 200, "<RestResponse status='200'/>")
     client = IoXClient(BASE, LocalAuth("admin", "p"), session)  # type: ignore[arg-type]
     client._authenticated = True

--- a/tests/test_client/test_parsers.py
+++ b/tests/test_client/test_parsers.py
@@ -655,14 +655,8 @@ def test_parse_api_programs_skips_entries_without_id() -> None:
 
 
 def test_parse_api_programs_upconverts_decimal_json_int_id_to_hex() -> None:
-    """Current IoX firmware reports ``id`` / ``parentId`` as a plain
-    decimal JSON *number* (``"id": 149``, per issue #193) rather than
-    the classic hex id older firmware sent as a JSON string. The
-    legacy ``/rest/programs/{id}/...`` command endpoint 404s on
-    decimal, so the parser upconverts to hex -- keyed on the wire
-    type (``int``), not the string shape, so it can tell a real
-    decimal id apart from an already-hex id that merely looks
-    numeric (see the next test)."""
+    """Current firmware sends ``id`` / ``parentId`` as a decimal JSON
+    number (``"id": 149``, #193); the parser upconverts to hex."""
     raw = [
         {"id": 6, "name": "HA.switch", "folder": True, "status": "true"},
         {"id": 149, "name": "actions", "parentId": 6, "folder": False, "status": "true", "enabled": True},
@@ -674,23 +668,17 @@ def test_parse_api_programs_upconverts_decimal_json_int_id_to_hex() -> None:
 
 
 def test_parse_api_programs_decimal_root_parent_id_zero_collapses_to_none() -> None:
-    """A root-level entry's ``parentId`` may arrive as the JSON
-    integer ``0`` rather than an omitted key. That must still collapse
-    to ``parent_address=None`` (same "no parent" convention ``_path()``
-    already applies) -- not upconvert to the dangling ``"0000"`` (id
-    ``0`` entries are excluded from the registry, and ``"0000"`` would
-    violate ``parent_address``'s "``None`` for the root" contract)."""
+    """A root-level ``parentId`` of the JSON integer ``0`` must still
+    collapse to ``parent_address=None``, not upconvert to ``"0000"``."""
     raw = [{"id": 6, "parentId": 0, "name": "HA.switch", "folder": True, "status": "true"}]
     records = parse_api_programs(raw)
     assert records["0006"].parent_address is None
 
 
 def test_parse_api_programs_preserves_numeric_looking_hex_string_id() -> None:
-    """An already-hex id from older firmware that happens to look
-    like a decimal number (``"0010"`` meaning hex 0x10, i.e. decimal
-    16) must NOT be reparsed as decimal -- that would silently
-    corrupt it (to ``"000A"``). Since it arrives as a JSON *string*
-    (not a number), it passes through untouched."""
+    """A hex id that looks decimal (``"0010"`` = hex 0x10) must not be
+    reparsed as decimal (-> ``"000A"``); arriving as a JSON string
+    (not a number) is what tells the parser to pass it through."""
     raw = [{"id": "0010", "name": "Legacy Folder", "folder": True, "status": "true"}]
     records = parse_api_programs(raw)
     assert records["0010"].address == "0010"

--- a/tests/test_client/test_parsers.py
+++ b/tests/test_client/test_parsers.py
@@ -673,6 +673,18 @@ def test_parse_api_programs_upconverts_decimal_json_int_id_to_hex() -> None:
     assert records["0095"].parent_address == "0006"
 
 
+def test_parse_api_programs_decimal_root_parent_id_zero_collapses_to_none() -> None:
+    """A root-level entry's ``parentId`` may arrive as the JSON
+    integer ``0`` rather than an omitted key. That must still collapse
+    to ``parent_address=None`` (same "no parent" convention ``_path()``
+    already applies) -- not upconvert to the dangling ``"0000"`` (id
+    ``0`` entries are excluded from the registry, and ``"0000"`` would
+    violate ``parent_address``'s "``None`` for the root" contract)."""
+    raw = [{"id": 6, "parentId": 0, "name": "HA.switch", "folder": True, "status": "true"}]
+    records = parse_api_programs(raw)
+    assert records["0006"].parent_address is None
+
+
 def test_parse_api_programs_preserves_numeric_looking_hex_string_id() -> None:
     """An already-hex id from older firmware that happens to look
     like a decimal number (``"0010"`` meaning hex 0x10, i.e. decimal

--- a/tests/test_client/test_parsers.py
+++ b/tests/test_client/test_parsers.py
@@ -654,6 +654,36 @@ def test_parse_api_programs_skips_entries_without_id() -> None:
     assert list(records) == ["0011"]
 
 
+def test_parse_api_programs_upconverts_decimal_json_int_id_to_hex() -> None:
+    """Current IoX firmware reports ``id`` / ``parentId`` as a plain
+    decimal JSON *number* (``"id": 149``, per issue #193) rather than
+    the classic hex id older firmware sent as a JSON string. The
+    legacy ``/rest/programs/{id}/...`` command endpoint 404s on
+    decimal, so the parser upconverts to hex -- keyed on the wire
+    type (``int``), not the string shape, so it can tell a real
+    decimal id apart from an already-hex id that merely looks
+    numeric (see the next test)."""
+    raw = [
+        {"id": 6, "name": "HA.switch", "folder": True, "status": "true"},
+        {"id": 149, "name": "actions", "parentId": 6, "folder": False, "status": "true", "enabled": True},
+    ]
+    records = parse_api_programs(raw)
+    assert set(records) == {"0006", "0095"}
+    assert records["0095"].address == "0095"
+    assert records["0095"].parent_address == "0006"
+
+
+def test_parse_api_programs_preserves_numeric_looking_hex_string_id() -> None:
+    """An already-hex id from older firmware that happens to look
+    like a decimal number (``"0010"`` meaning hex 0x10, i.e. decimal
+    16) must NOT be reparsed as decimal -- that would silently
+    corrupt it (to ``"000A"``). Since it arrives as a JSON *string*
+    (not a number), it passes through untouched."""
+    raw = [{"id": "0010", "name": "Legacy Folder", "folder": True, "status": "true"}]
+    records = parse_api_programs(raw)
+    assert records["0010"].address == "0010"
+
+
 # --- /api/variables/{type} ------------------------------------------------
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1371,6 +1371,41 @@ async def test_program_status_event_updates_record_in_place() -> None:
 
 
 @pytest.mark.asyncio
+async def test_program_status_event_resolves_against_decimal_json_id() -> None:
+    """Current firmware reports ``/api/programs`` ids as a decimal
+    JSON number (``"id": 141``, #193); ``parse_api_programs``
+    upconverts that to the hex registry key (``"008D"``). The WS
+    dispatcher's unpadded-hex ``<id>8D</id>`` frame must still resolve
+    against that hex key -- this is the same address the
+    ``/rest/programs/{id}/...`` command endpoint requires."""
+    session = FakeSession(BASE)
+    _stub_responses(session)
+    session.set_route(
+        "GET",
+        "/api/programs",
+        200,
+        _programs_payload(
+            {"id": 141, "name": "Foo", "folder": False, "status": "true", "enabled": False},
+        ),
+    )
+    controller = Controller(BASE, LocalAuth("admin", "p"), session=session)  # type: ignore[arg-type]
+    await controller.connect(start_websocket=False)
+
+    assert "008D" in controller.programs
+
+    frame = (
+        '<?xml version="1.0"?><Event seqnum="9" sid="x" timestamp="t">'
+        "<control>_1</control><action>0</action><node></node>"
+        "<eventInfo><id>8D</id><on /><s>21</s></eventInfo></Event>"
+    )
+    controller.feed_event_frame(frame)
+
+    assert controller.programs["008D"].status is True
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
 async def test_program_status_event_off_marker_flips_enabled_false() -> None:
     """``<off/>`` is the enabled-flag, not status. ``<s>21</s>`` carries
     eval-state TRUE so status flips True regardless of the on/off marker."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1372,12 +1372,9 @@ async def test_program_status_event_updates_record_in_place() -> None:
 
 @pytest.mark.asyncio
 async def test_program_status_event_resolves_against_decimal_json_id() -> None:
-    """Current firmware reports ``/api/programs`` ids as a decimal
-    JSON number (``"id": 141``, #193); ``parse_api_programs``
-    upconverts that to the hex registry key (``"008D"``). The WS
-    dispatcher's unpadded-hex ``<id>8D</id>`` frame must still resolve
-    against that hex key -- this is the same address the
-    ``/rest/programs/{id}/...`` command endpoint requires."""
+    """A program loaded from a decimal JSON id (#193) is registered
+    under its upconverted hex key; the WS dispatcher's unpadded-hex
+    ``<id>8D</id>`` frame must still resolve against it."""
     session = FakeSession(BASE)
     _stub_responses(session)
     session.set_route(


### PR DESCRIPTION
## Summary

Fixes #193. Program/folder commands (`run`, `run_then`, `run_else`, `enable`, `disable`, etc.) 404 on current IoX firmware because the id `/api/programs` reports has changed shape, but the legacy `/rest/programs/{id}/{command}` endpoint every one of those commands funnels through still requires the classic 4-character hex id.

## Root cause

Current IoX firmware reports `/api/programs` `id` / `parentId` as a plain decimal JSON number (`"id": 149`, per #193's live capture), where older firmware sent a JSON string that was already the classic hex id (e.g. `"009C"` — confirmed against the fixture captured for PR #63, back when this same endpoint's `id` field was still a hex string). The WS event dispatcher's `<id>` resolution (`_apply_program_status`) already assumed the registry was hex-keyed — its own comment says so — so this decimal shift is also why WS program-status frames silently failed to correlate for any id where hex and decimal representations diverge, not just the REST command path.

## Fix

`parse_api_programs()` upconverts `id` / `parentId` to the hex form once, at the parse chokepoint — keyed on the wire **type**, not the string shape: a JSON `int` gets upconverted, a JSON `str` passes through untouched. This matters because a numeric-looking hex string (`"0010"` meaning hex `0x10`, i.e. decimal 16) would otherwise be silently corrupted by a naive decimal reparse (`isdigit()`-style checks aren't safe here).

`ProgramRecord.address` / `Program.address` stay the hex id — not flipped to decimal — matching the ISY/IoX UI convention and what HA-side consumers display/key on (entity `unique_id`s, etc.). This restores the invariant that held before firmware started sending decimal ids, rather than introducing a new decimal convention downstream.

`Client.run_program_command()` itself needed no change once the parse-time fix is in — it always receives an already-hex id from `Program`/`ProgramFolder`.

## Test plan

- [x] `parse_api_programs` tests: decimal JSON-int id upconverts to hex; an already-hex numeric-looking string id (`"0010"`) is preserved, not corrupted
- [x] WS program-status dispatch test: a program loaded from a decimal JSON id still resolves against the WS `<id>` unpadded-hex frame
- [x] Full existing `Program`/`ProgramFolder`/`Controller.send_program_command` command-wrapper test coverage (unchanged — these already used already-hex string ids, which still pass straight through)
- [x] `pytest -q` — 891 passed
- [x] `ruff check` / `ruff format --check` / `mypy` / `pylint` — clean