### PR TITLE
fix(auth): stop using deprecated aiohttp.BasicAuth in LocalAuth

### DIFF
--- a/docs/connection-flow.md
+++ b/docs/connection-flow.md
@@ -102,10 +102,10 @@ python3 -m pyisyox https://eisy.local:8443 admin           admin-pw
 
 ### LocalAuth lifecycle
 
-No login round-trip — every request carries `Authorization: Basic …`
-attached via `aiohttp.BasicAuth`. A 401 means the credentials are
-wrong, so re-auth cannot recover and the client raises
-`AuthError` to the caller.
+No login round-trip — every request carries a pre-encoded
+`Authorization: Basic …` header (`aiohttp.encode_basic_auth()`). A 401
+means the credentials are wrong, so re-auth cannot recover and the
+client raises `AuthError` to the caller.
 
 ## The connect() call
 
@@ -188,11 +188,9 @@ background `asyncio.Task`.
    `/rest/subscribe`; the modern JSON-envelope path
    `/api/events/subscribe` is opt-in).
 2. Pull `auth.request_kwargs(session, base_url)` and pass them to
-   `session.ws_connect(...)`. `LocalAuth` returns
-   `{"auth": aiohttp.BasicAuth(...)}` — aiohttp's `ws_connect` accepts
-   `auth` directly. `PortalAuth` returns
-   `{"headers": {"Authorization": "Bearer …"}}`, passed through
-   verbatim.
+   `session.ws_connect(...)`. Both `LocalAuth` and `PortalAuth` return
+   `{"headers": {"Authorization": "Basic …"}}` / `"Bearer …"` respectively,
+   passed through verbatim.
 3. On success, transition to `EventStreamStatus.CONNECTED` and notify
    any status listeners.
 

--- a/pyisyox/auth.py
+++ b/pyisyox/auth.py
@@ -184,14 +184,17 @@ class LocalAuth:
             username: Local admin username (typically ``"admin"``).
             password: Local admin password.
         """
-        self._auth = aiohttp.BasicAuth(username, password)
+        # aiohttp.BasicAuth is deprecated (removed in aiohttp 4.0) in
+        # favor of a plain Authorization header -- pre-encode it once
+        # here rather than on every request.
+        self._auth_header = aiohttp.encode_basic_auth(username, password)
 
     async def authenticate(self, session: aiohttp.ClientSession, base_url: str) -> None:
         """No-op — basic auth attaches per request."""
 
     async def request_kwargs(self, session: aiohttp.ClientSession, base_url: str) -> dict[str, Any]:
         """Return kwargs that attach HTTP basic auth."""
-        return {"auth": self._auth}
+        return {"headers": {"Authorization": self._auth_header}}
 
     async def handle_unauthorized(self, session: aiohttp.ClientSession, base_url: str) -> bool:
         """Cannot recover from 401 with basic auth — credentials are wrong."""

--- a/pyisyox/runtime/ws.py
+++ b/pyisyox/runtime/ws.py
@@ -7,14 +7,10 @@ runs a read loop that feeds every frame to an
 exponential backoff on transport errors; refreshes auth tokens on a
 401-class WebSocket handshake failure.
 
-Auth integration:
-
-* :class:`LocalAuth` returns ``{"auth": aiohttp.BasicAuth(...)}`` from
-  ``request_kwargs`` — aiohttp's ``ws_connect`` accepts ``auth``
-  directly, so the upgrade carries an ``Authorization: Basic`` header.
-* :class:`PortalAuth` returns ``{"headers": {"Authorization": "Bearer
-  ..."}}``. ``ws_connect`` passes ``headers`` through verbatim, so the
-  bearer rides on the upgrade.
+Auth integration: both :class:`LocalAuth` and :class:`PortalAuth`
+return ``{"headers": {"Authorization": ...}}`` from ``request_kwargs``
+(``"Basic ..."`` / ``"Bearer ..."`` respectively) — ``ws_connect``
+passes ``headers`` through verbatim, so the upgrade carries it.
 
 The loop is intentionally split from the parsing/dispatch logic in
 :mod:`pyisyox.runtime.events` so the dispatcher can be unit-tested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version"]
 requires-python = ">=3.11"
 
 dependencies = [
-    "aiohttp>=3.13.5",
+    "aiohttp>=3.14.0",
     "colorlog>=6.10.1",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp>=3.13.5
+aiohttp>=3.14.0
 colorlog>=6.10.1

--- a/tests/test_auth/test_auth.py
+++ b/tests/test_auth/test_auth.py
@@ -151,9 +151,7 @@ async def test_local_auth_attaches_basic() -> None:
     sess = FakeSession()
     await auth.authenticate(sess, "https://eisy.local:8443")  # no-op
     kwargs = await auth.request_kwargs(sess, "https://eisy.local:8443")
-    assert isinstance(kwargs["auth"], aiohttp.BasicAuth)
-    assert kwargs["auth"].login == "admin"
-    assert kwargs["auth"].password == "hunter2"
+    assert kwargs["headers"]["Authorization"] == aiohttp.encode_basic_auth("admin", "hunter2")
 
 
 @pytest.mark.asyncio

--- a/tests/test_client/test_client.py
+++ b/tests/test_client/test_client.py
@@ -38,7 +38,7 @@ async def test_fetch_config_unwraps_data_envelope(session: FakeSession) -> None:
     # flow 401'd when this was fetched unauthenticated.
     _, path, kwargs = session.calls[0]
     assert path == "/api/config"
-    assert kwargs.get("auth") is not None  # BasicAuth from LocalAuth was attached
+    assert kwargs.get("headers", {}).get("Authorization")  # basic auth header from LocalAuth
 
 
 @pytest.mark.asyncio
@@ -50,7 +50,7 @@ async def test_get_text_attaches_local_auth(session: FakeSession) -> None:
     assert text == "<nodes/>"
     method, path, kwargs = session.calls[0]
     assert method == "GET" and path == "/rest/status"
-    assert kwargs.get("auth") is not None  # BasicAuth from LocalAuth
+    assert kwargs.get("headers", {}).get("Authorization")  # basic auth header from LocalAuth
 
 
 # --- 401 retry ------------------------------------------------------------

--- a/tests/test_runtime/test_ws.py
+++ b/tests/test_runtime/test_ws.py
@@ -319,9 +319,8 @@ async def test_ws_reader_url_translates_https_to_wss() -> None:
 
 @pytest.mark.asyncio
 async def test_ws_reader_attaches_local_auth() -> None:
-    """LocalAuth -> request_kwargs returns ``auth=BasicAuth``; the stream
-    forwards that as kwargs to ws_connect so the upgrade carries
-    ``Authorization: Basic`` headers."""
+    """LocalAuth -> request_kwargs returns an ``Authorization: Basic``
+    header; the stream forwards that as kwargs to ws_connect."""
     session = FakeWSSession()
     session.queue_success([_closed_frame()])
     client = _make_client(session)
@@ -334,7 +333,7 @@ async def test_ws_reader_attaches_local_auth() -> None:
         await asyncio.sleep(0)
     await stream.stop()
 
-    assert isinstance(session.calls[0].kwargs.get("auth"), aiohttp.BasicAuth)
+    assert session.calls[0].kwargs.get("headers", {}).get("Authorization", "").startswith("Basic ")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Surfaced as a `DeprecationWarning` in PR #194's test run: `aiohttp.BasicAuth` is deprecated and slated for removal in aiohttp 4.0.

`LocalAuth` now pre-encodes the `Authorization` header via `aiohttp.encode_basic_auth()` and returns it through the same `{"headers": {...}}` shape `PortalAuth` already uses, so both auth strategies attach identically at every `request_kwargs()` call site (REST client + WS `ws_connect` — see the updated docstring in `runtime/ws.py`).

`encode_basic_auth()` was only added in aiohttp 3.14.0 (confirmed absent in 3.13.5, present in 3.14.0), so the `aiohttp` floor moves from `>=3.13.5` to `>=3.14.0` in both `requirements.txt` and `pyproject.toml`. This doesn't tighten the real-world floor — HA Core is already on `aiohttp==3.14.1`.

## Test plan

- [x] `pytest -q` — 892 passed, no deprecation warning
- [x] `ruff check` / `ruff format --check` / `mypy` / `pylint` — clean